### PR TITLE
Qnrr 418 스터디 신청 모달 유효성 검증

### DIFF
--- a/src/features/study/ui/start-study-modal.tsx
+++ b/src/features/study/ui/start-study-modal.tsx
@@ -3,7 +3,7 @@
 import { XIcon } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import {
   useAvailableStudyTimesQuery,
   useStudySubjectsQuery,
@@ -146,7 +146,6 @@ function StartStudyForm({ memberId }: StartStudyModalProps) {
     blogOrSnsLink,
     preferredStudySubjectId,
     availableStudyTimeIds,
-    techStackIds,
   } = form;
 
   const { data: availableStudyTimes } = useAvailableStudyTimesQuery();
@@ -173,30 +172,17 @@ function StartStudyForm({ memberId }: StartStudyModalProps) {
   };
 
   const handleSubmit = () => {
-    const isValidSelfIntroduction = selfIntroduction.trim() !== '';
-    const isValidStudyPlan = studyPlan.trim() !== '';
-    const isValidTel = tel.trim() !== '';
-    const isValidPreferredStudySubjectId =
-      preferredStudySubjectId !== undefined;
-    const isValidAvailableStudyTimeIds = availableStudyTimeIds.length > 0;
-    const isValidTechStackIds = techStackIds.length > 0;
+    const newError: JoinStudyFormError = {
+      selfIntroduction: selfIntroduction.trim() === '',
+      studyPlan: studyPlan.trim() === '',
+      tel: !/^\d{2,3}-\d{3,4}-\d{4}$/.test(tel),
+      preferredStudySubjectId: preferredStudySubjectId === undefined,
+      availableStudyTimeIds: availableStudyTimeIds.length === 0,
+      techStackIds: form.techStackIds.length === 0,
+    };
 
-    if (
-      !isValidSelfIntroduction ||
-      !isValidStudyPlan ||
-      !isValidTel ||
-      !isValidPreferredStudySubjectId ||
-      !isValidAvailableStudyTimeIds ||
-      !isValidTechStackIds
-    ) {
-      setError({
-        selfIntroduction: !isValidSelfIntroduction,
-        studyPlan: !isValidStudyPlan,
-        tel: !isValidTel,
-        preferredStudySubjectId: !isValidPreferredStudySubjectId,
-        availableStudyTimeIds: !isValidAvailableStudyTimeIds,
-        techStackIds: !isValidTechStackIds,
-      });
+    if (Object.values(newError).some(Boolean)) {
+      setError(newError);
 
       return;
     }
@@ -241,15 +227,19 @@ function StartStudyForm({ memberId }: StartStudyModalProps) {
             description="간단한 자기소개를 입력해 주세요."
           >
             <BaseInput
-              className="border-border-default rounded-100 border p-150"
               placeholder="신입 프론트엔드 개발자입니다. 리액트를 중심으로 공부 중이고, 꾸준히 기록하는 습관을 들이고 있어요."
               value={selfIntroduction}
-              onChange={(e) =>
+              color={error.selfIntroduction ? 'error' : 'default'}
+              onChange={(e) => {
                 setForm((prev) => ({
                   ...prev,
                   selfIntroduction: e.target.value,
-                }))
-              }
+                }));
+                setError((prev) => ({
+                  ...prev,
+                  selfIntroduction: e.target.value.trim() === '',
+                }));
+              }}
             />
           </LabeledField>
 
@@ -259,15 +249,19 @@ function StartStudyForm({ memberId }: StartStudyModalProps) {
             description="스터디에서 다루고 싶은 주제와 학습 목표를 알려주세요."
           >
             <BaseInput
-              className="border-border-default rounded-100 border p-150"
+              color={error.studyPlan ? 'error' : 'default'}
               placeholder="CS 기본기를 탄탄하게 다지는 것이 목표입니다. 각자 맡은 주제를 정리하고 공유하는 방식으로 진행하고 싶어요."
               value={studyPlan}
-              onChange={(e) =>
+              onChange={(e) => {
                 setForm((prev) => ({
                   ...prev,
                   studyPlan: e.target.value,
-                }))
-              }
+                }));
+                setError((prev) => ({
+                  ...prev,
+                  studyPlan: e.target.value.trim() === '',
+                }));
+              }}
             />
           </LabeledField>
 
@@ -277,6 +271,7 @@ function StartStudyForm({ memberId }: StartStudyModalProps) {
             description="관심 있는 스터디 유형을 선택해 주세요."
           >
             <SingleDropdown
+              error={error.preferredStudySubjectId}
               defaultValue={preferredStudySubjectId}
               options={(studySubjects ?? []).map(
                 ({ studySubjectId, name }) => ({
@@ -285,12 +280,16 @@ function StartStudyForm({ memberId }: StartStudyModalProps) {
                 }),
               )}
               placeholder="선택하세요"
-              onChange={(value) =>
+              onChange={(value) => {
                 setForm((prev) => ({
                   ...prev,
                   preferredStudySubjectId: value.toString(),
-                }))
-              }
+                }));
+                setError((prev) => ({
+                  ...prev,
+                  preferredStudySubjectId: value === undefined,
+                }));
+              }}
             />
           </LabeledField>
 
@@ -320,6 +319,7 @@ function StartStudyForm({ memberId }: StartStudyModalProps) {
             description="현재 본인이 사용할 수 있는 기술 스택을 모두 선택해 주세요."
           >
             <MultiDropdown
+              error={error.techStackIds}
               options={(techStacks ?? []).map(
                 ({ techStackId, techStackName }) => ({
                   value: techStackId,
@@ -330,6 +330,10 @@ function StartStudyForm({ memberId }: StartStudyModalProps) {
                 setForm((prev) => ({
                   ...prev,
                   techStackIds: newSelected as number[],
+                }));
+                setError((prev) => ({
+                  ...prev,
+                  techStackIds: newSelected.length === 0,
                 }));
               }}
               placeholder="기술을 선택해주세요"
@@ -342,13 +346,17 @@ function StartStudyForm({ memberId }: StartStudyModalProps) {
             description="스터디 진행을 위해 연락 가능한 정보를 입력해 주세요. 입력하신 정보는 매칭된 스터디원에게만 제공되며, 외부에는 노출되지 않습니다."
           >
             <BaseInput
-              className="border-border-default rounded-100 border p-150"
               placeholder="010-1234-5678"
               value={tel}
+              color={error.tel ? 'error' : 'default'}
               onChange={(e) => {
                 setForm((prev) => ({
                   ...prev,
                   tel: e.target.value,
+                }));
+                setError((prev) => ({
+                  ...prev,
+                  tel: !/^\d{2,3}-\d{3,4}-\d{4}$/.test(e.target.value),
                 }));
               }}
             />
@@ -359,7 +367,6 @@ function StartStudyForm({ memberId }: StartStudyModalProps) {
             description="본인의 활동을 확인할 수 있는 GitHub 링크를 입력해 주세요."
           >
             <BaseInput
-              className="border-border-default rounded-100 border p-150"
               placeholder="https://github.com/@zero-one"
               value={githubLink}
               onChange={(e) =>
@@ -373,7 +380,6 @@ function StartStudyForm({ memberId }: StartStudyModalProps) {
             description="본인의 활동을 확인할 수 있는 외부 링크가 있다면 입력해 주세요."
           >
             <BaseInput
-              className="border-border-default rounded-100 border p-150"
               placeholder="https://velog.io/@zero-one"
               value={blogOrSnsLink}
               onChange={(e) =>
@@ -393,12 +399,7 @@ function StartStudyForm({ memberId }: StartStudyModalProps) {
             취소
           </Button>
         </Modal.Close>
-        <Button
-          size="large"
-          color="primary"
-          onClick={handleSubmit}
-          disabled={Object.values(error).some(Boolean)}
-        >
+        <Button size="large" color="primary" onClick={handleSubmit}>
           신청 완료
         </Button>
       </Modal.Footer>

--- a/src/shared/ui/dropdown/multi.tsx
+++ b/src/shared/ui/dropdown/multi.tsx
@@ -17,6 +17,7 @@ interface Option {
 interface MultiDropdownProps {
   options: Option[];
   defaultValue?: (string | number)[];
+  error?: boolean;
   onChange?: (selected: (string | number)[]) => void;
   placeholder?: string;
 }
@@ -24,6 +25,7 @@ interface MultiDropdownProps {
 function MultiDropdown({
   options,
   defaultValue = [],
+  error = false,
   onChange,
   placeholder = '선택해주세요',
 }: MultiDropdownProps) {
@@ -63,7 +65,7 @@ function MultiDropdown({
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger asChild>
         <div
-          className="rounded-150 border-border-default bg-fill-neutral-subtle-default flex h-auto max-h-[120px] w-full cursor-pointer flex-wrap items-center justify-between border px-150 py-100"
+          className={`rounded-150 ${error ? 'border-border-error' : 'border-border-default'} bg-fill-neutral-subtle-default flex h-auto max-h-[120px] w-full cursor-pointer flex-wrap items-center justify-between border px-150 py-100`}
           role="button"
           tabIndex={0}
         >

--- a/src/shared/ui/dropdown/single.tsx
+++ b/src/shared/ui/dropdown/single.tsx
@@ -16,6 +16,7 @@ interface Props {
   options: Option[];
   defaultValue?: string | number;
   placeholder?: string;
+  error?: boolean;
   onChange: (value: string | number) => void;
 }
 
@@ -23,6 +24,7 @@ function SingleDropdown({
   placeholder,
   options,
   defaultValue,
+  error = false,
   onChange,
 }: Props) {
   const [selectedValue, setSelectedValue] = useState<
@@ -37,7 +39,9 @@ function SingleDropdown({
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger className="w-full focus:outline-none">
-        <div className="rounded-150 border-border-default bg-fill-neutral-subtle-default flex h-[48px] w-full items-center justify-between border px-150">
+        <div
+          className={`rounded-150 ${error ? 'border-border-error' : 'border-border-default'} bg-fill-neutral-subtle-default flex h-[48px] w-full items-center justify-between border px-150`}
+        >
           <span
             className={`font-designer-14m ${selectedOption ? 'text-text-subtle' : 'text-text-subtlest'}`}
           >

--- a/src/shared/ui/input/base.tsx
+++ b/src/shared/ui/input/base.tsx
@@ -2,8 +2,10 @@ import { cva } from 'class-variance-authority';
 import { cn } from '@/shared/shadcn/lib/utils';
 import { Input as ShadcnInput } from '@/shared/shadcn/ui/input';
 
-interface BaseInputProps extends React.ComponentProps<typeof ShadcnInput> {
+interface BaseInputProps
+  extends Omit<React.ComponentProps<typeof ShadcnInput>, 'size'> {
   color?: 'default' | 'error' | 'success';
+  size?: 'm' | 'l';
 }
 
 const inputVariants = cva(
@@ -15,6 +17,10 @@ const inputVariants = cva(
         error: 'border-border-error text-text-default',
         success: 'border-border-success text-text-default',
       },
+      size: {
+        m: 'py-100',
+        l: 'py-150',
+      },
     },
     defaultVariants: {
       color: 'default',
@@ -22,10 +28,15 @@ const inputVariants = cva(
   },
 );
 
-function BaseInput({ className, color = 'default', ...props }: BaseInputProps) {
+function BaseInput({
+  className,
+  color = 'default',
+  size = 'l',
+  ...props
+}: BaseInputProps) {
   return (
     <ShadcnInput
-      className={cn(inputVariants({ color }), className)}
+      className={cn(inputVariants({ color, size }), className)}
       {...props}
     />
   );


### PR DESCRIPTION
## 🌱 연관된 이슈

Qnrr 418

## ☘️ 작업 내용

### 1. 스터디 신청 폼 분리

StartStudyModal에 있는 폼 상태를 분리하였습니다.
이 모달이 재오픈시 이전에 기록해둔 내역이 남아있습니다. (#97 과 동일한 문제니 PR 참고 부탁드립니다 🙇 )

### 2. error 스타일 추가
MultiDropdown과 SingleDropdown에 error prop을 추가하였습니다.

### 3. 인풋 컴포넌트에 size prop 추가

size는 l과 m이 있습니다. 디자인 시스템과 비슷하게 사이즈를 조절하였으나 추후에 리팩토링해야 할 것 같습니다..

### 4. 스터디 신청 폼 에러 검사 시점

에러 검사는 
1. input에 값을 입력할 때마다
2. 신청 버튼을 클릭했을 때
발생합니다. ([slack 참고](https://goodmorning-cs-study.slack.com/archives/C0873Q5Q81E/p1753718615360969))

form 상태로 error임을 판단할 수 있었을텐데, 왜 error 상태를 만들었는지 의문이 드실 수 있으실 것 같아요.
다만, 첫 렌더링에서 input들을 에러 표시로 둘 수 없었기에 상태를 만들었습니다.

error가 상태 업데이트되는 trigger는 아래와 같습니다.
1. 제출 버튼 클릭시
2. 자기소개, 공부 주제 및 계획, 선호하는 스터디 주제, 사용 가능한 기술 스택, 연락처의 값이 바뀔 때

