### PR TITLE
프론트엔드 배포 502 에러 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # 운영환경(main branch)에서 사용하는 Dockerfile
 
 # 1단계: build
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 WORKDIR /app
 
 COPY . .
@@ -12,7 +12,7 @@ COPY .env .env
 RUN yarn install && yarn build
 
 # 2단계: production
-FROM node:18-alpine AS runner
+FROM node:20-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 # 운영환경(main branch)에서 사용하는 Dockerfile
 
 # 1단계: build
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 WORKDIR /app
 
 COPY . .
@@ -12,7 +12,7 @@ COPY .env .env
 RUN yarn install && yarn build
 
 # 2단계: production
-FROM node:18-alpine AS runner
+FROM node:20-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,7 +1,7 @@
 # 운영환경(main branch)에서 사용하는 Dockerfile
 
 # 1단계: build
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 WORKDIR /app
 
 COPY . .
@@ -12,7 +12,7 @@ COPY .env .env
 RUN yarn install && yarn build
 
 # 2단계: production
-FROM node:18-alpine AS runner
+FROM node:20-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
프론트엔드 502 에러 해결을 위한 pr 입니다.
Dockerfile 버전 업데이트 하여 시도해보려고 합니다.


++ 추가적으로 만약 이걸로 해서 해결한다면 제가 생각한 원인이 맞다는 가정하에 말씀드리겠습니다...
저희 깃허브 로그를 보면
`error eventsource-parser@3.0.5: The engine "node" is incompatible with this module. Expected version ">=20.0.0". Got "18.20.8"`

이런 오류가 있습니다.
eventsource-parser라는 게 노드 버전을 20 이상을 요구하는데, 저희는 노드 18을 쓰고 있어서 생기는 오류라는 건데...
문제는 이 녀석이 왜 추가된 건지 모르겠습니다.
eventsource-parser라는 게 SSE에 사용되는 서버 전송 스트리밍 관련 의존인데...
찾아보니 그나마 가능성 있는 이유가 저희가 직접 추가한 게 아니라, 추가한 의존성의 하위로 들어갈 수 있다고 합니다..

그런데 제가 추가한 react hook form 이나 zod 는 상태 관리지, 스트리밍과 관련이 없는 의존성이고 저희가 추가할 일도 없는데 대체 저 녀석이 어디서 추가된 건지도 모르겠고..... 왜 저게 있는지도 모르겠습니다.

해결 방법이 도커파일에서 프로즌 시켜서 CI가 재해석을 하지 못하게 막으면 이런 일을 방지할 수 있다는데....
일단 이걸 방지하는 것보다는 저희가 할 일이 많으니... 나중에 한 번 살펴봐야할 것 같습니다..
