### PR TITLE
Qnrr 375 프로필을 기본 프로필로 수정했을 때의 요청 로직 수정

### DIFF
--- a/src/features/my-page/ui/profile-edit-modal.tsx
+++ b/src/features/my-page/ui/profile-edit-modal.tsx
@@ -96,7 +96,8 @@ function ProfileEditForm({
 
   const handleSubmit = async () => {
     const file = fileInputRef.current?.files?.[0];
-    const profileImageExtension = file?.name.split('.').pop();
+    const profileImageExtension =
+      image === DEFAULT_PROFILE_IMAGE_URL ? 'jpg' : file?.name.split('.').pop();
 
     const rawFormData: UpdateUserProfileRequest = {
       name: profileForm.name,
@@ -116,36 +117,22 @@ function ProfileEditForm({
 
     const updatedProfile = await updateProfile(formData);
 
-    // todo: 서버 측에서 api 수정되면, 리팩토링
-    // 기본 프로필 이미지를 선택할 경우, 기본 프로필 이미지 전송 -> 서버 측에서 나중에 리팩토링 예정
-    // public 폴더의 profile-default.jpg 파일을 fetch해서 FormData에 추가
-    // profile-default.jpg를 추가한 이유는 서버에서 프로필 이미지 확장자에 svg 파일을 고려하지 못함 -> 서버 측에서 리팩토링 예정
-    if (image === DEFAULT_PROFILE_IMAGE_URL) {
-      try {
+    if (updatedProfile.profileImageUploadUrl) {
+      const imageFormData = new FormData();
+
+      if (file) imageFormData.append('file', file);
+
+      // 기본 프로필 이미지를 선택할 경우, public 폴더의 profile-default.jpg로 서버 api에게 기본 프로필 이미지 전송 -> 서버 측에서 나중에 리팩토링 예정
+      // profile-default.jpg를 추가한 이유는 서버에서 프로필 이미지 확장자에 svg 파일을 고려하지 못함 -> 서버 측에서 리팩토링 예정
+      if (!file && image === DEFAULT_PROFILE_IMAGE_URL) {
         const defaultProfileImage = 'profile-default.jpg';
         const response = await fetch(defaultProfileImage);
         const blob = await response.blob();
-        const defaultFile = new File([blob], defaultProfileImage, {
-          type: 'image/jpeg',
+        const defaultProfileFile = new File([blob], defaultProfileImage, {
+          type: 'image/jpg',
         });
-        const imageFormData = new FormData();
-        imageFormData.append('file', defaultFile);
-
-        await uploadProfileImage({
-          memberId,
-          filename: defaultProfileImage,
-          file: imageFormData,
-        });
-      } catch (error) {
-        console.error('기본 프로필 이미지 업로드 실패:', error);
-        alert('기본 프로필 이미지 업로드에 실패했습니다.');
+        imageFormData.append('file', defaultProfileFile);
       }
-    }
-
-    // 폴더에서 이미지를 선택한 경우
-    if (file && updatedProfile.profileImageUploadUrl) {
-      const imageFormData = new FormData();
-      imageFormData.append('file', file);
 
       const filename = updatedProfile.profileImageUploadUrl.split('/').pop();
       if (!filename) return;


### PR DESCRIPTION
### 🌱 연관된 이슈

Qnrr 375


### ☘️ 작업 내용

프로필 이미지 수정 로직을 잘못 작성하였습니다.
프로필 이미지 수정 로직은 다음과 같습니다.

1. 프로필 수정 api 요청할 때 선택한 이미지의 확장자를 전송 (updateProfile)
2. 응답 데이터로 온 profileImageUploadUrl으로 [프로필 업로드 api](https://test-api.zeroone.it.kr/swagger-ui/index.html#/file-controller/uploadProfileImage)에 요청 (uploadProfileImage)

프로필 수정 api와 프로필 업로드 api 두 개로 구분한 이유는 [경도님의 답변](https://goodmorning-cs-study.slack.com/archives/C082V7MQPB2/p1752837242846759?thread_ts=1752832128.280979&cid=C082V7MQPB2)을 봐주시면 됩니다.