### PR TITLE
[Hotfix] 어드민 페이지 사용자 검색

### DIFF
--- a/src/features/admin/ui/member-list-table.tsx
+++ b/src/features/admin/ui/member-list-table.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
+import { useDebounce } from '@/shared/lib/debounce';
 import { formatYYYYMMDD } from '@/shared/lib/time';
 import Badge from '@/shared/ui/badge';
 import Button from '@/shared/ui/button';
@@ -25,13 +26,14 @@ import { useGetMemberListQuery } from '../model/use-member-list-query';
 export default function MemberListTable() {
   const [roleId, setRoleId] = useState<RoleId | null>(null);
   const [memberStatus, setMemberStatus] = useState<MemberStatus | null>(null);
-  const [searchKeyword, setSearchKeyword] = useState<string>('');
   const [page, setPage] = useState<number>(1);
+  const [searchKeyword, setSearchKeyword] = useState<string>('');
+  const debouncedSearchKeyword = useDebounce(searchKeyword, 500);
 
   const { data } = useGetMemberListQuery({
     roleId,
     memberStatus,
-    searchKeyword,
+    searchKeyword: debouncedSearchKeyword,
     page,
   });
 

--- a/src/shared/lib/debounce.ts
+++ b/src/shared/lib/debounce.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce(value: string, delay: number = 500) {
+  const [debounced, setDebounced] = useState<string>(value);
+
+  useEffect(() => {
+    const timeId = setTimeout(() => setDebounced(value), delay);
+
+    return () => clearTimeout(timeId);
+  }, [value, delay]);
+
+  return debounced;
+}


### PR DESCRIPTION
## ☘️ 작업 내용

우선 main에 머지해놓고 develop을 바라보는 PR 올리도록 하겠습니다.
괜찮으시다면, develop을 base로 하는 PR은 바로 머지해도 되는지 의견 부탁드립니다.

### 검색어 입력하면, page 상태 초기화

[slack 제보](https://goodmorning-cs-study.slack.com/archives/C08PFFYUNU9/p1760173650950099)

1페이지 아닌 곳에서 검색어를 입력하면, 1페이지가 아닌 해당 페이지에서 검색 요청이 날라가는 믄제가 있었습니다.
그래서, 검색어 상태를 변경하면 page 상태를 초기화하였습니다.

### debounce 적용

[slack 제보](https://goodmorning-cs-study.slack.com/archives/C08PFFYUNU9/p1760172647634879)

검색어 입력할 때마다 요청가는 것보다, 맨 마지막에 입력한 검색어로 요청가도록 debounce를 적용하였습니다.

**디바운스 적용 전**


https://github.com/user-attachments/assets/3ce46888-1c57-43c5-bcb1-4a51e099da89



**디바운스 적용 후**


https://github.com/user-attachments/assets/451577fe-014a-45ab-959a-155a03a0c54d

