### PR TITLE
Qnrr 354 코드 리뷰하면 PR 작성자에게 DM 전송하는 자동화 안되는 문제

### DIFF
--- a/.github/workflows/notify-pr-author-on-review.yml
+++ b/.github/workflows/notify-pr-author-on-review.yml
@@ -49,36 +49,10 @@ jobs:
 
       - name: Send Slack DM to PR Author
         if: steps.extract_info.outputs.skip != 'true'
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          AUTHOR_SLACK_ID: ${{ steps.extract_info.outputs.author_slack_id }}
-          TEXT: ${{ steps.extract_info.outputs.text }}
-        run: |
-          # slack bot과 PR 작성자와의 채널 조회 (DM을 보내기 위해, 반드시 slack bot과의 채널 id가 필요함)
-          JSON_IM_CHANNEL=$(curl -s -X POST https://slack.com/api/conversations.open \
-            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{\"users\":\"$AUTHOR_SLACK_ID\"}")
-          # slack bot과의 채널 id 저장
-          IM_CHANNEL_ID=$(echo "$JSON_IM_CHANNEL" | jq -r '.channel.id') 
-
-          JSON_DATA=$(jq -n \
-            --arg channel "$IM_CHANNEL_ID" \
-            --arg text "$TEXT" \
-            '{
-              "channel": $channel,
-              "text": $text
-            }')
-
-          RESPONSE=$(curl -s -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "$JSON_DATA")
-
-          echo "Slack DM 전송 응답: $RESPONSE"
-
-          if ! echo "$RESPONSE" | jq -e '.ok' | grep -q true; then
-            echo "❌ Slack 메시지 전송 실패"
-            echo "에러 상세: $(echo "$RESPONSE" | jq -r '.error // "unknown error"')"
-            exit 1
-          fi
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ steps.extract_info.outputs.author_slack_id }}
+            text: ${{ steps.extract_info.outputs.text }}


### PR DESCRIPTION
### 🌱 연관된 이슈

Qnrr 354


### ☘️ 작업 내용

팀원이 코드리뷰를 하면 PR 작성자에게 DM 전송하는 자동화가 안됐습니다. 
slack api로 요청하여 slack bot이 DM 보내도록 했지만, [missing_post_type 에러](https://api.slack.com/methods/chat.postMessage#errors)가 발생합니다. 
추측하기에, slack api가 저희 보내는 데이터 형식을 제대로 이해하지 못한 것 같습니다.
기존에 JSON 데이터를 문자열로 직접 삽입해서 요청보냈으나, 이 경우 특수문자나 줄바꿈이 있으면 JSON 형식이 깨질 수 있다고 합니다.
JSON 데이터를 변수에 저장하여 slack api에게 보내면 안전하게 JSON으로 보낼 수 있다고 합니다.

![image](https://github.com/user-attachments/assets/dcf6ad79-3c38-41c5-86b8-2f99ed53bed1)
