### PR TITLE
[Fix] 그룹스터디 항목에서 제목 또는 설명이 너무 길어지면, 내부 컨텐츠가 부모요소를 벗어나는 문제 해결

### DIFF
--- a/src/features/study/group/ui/group-study-list.tsx
+++ b/src/features/study/group/ui/group-study-list.tsx
@@ -126,11 +126,11 @@ export default function GroupStudyList({ isLoggedIn }: GroupStudyListProps) {
                           <Badge color="red">제로원 스터디</Badge>
                         )}
 
-                        <span className="font-designer-18b max-w-[673px] truncate text-[#252B37]">
+                        <span className="font-designer-18b max-w-[346px] truncate text-[#252B37]">
                           {study.simpleDetailInfo.title}
                         </span>
                       </div>
-                      <p className="font-designer-15r line-clamp-2 text-[15px] leading-[29px] text-[#535862]">
+                      <p className="font-designer-15r line-clamp-2 max-w-[346px] text-[#535862]">
                         {study.simpleDetailInfo.summary}
                       </p>
                     </div>


### PR DESCRIPTION
### 🌱 연관된 이슈

[622](https://code-zero-to-one.atlassian.net/jira/software/projects/QNRR/boards/4/backlog)


### ☘️ 작업 내용

제목은 1줄까지, 설명은 2줄까지로 표시하였습니다. 만약 더 길어지면 말줄임표로 표시하였습니다.


<img width="645" height="438" alt="스크린샷 2025-11-15 오후 2 15 55" src="https://github.com/user-attachments/assets/bf32b2a1-91a2-4588-95cf-143c5c2a60eb" />

### 논의하고 싶은 내용

위 사진에서 주제가 2개 이상인 경우, UI가 깨지는 문제가 있어요.
개인적으로 주제를 복수선택되는게 이상하다고 느껴지는데, 저만 그런건지 이야기 나누고 싶어요.