### PR TITLE
[Fix] MultiDropdown에서 badge가 삭제되지 않는 문제

### DIFF
--- a/src/shared/ui/dropdown/multi.tsx
+++ b/src/shared/ui/dropdown/multi.tsx
@@ -107,8 +107,11 @@ export default function MultiDropdown({
                 {item.label}
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onPointerDown={(e) => {
+                    e.preventDefault();
                     e.stopPropagation();
+                  }}
+                  onClick={(e) => {
                     remove(item.value);
                   }}
                   className="cursor-pointer"
@@ -124,8 +127,11 @@ export default function MultiDropdown({
             {selected.length > 0 && (
               <button
                 type="button"
-                onClick={(e) => {
+                onPointerDown={(e) => {
+                  e.preventDefault();
                   e.stopPropagation();
+                }}
+                onClick={(e) => {
                   clear();
                 }}
                 className="bg-icon-strong flex h-200 w-200 items-center justify-center rounded-full"


### PR DESCRIPTION
### ☘️ 작업 내용

확실한 해결책인지는 명확하지 않지만 한 번 확인부탁드립니다.

#### 이전 Flow

x버튼을 클릭하면 dropdown 열고 닫는 핸들러(`DropdownMenu`의 `onOpenChange`)가 실행됩니다.
그래서, x버튼 클릭할 때마다 dropdown이 열리고 닫혀요.

https://github.com/user-attachments/assets/ee2dd41b-1a72-4942-a3ca-3e7c7ad315ee

그래서 콘솔을 다 찍어봤습니다..

```tsx
    <DropdownMenu
      open={open}
      onOpenChange={(option) => {
        console.log('open change');

        return !disabled && setOpen(option);
      }}
    >
      <DropdownMenuTrigger
        asChild
        onPointerDown={() => {
          console.log('pointer down');
        }}
      >
                <button
                  type="button"
                  onPointerDown={(e) => {
                    console.log('button pointer down');
                  }}
                  onClick={(e) => {
                    e.stopPropagation();
                    console.log('button click');
                    remove(item.value);
                  }}
                >
                  <XIcon size={16} />
                </button>
              // ...
```

x 버튼 클릭하면 아래와 같은 flow로 진행됩니다.

1. x 버튼 onPointerDown 실행
2. Trigger의 onPointerDown 실행
3. DropdownMenu의 onOpenChange 실행
4. x 버튼 onClick 실행

onOpenChange은 왜 실행되는지 찾아보니, [`DropdownMenuPrimitive.Root` 내부에서 onPointerDown을 사용](https://github.com/radix-ui/primitives/blob/36d954d3c1b41c96b1d2e875b93fc9362c8c09e6/packages/react/dropdown-menu/src/dropdown-menu.tsx#L117-L126)하고 있더라구요.

#### 수정 후 Flow

x버튼 클릭해도 dropdown 열림 상태에 변화가 없습니다.

https://github.com/user-attachments/assets/50f05835-770a-4ade-8a3a-b8cacc82376c

x 버튼의 onPointerDown 이벤트에  `e.preventDefault(); e.stopPropagation();`를 걸었습니다.
클릭 이벤트 전에 onPointerDown로 인해 dropdown 토글 이벤트 핸들러가 실행되어 클릭 이벤트 핸들러 실행이 무시되는 게 아닐까 싶었습니다.