### PR TITLE
Qnrr 415 설정 아이콘을 클릭하면 "프로필" 페이지로 이동

### DIFF
--- a/src/features/study/ui/my-profile-card.tsx
+++ b/src/features/study/ui/my-profile-card.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import Link from 'next/link';
 import React, { useState } from 'react';
 import { usePatchAutoMatchingMutation } from '@/entities/user/model/use-user-profile-query';
-import UserProfileModal from '@/features/my-page/ui/user-profile-modal';
 import UserAvatar from '@/shared/ui/avatar';
 import { ToggleSwitch } from '@/shared/ui/toggle';
 import AccessTimeIcon from 'public/icons/access_time.svg';
@@ -56,14 +56,12 @@ export default function MyProfileCard({
       <div className="flex flex-row items-center gap-200">
         <div className="relative h-[64px] w-[64px] shrink-0">
           <UserAvatar size={64} image={imageUrl?.trim() || ''} />
-          <UserProfileModal
-            memberId={memberId}
-            trigger={
-              <button className="bg-background-accent-gray-strong absolute right-0 bottom-0 flex h-[24px] w-[24px] items-center justify-center rounded-full">
-                <SettingIcon />
-              </button>
-            }
-          />
+          <Link
+            href="my-page"
+            className="bg-background-accent-gray-strong absolute right-0 bottom-0 flex h-[24px] w-[24px] items-center justify-center rounded-full"
+          >
+            <SettingIcon />
+          </Link>
         </div>
         <div className="flex flex-col">
           <div className="font-designer-18b">{name?.trim() || '비회원'}님</div>


### PR DESCRIPTION
### 🌱 연관된 이슈

Qnrr 415

### ☘️ 작업 내용

오른쪽 프로필 이미지 옆에 설정 아이콘을 클릭하면, 모달이 뜹니다.

https://github.com/user-attachments/assets/fbf28b11-86af-4174-b823-3fcf5a58ef42

원래 기획은 **설정 아이콘을 클릭하면, "프로필" 페이지로 이동**해야 합니다.


https://github.com/user-attachments/assets/0fead83c-ed86-4e14-8bb2-0a0832d76d0c

