### PR TITLE
[Fix] 마이스터디에서 memberId 1로 고정인 값 수정

### DIFF
--- a/app/(service)/(my)/my-study/page.tsx
+++ b/app/(service)/(my)/my-study/page.tsx
@@ -8,6 +8,7 @@ import { useMemberStudyListQuery } from '@/features/study/group/model/use-member
 import CompletedGroupStudyList from '@/features/study/group/ui/completed-group-study-list';
 import NotCompletedGroupStudyList from '@/features/study/group/ui/not-completed-group-study-list';
 import OpenGroupStudyModal from '@/features/study/group/ui/open-group-modal';
+import { getCookie } from '@/shared/tanstack-query/cookie';
 import Button from '@/shared/ui/button';
 
 interface MemberGroupStudyList extends MemberStudyItem {
@@ -15,8 +16,10 @@ interface MemberGroupStudyList extends MemberStudyItem {
 }
 
 export default function MyStudy() {
+  const memberIdStr = getCookie('memberId');
+
   const { data, isLoading } = useMemberStudyListQuery({
-    memberId: 1,
+    memberId: Number(memberIdStr),
     studyType: 'GROUP_STUDY',
     studyStatus: 'BOTH',
   });


### PR DESCRIPTION
## ☘️ 작업 내용

마이스터디에서 memberId를 1로 고정하고 있었습니다.
memberId를 쿠키에 저장된 값으로 변경하였습니다.