### PR TITLE
[Fix] node 힙 메모리 용량으로 인한 테스트 서버 빌드 502 에러 

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -26,6 +26,9 @@ COPY --from=builder /app/next.config.ts ./next.config.ts
 # 런타임시점에도 .env 파일 복사
 COPY --from=builder /app/.env .env
 
+# 빌드 시 Node 힙 메모리를 4GB까지 허용 (4096 = 4GB)
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
 # devDependencies는 설치하지 않고 dependencies만 설치
 RUN yarn install --production 
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -26,6 +26,9 @@ COPY --from=builder /app/next.config.ts ./next.config.ts
 # 런타임시점에도 .env 파일 복사
 COPY --from=builder /app/.env .env
 
+# 빌드 시 Node 힙 메모리를 4GB까지 허용 (4096 = 4GB)
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
 # devDependencies는 설치하지 않고 dependencies만 설치
 RUN yarn install --production 
 


### PR DESCRIPTION
### ☘️ 작업 내용

<img width="1032" height="285" alt="스크린샷 2025-08-27 오전 12 34 10" src="https://github.com/user-attachments/assets/c88f117f-450b-4d53-bdd8-05878c258dff" />

제 PR을 머지하면서, 프론트 테스트 서버가 502 에러가 발생했습니다.
[사진 workflow](https://github.com/code-zero-to-one/study-platform-client/actions/runs/17242277911/job/48923985966) 보시면 node에서 사용할 수 있는 최대 메모리 용량이 512MB인데, 빌드하면서 이 용량 넘겨서 실패한 것 같아요.

[검색](https://www.google.com/search?q=Reached+heap+limit+Allocation+failed+-+JavaScript+heap+out+of+memory&sca_esv=3625eca33e5fb376&sxsrf=AE3TifP4KD-E_3wcBGQ32tCaonw2HBfxeg%3A1756223290779&ei=OtetaNyiL_6Pvr0P3LuGuQM&ved=0ahUKEwjcp5LL6aiPAxX-h68BHdydITcQ4dUDCBA&uact=5&oq=Reached+heap+limit+Allocation+failed+-+JavaScript+heap+out+of+memory&gs_lp=Egxnd3Mtd2l6LXNlcnAiRFJlYWNoZWQgaGVhcCBsaW1pdCBBbGxvY2F0aW9uIGZhaWxlZCAtIEphdmFTY3JpcHQgaGVhcCBvdXQgb2YgbWVtb3J5MgUQABiABDIIEAAYgAQYywEyCBAAGIAEGMsBMggQABiABBjLATIEEAAYHjIEEAAYHjIEEAAYHjIEEAAYHjIEEAAYHjIEEAAYHkieA1AAWH9wAHgAkAEAmAHOAaABxwKqAQUwLjEuMbgBA8gBAPgBAZgCAaACgAGYAwCSBwMwLjGgB6gTsgcDMC4xuAeAAcIHAzItMcgHBg&sclient=gws-wiz-serp)해보니, Node 힙 메모리 제한용량을 늘려서 해결하더라구요.

물론 이게 머지가 되어도 해결되지 않을 수도 있어요..