### PR TITLE
Qnrr 380 1일 전의 날짜로 특정 날짜의 내 스터디 조회하는 버그 해결

### DIFF
--- a/src/features/study/ui/study-card.tsx
+++ b/src/features/study/ui/study-card.tsx
@@ -62,7 +62,10 @@ export default function StudyCard() {
     day: selectedDate.getDate(),
   };
 
-  const studyParams = { studyDate: selectedDate.toISOString().split('T')[0] };
+  const offset = selectedDate.getTimezoneOffset() * 60000; // ms단위라 60000곱해줌
+  const dateOffset = new Date(selectedDate.getTime() - offset);
+
+  const studyParams = { studyDate: dateOffset.toISOString().split('T')[0] };
 
   const { data: participationData } = useWeeklyParticipation(params);
   const isParticipate = participationData?.isParticipate ?? false;


### PR DESCRIPTION
## 🌱 연관된 이슈

Qnrr 380

## ☘️ 작업 내용
14일이면 study/daily/mine/2025-07-13으로 요청되는 버그가 있었습니다. ([/api/v1/study/daily/mine/{studyDate}](https://test-api.zeroone.it.kr/swagger-ui/index.html#/%EC%8A%A4%ED%84%B0%EB%94%94%20%EB%8D%B0%EC%9D%BC%EB%A6%AC%20API/getMyDailyStudyByDate) 스웨거 참고)

<img width="3600" height="1382" alt="image" src="https://github.com/user-attachments/assets/057090bc-94f3-4aa0-b77f-0ad7298f0a9e" />

이 버그의 원인은 **selectedDate.toISOString()**입니다.

selectedDate는 잘 업데이트 됩니다.
studyDate의 값이 selectedDate.toISOString().split('T')[0]인데, 1일전 날자로 설정됩니다.

<img width="1824" height="88" alt="image" src="https://github.com/user-attachments/assets/6cab0bac-5672-44a6-9dbc-cb23050e7546" />


toISOString은 **UTC(협정 세계시)** 기준으로 날짜를 출력합니다.
**한국 시간은 UTC보다 9시간 앞섭니다.**

예를 들어, selectedDate가 한국 시간인 "Tue Jul 15 2025 00:00:00 GMT+0900 (한국 표준시)"이면, 
selectedDate보다 9시간 앞선 '2025-07-14T15:00:00.000Z'에서 “2025-07-14”를 studyDate로 설정하게 됩니다.

[블로그 글](https://anywaydevlog.tistory.com/46)을 참고하여 수정하였습니다.
