### PR TITLE
[Refactor] 실시간 신청자 목록에서 승인 대기중인 사람과 승인된 사람들을 보여주도록 수정

### DIFF
--- a/src/features/study/group/ui/study-info-section.tsx
+++ b/src/features/study/group/ui/study-info-section.tsx
@@ -60,6 +60,11 @@ export default function StudyInfoSection({
     status: 'PENDING',
   });
 
+  const applicants = [
+    ...(approvedApplicants?.pages.flatMap(({ content }) => content) || []),
+    ...(pendingApplicants?.pages.flatMap(({ content }) => content) || []),
+  ];
+
   const basicInfoItems = (basicInfo: BasicInfoDetail) => {
     const getDurationText = (startDate: string, endDate: string): string => {
       const start = new Date(startDate);
@@ -230,54 +235,46 @@ export default function StudyInfoSection({
               )}
             </div>
 
-            {[
-              ...(approvedApplicants?.pages || []),
-              ...(pendingApplicants?.pages || []),
-            ].map((applicant) => (
-              <div
-                key={applicant.page}
-                className="grid grid-cols-2 grid-rows-2 gap-200"
-              >
-                {applicant.content.map((data) => {
-                  const temperPreset = getSincerityPresetByLevelName(
-                    data.applicantInfo.sincerityTemp.levelName as string,
-                  );
+            <div className="grid grid-cols-2 grid-rows-2 gap-200">
+              {applicants.map((data) => {
+                const temperPreset = getSincerityPresetByLevelName(
+                  data.applicantInfo.sincerityTemp.levelName as string,
+                );
 
-                  return (
-                    <div
-                      key={data.applyId}
-                      className="rounded-100 border-border-subtle flex h-[100px] w-[382px] items-center justify-between gap-150 border px-200 py-300"
-                    >
-                      <UserAvatar size={48} image={undefined} />
-                      <div className="flex min-w-0 flex-1 flex-col">
-                        <div className="flex flex-row items-center gap-50">
-                          <div className="font-designer-16b">
-                            {data.applicantInfo.memberName}
-                          </div>
-                          <span
-                            className={cn(
-                              'font-designer-13r rounded-full px-150 py-50 leading-250',
-                              temperPreset.bgClass,
-                              temperPreset.textClass,
-                            )}
-                          >
-                            {`${data.applicantInfo.sincerityTemp.temperature}`}℃
-                          </span>
+                return (
+                  <div
+                    key={data.applyId}
+                    className="rounded-100 border-border-subtle flex h-[100px] w-[382px] items-center justify-between gap-150 border px-200 py-300"
+                  >
+                    <UserAvatar size={48} image={undefined} />
+                    <div className="flex min-w-0 flex-1 flex-col">
+                      <div className="flex flex-row items-center gap-50">
+                        <div className="font-designer-16b">
+                          {data.applicantInfo.memberName}
                         </div>
+                        <span
+                          className={cn(
+                            'font-designer-13r rounded-full px-150 py-50 leading-250',
+                            temperPreset.bgClass,
+                            temperPreset.textClass,
+                          )}
+                        >
+                          {`${data.applicantInfo.sincerityTemp.temperature}`}℃
+                        </span>
                       </div>
-                      <UserProfileModal
-                        memberId={data.applicantInfo.memberId}
-                        trigger={
-                          <div className="bg-fill-neutral-default-default text-text-default hover:bg-fill-neutral-default-hover active:bg-fill-neutral-default-pressed font-designer-14b rounded-75 flex cursor-pointer items-center justify-center px-75 py-50">
-                            프로필
-                          </div>
-                        }
-                      />
                     </div>
-                  );
-                })}
-              </div>
-            ))}
+                    <UserProfileModal
+                      memberId={data.applicantInfo.memberId}
+                      trigger={
+                        <div className="bg-fill-neutral-default-default text-text-default hover:bg-fill-neutral-default-hover active:bg-fill-neutral-default-pressed font-designer-14b rounded-75 flex cursor-pointer items-center justify-center px-75 py-50">
+                          프로필
+                        </div>
+                      }
+                    />
+                  </div>
+                );
+              })}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## ☘️ 작업 내용

실시간 신청자 목록은
status가 PENDING + APPORVED인 유저를 보여주기로 수정되었습니다!

옆에 표시되는 N명은 PENDING + APPROVED 인원 수입니다.
그리고 프로필의 memberId가 1로 고정되어 있어서 이 부분도 수정하였습니다.

<img width="895" height="187" alt="스크린샷 2025-11-01 오후 4 28 00" src="https://github.com/user-attachments/assets/e5099b30-ef8f-4d03-aefd-ebc87780e086" />
