### PR TITLE
[Feat] 어드민 페이지로 이동하는 드롭다운 옵션 추가

### DIFF
--- a/src/features/auth/ui/header-user-dropdown.tsx
+++ b/src/features/auth/ui/header-user-dropdown.tsx
@@ -1,22 +1,43 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { decodeJwt } from '@/shared/lib/jwt';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/shared/shadcn/ui/dropdown-menu';
+import { getCookie } from '@/shared/tanstack-query/cookie';
 import UserAvatar from '@/shared/ui/avatar';
 import { useLogoutMutation } from '../model/use-auth-mutation';
 
 export default function HeaderUserDropdown({ userImg }: { userImg: string }) {
   const { mutateAsync: logout } = useLogoutMutation();
+
+  const jwt = getCookie('accessToken');
+  const decodedJwt = decodeJwt(jwt);
+
+  const hasAdminRole = decodedJwt && decodedJwt?.roleIds.includes('ROLE_ADMIN');
+
   const router = useRouter();
 
   const handleLogout = async () => {
     await logout();
   };
+
+  const baseOptions = [
+    {
+      label: '내 정보 수정',
+      value: '/my-page',
+      onMenuClick: () => router.push('/my-page'),
+    },
+    {
+      label: '로그아웃',
+      value: 'logout',
+      onMenuClick: handleLogout,
+    },
+  ];
 
   return (
     <DropdownMenu>
@@ -27,18 +48,17 @@ export default function HeaderUserDropdown({ userImg }: { userImg: string }) {
       </DropdownMenuTrigger>
 
       <DropdownMenuContent className="rounded-100 border-border-default bg-background-default shadow-2 flex w-full flex-col gap-50 border p-50">
-        {[
-          {
-            label: '내 정보 수정',
-            value: '/my-page',
-            onMenuClick: () => router.push('/my-page'),
-          },
-          {
-            label: '로그아웃',
-            value: 'logout',
-            onMenuClick: handleLogout,
-          },
-        ].map((option) => (
+        {(hasAdminRole
+          ? [
+              ...baseOptions,
+              {
+                label: '서비스 관리',
+                value: '/admin',
+                onMenuClick: () => router.push('/admin'),
+              },
+            ]
+          : baseOptions
+        ).map((option) => (
           <DropdownMenuItem
             key={option.value}
             onClick={option.onMenuClick}

--- a/src/shared/lib/jwt.ts
+++ b/src/shared/lib/jwt.ts
@@ -1,4 +1,6 @@
 export const decodeJwt = (token: string) => {
+  if (!token) return null;
+
   const base64Url = token.split('.')[1];
   const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
   const jsonPayload = decodeURIComponent(


### PR DESCRIPTION
### ☘️ 작업 내용

jwt 토큰의 roleIds에 `ROLE_ADMIN`이 있으면, 헤더 드롭다운에 `서비스 관리` 옵션이 추가로 있습니다.
`서비스 관리`를 클릭하면, 어드민 페이지로 이동합니다.

https://github.com/user-attachments/assets/cf3114a8-84a1-4ce3-82f9-140f56446345

