### PR TITLE
[Refactor] 헤더 탭 네이밍 변경

### DIFF
--- a/src/widgets/home/header.tsx
+++ b/src/widgets/home/header.tsx
@@ -45,8 +45,8 @@ export default async function Header() {
 
         {/* 1차 MVP에선 사용하지 않아 제외 */}
         <nav className="font-designer-14m text-text-default flex flex-grow items-center gap-300 px-600">
-          <Link href={isLoggedIn ? '/home' : '/login'}>1:1 CS스터디</Link>
-          <Link href="/study">스터디 둘러보기</Link>
+          <Link href={isLoggedIn ? '/home' : '/login'}>1:1 스터디</Link>
+          <Link href="/study">그룹스터디</Link>
           {/* <Link href="/">팀소개하기로 했었구나</Link> */}
         </nav>
 


### PR DESCRIPTION
## ☘️ 작업 내용

### 헤더 탭 네이밍 변경

before

<img width="1436" height="57" alt="스크린샷 2025-11-09 오후 2 59 08" src="https://github.com/user-attachments/assets/62e27bd4-9c19-4ec2-ac44-73f8939fd4cf" />

after

<img width="1440" height="60" alt="스크린샷 2025-11-09 오후 2 59 41" src="https://github.com/user-attachments/assets/abda062c-a20f-47aa-9d5b-198fa69d4e07" />
