### PR TITLE
Qnrr 390 스터디 신청 완료 안내 문구 alert로 표시

### DIFF
--- a/src/features/study/ui/start-study-modal.tsx
+++ b/src/features/study/ui/start-study-modal.tsx
@@ -321,6 +321,7 @@ export default function StartStudyModal({ memberId }: StartStudyModalProps) {
                     },
                     {
                       onSuccess: () => {
+                        alert('스터디 신청이 완료되었습니다!');
                         router.refresh();
                       },
                       onError: () => {


### PR DESCRIPTION
### 🌱 연관된 이슈

Qnrr 390 

### ☘️ 작업 내용

Toast 컴포넌트를 개발까지 했으나 적용하는데 어려움이 있었습니다.
스터디 신청에 성공하면 화면을 새로고침하고 바로 Toast를 띄워줘야 합니다. 우선 alert로 처리하였지만, 리팩토링해야 합니다.

Toast로 스터디 신청 성공 안내 문구를 보여주기 위해 제가 생각한 방법은 아래와 같아요.

1. 스터디 신청 성공
2. 쿠키에 스터디 신청 성공 값을 저장
3. 새로고침
4. 2번 값으로 Toast 렌더링 여부 결정. 만약 렌더링하면, 언마운트될 때 쿠키 값 삭제

이 방법이 좋은 방법인지는 모르겠습니다. 더 좋은 방법이 있다면 알려주세요!

그리고 shadcn에서 toast를 구현하기 위해 [sonner](https://sonner.emilkowal.ski/)라는 라이브러리를 설치하라고 명시되어 있습니다. 이걸로 toast 구현하긴 했는데, 다른 분들은 어떻게 생각하시나요?