### PR TITLE
[Fix] InterviewPost 타입 제거

### DIFF
--- a/src/features/study/group/api/group-study-types.ts
+++ b/src/features/study/group/api/group-study-types.ts
@@ -119,10 +119,6 @@ export interface GroupStudyData {
   simpleDetailInfo: SimpleDetailInfo;
 }
 
-export interface InterviewPost {
-  interviewPost: { question: string; id: number }[];
-}
-
 // 그룹 스터디 신청 Request 타입
 export interface ApplyGroupStudyRequest {
   groupStudyId: number;
@@ -146,8 +142,10 @@ export interface DetailInfoDetail extends DetailInfo, Timestamps {
   thumbnailUploadUrl: string | null;
 }
 
-/** 상세 화면용 InterviewPost (기존 InterviewPost 확장) */
-export interface InterviewPostDetail extends InterviewPost, Timestamps {}
+/** 상세 화면용 InterviewPost */
+export interface InterviewPostDetail extends Timestamps {
+  interviewPost: { question: string; id: number }[];
+}
 
 // 그룹 스터디 신청 Response 타입
 export interface ApplyGroupStudyResponse {
@@ -161,7 +159,9 @@ export interface ApplyGroupStudyResponse {
 export interface OpenGroupStudyRequest {
   basicInfo: BasicInfo;
   detailInfo: DetailInfo;
-  interviewPost: InterviewPost;
+  interviewPost: {
+    interviewPost: string[];
+  };
   thumbnailExtension: ThumbnailExtension;
 }
 


### PR DESCRIPTION
## ☘️ 작업 내용

InterviewPost 타입이 쓰이는 곳은 다음과 같았어요.
- OpenGroupStudyRequest: 그룹스터디 생성했을 때 서버에게 보낼 데이터 타입
- GroupStudyDetailResponse: 그룹스터디 상세 데이터 응답 타입

그룹스터디 생성했을 때에는 질문들을 `string[]` 타입으로 보내야해요.
그룹스터디 상세 데이터에서는 질문들이 `{id: number, question: string}[]` 타입으로 응답와요.

그래서 InterviewPost 타입을 위에서 말한 두 타입에서 재사용하지 않아서, 삭제하였습니다.