### PR TITLE
Qnrr 377 면접 준비/완료 모달 Footer 디자인 수정

### DIFF
--- a/src/features/study/ui/today-study-modal.tsx
+++ b/src/features/study/ui/today-study-modal.tsx
@@ -241,14 +241,14 @@ function DoneForm({
               면접 결과에 대한 간단한 피드백을 입력해 주세요.
             </span>
           </div>
-        </div>
 
-        <TextAreaInput
-          placeholder="커뮤니케이션 능력은 우수하나, 자료구조 이해도가 부족해 추가 학습이 필요해 보입니다."
-          value={feedback}
-          maxLength={100}
-          onChange={(e) => setFeedback(e)}
-        />
+          <TextAreaInput
+            placeholder="커뮤니케이션 능력은 우수하나, 자료구조 이해도가 부족해 추가 학습이 필요해 보입니다."
+            value={feedback}
+            maxLength={100}
+            onChange={(e) => setFeedback(e)}
+          />
+        </div>
       </Modal.Body>
 
       <Modal.Footer className="flex justify-end gap-100">


### PR DESCRIPTION
## 🌱 연관된 이슈

Qnrr 377

## ☘️ 작업 내용

이전에는 면접 관련 모달들의 Footer가 피그마 명시되어있는 디자인과 달랐습니다.

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/81c9eece-2e5b-4637-b74c-8b18ad8ad8f1" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/29f23032-8b46-48c8-b1dd-745ad3455db3" />

아래 사진들은 수정한 후 모달 모습입니다.

<img width="300" alt="스크린샷 2025-07-19 오후 6 06 28" src="https://github.com/user-attachments/assets/1a2a63b2-ce3e-4b00-9e0e-bed16b0577b8" />

<img width="300" alt="스크린샷 2025-07-19 오후 5 52 38" src="https://github.com/user-attachments/assets/223303d9-e568-4df9-a469-6a9a9927d028" />

## 논의할 내용

### 1. 면접 관련 모달

면접 준비하기와 완료하기 모달은 하나의 컴포넌트 TodayStudyModal에서 처리되고 있습니다.
민주님 pr에 [질문](https://github.com/code-zero-to-one/study-platform-client/pull/89#discussion_r2215735219)한 내용인데, 개인적으로 면접 준비하기와 완료하기는 다른 기능이기 때문에 **서로 다른 컴포넌트로 분리해야 한다**고 생각합니다. (민주님도 같은 의견이십니다.)
나중에 리팩토링해야 할 부분입니다.

### 2. 버튼 컴포넌트

모달의 Footer에 있는 Button 컴포넌트들 size가 large입니다. **피그마 상에서는 large이면 좌우 padding이 16px인데, 실제 적용된 스타일은 12px입니다.**
지금 여기서 고치기에 적합하지 않다고 판단하여, 수정하지 않았습니다.