### PR TITLE
[Refactor] color가 gray인 Badge에서 border 삭제

### DIFF
--- a/src/shared/ui/badge/index.tsx
+++ b/src/shared/ui/badge/index.tsx
@@ -17,7 +17,7 @@ const badgeVariants = cva(
         blue: 'bg-background-accent-blue-subtle text-text-information border-background-accent-blue-subtle',
         orange:
           'bg-background-accent-orange-subtle text-background-accent-orange-strong',
-        gray: 'bg-background-accent-gray-subtle text-background-accent-gray-strong',
+        gray: 'bg-background-accent-gray-subtle text-background-accent-gray-strong border-0',
         purple:
           'bg-background-accent-purple-subtle text-background-accent-purple-strong',
       },


### PR DESCRIPTION
### ☘️ 작업 내용
여기서 `<Badge color="gray">뱃지</Badge>`를 사용하는데, border가 없어서 임시방편으로 삭제했습니다.
나중에 Badge 컴포넌트를 리팩토링해야 할 것 같아요 😢 

<img width="742" height="424" alt="스크린샷 2025-10-11 오후 3 34 44" src="https://github.com/user-attachments/assets/d9961858-2d69-4a89-bea1-6dfc670c05a2" />
