### PR TITLE
[Refactor] Pagination 컴포넌트 이동

### DIFF
--- a/app/(service)/(my)/my-study/completed/page.tsx
+++ b/app/(service)/(my)/my-study/completed/page.tsx
@@ -2,12 +2,12 @@
 
 import { Plus } from 'lucide-react';
 import React, { useState } from 'react';
+import Pagination from '@/components/ui/pagination';
 import { MemberStudyItem } from '@/features/study/group/api/group-study-types';
 import { useMemberStudyListQuery } from '@/features/study/group/model/use-member-study-list-query';
 import CompletedGroupStudyList from '@/features/study/group/ui/completed-group-study-list';
 import OpenGroupStudyModal from '@/features/study/group/ui/open-group-modal';
 import Button from '@/shared/ui/button';
-import Pagination from '@/shared/ui/pagination';
 
 interface MemberGroupStudyList extends MemberStudyItem {
   type: 'GROUP_STUDY';

--- a/app/(service)/(my)/my-study/not-completed/page.tsx
+++ b/app/(service)/(my)/my-study/not-completed/page.tsx
@@ -2,12 +2,12 @@
 
 import { Plus } from 'lucide-react';
 import React, { useState } from 'react';
+import Pagination from '@/components/ui/pagination';
 import { MemberStudyItem } from '@/features/study/group/api/group-study-types';
 import { useMemberStudyListQuery } from '@/features/study/group/model/use-member-study-list-query';
 import NotCompletedGroupStudyList from '@/features/study/group/ui/not-completed-group-study-list';
 import OpenGroupStudyModal from '@/features/study/group/ui/open-group-modal';
 import Button from '@/shared/ui/button';
-import Pagination from '@/shared/ui/pagination';
 
 interface MemberGroupStudyList extends MemberStudyItem {
   type: 'GROUP_STUDY';

--- a/src/components/ui/pagination/index.tsx
+++ b/src/components/ui/pagination/index.tsx
@@ -77,7 +77,7 @@ const pageButtonVariants = cva(
   },
 );
 
-export default function Pagination({
+function Pagination({
   page: currentPage,
   totalPages,
   onChangePage,
@@ -158,3 +158,5 @@ export default function Pagination({
     </div>
   );
 }
+
+export default Pagination;

--- a/src/features/admin/ui/member-list-table.tsx
+++ b/src/features/admin/ui/member-list-table.tsx
@@ -2,13 +2,13 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
+import Pagination from '@/components/ui/pagination';
 import { useDebounce } from '@/shared/lib/debounce';
 import { formatYYYYMMDD } from '@/shared/lib/time';
 import Badge from '@/shared/ui/badge';
 import Button from '@/shared/ui/button';
 import Checkbox from '@/shared/ui/checkbox';
 import { SingleDropdown } from '@/shared/ui/dropdown';
-import Pagination from '@/shared/ui/pagination';
 import FilledX from 'public/icons/filled-x.svg';
 import SealCheckIcon from 'public/icons/seal-check.svg';
 import SearchIcon from 'public/icons/search.svg';

--- a/src/features/admin/ui/sincerity-temp-table.tsx
+++ b/src/features/admin/ui/sincerity-temp-table.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
+import Pagination from '@/components/ui/pagination';
 import { formatYYYYMMDD } from '@/shared/lib/time';
-import Pagination from '@/shared/ui/pagination';
 import TrendingDown from 'public/icons/trending-down.svg';
 import TrendingUp from 'public/icons/trending-up.svg';
 import { useGetSincerityTemperatureHistoryQuery } from '../model/use-sincerity-temperature-history-query';

--- a/src/features/study/group/ui/group-study-member-list.tsx
+++ b/src/features/study/group/ui/group-study-member-list.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import { useState } from 'react';
-import Pagination from '@/shared/ui/pagination';
+import Pagination from '@/components/ui/pagination';
 import GroupStudyMemberItem from './group-study-member-item';
 import KickedReasonModal from './kicked-reason-modal';
 import { GroupStudyMyStatusResponse } from '../api/group-study-types';


### PR DESCRIPTION
## ☘️ 작업 내용

Pagination 컴포넌트 위치를 이동했어요.
스토리북을 작성하고 싶었는데, public/icons의 이미지를 스토리북이 이해하지 못하는 것 같더라구요..
결국, 해결하지 못해서 먼저 올립니다.