### PR TITLE
chore: 페이지 전역 레이아웃 설정

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,8 @@
 import './global.css';
 
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
-import QueryProvider from '@/app/provider/queryProvider';
+import MainProvider from '@/app/provider';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -30,12 +29,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <QueryProvider>
-          {children}
-          {process.env.NODE_ENV === 'development' && (
-            <ReactQueryDevtools initialIsOpen={false} />
-          )}
-        </QueryProvider>
+        <MainProvider>
+          <main className="container mx-auto">{children}</main>
+        </MainProvider>
       </body>
     </html>
   );

--- a/src/app/provider/index.tsx
+++ b/src/app/provider/index.tsx
@@ -1,0 +1,19 @@
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import QueryProvider from '@/app/provider/queryProvider';
+
+interface ProviderProps {
+  children: React.ReactNode;
+}
+
+function MainProvider({ children }: ProviderProps) {
+  return (
+    <QueryProvider>
+      {children}
+      {process.env.NODE_ENV === 'development' && (
+        <ReactQueryDevtools initialIsOpen={false} />
+      )}
+    </QueryProvider>
+  );
+}
+
+export default MainProvider;


### PR DESCRIPTION
### 🌱 연관된 이슈
[화면 레이아웃 설정: 백로그 링크](https://code-zero-to-one.atlassian.net/jira/software/projects/QNRR/boards/4/backlog?selectedIssue=QNRR-60&atlOrigin=eyJpIjoiMzcwYTY4MjNiMzdiNDBhYjllMzNlZjhkYzE0YTk5ZjEiLCJwIjoiaiJ9)

### ☘️ 작업 내용
- [x] 전역 레이아웃 설정

### 🍀 참고사항

<img width="600" alt="스크린샷 2025-03-01 오후 6 31 36" src="https://github.com/user-attachments/assets/fe29ea92-35c4-4ae8-80c2-3a8ebadc827b" />

tailwind container 스타일은 breakpoint마다 위의 사진에 적힌 너비를 설정할 수 있다. ( `@utility`설정으로 커스텀도 가능합니다. )

#### 스크린샷 (선택)
<img width="400" alt="스크린샷 2025-03-01 오후 6 27 43" src="https://github.com/user-attachments/assets/4d828fee-d758-4fda-b03a-e08cf8e5f6bd" />
<img width="400" alt="스크린샷 2025-03-01 오후 6 27 54" src="https://github.com/user-attachments/assets/b048f1d6-b621-46fa-90e5-ac1f9f4dab09" />
