### PR TITLE
feat: 유입경로 다른 페이지에서도 추적

### DIFF
--- a/app/(service)/redirection/page.tsx
+++ b/app/(service)/redirection/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, Suspense } from 'react';
 import { hashValue } from '@/shared/lib/hash';
 import { setCookie } from '@/shared/tanstack-query/cookie';
+import { getAttributionParams } from '@/shared/lib/attribution-tracker';
 
 function RedirectionContent() {
   const searchParams = useSearchParams();
@@ -34,11 +35,15 @@ function RedirectionContent() {
         } else {
           router.push('/home');
           router.refresh();
+          
+          const attributionParams = getAttributionParams();
+          
           sendGTMEvent({
             event: 'custom_member_login',
             dl_timestamp: new Date().toISOString(),
             dl_member_id: hashValue(memberId),
             dl_login_method: authVendor || '',
+            ...attributionParams,
           });
         }
       } catch (error) {

--- a/src/features/auth/ui/login-modal.tsx
+++ b/src/features/auth/ui/login-modal.tsx
@@ -4,6 +4,7 @@ import { sendGTMEvent } from '@next/third-parties/google';
 import { XIcon } from 'lucide-react';
 import Image from 'next/image';
 import { ReactNode, useEffect, useState } from 'react';
+import { getAttributionParams } from '@/shared/lib/attribution-tracker';
 import { Modal } from '../../../shared/ui/modal';
 
 export default function LoginModal({
@@ -21,8 +22,11 @@ export default function LoginModal({
 
   useEffect(() => {
     if (isOpen) {
+      const attributionParams = getAttributionParams();
+
       sendGTMEvent({
         event: 'login_modal_open',
+        ...attributionParams,
       });
     }
   }, [isOpen]);

--- a/src/features/auth/ui/sign-up-modal.tsx
+++ b/src/features/auth/ui/sign-up-modal.tsx
@@ -8,6 +8,7 @@ import {
 import SignupImageSelector from '@/features/auth/ui/sign-up-image-selector';
 import { hashValue } from '@/shared/lib/hash';
 import { getCookie, setCookie } from '@/shared/tanstack-query/cookie';
+import { getAttributionParams } from '@/shared/lib/attribution-tracker';
 import Button from '@/shared/ui/button';
 import { BaseInput } from '@/shared/ui/input';
 import { Modal } from '@/shared/ui/modal';
@@ -29,8 +30,11 @@ export default function SignupModal({
 
   useEffect(() => {
     if (open) {
+      const attributionParams = getAttributionParams();
+      
       sendGTMEvent({
         event: 'signup_modal_open',
+        ...attributionParams,
       });
     }
   }, [open]);
@@ -64,10 +68,13 @@ export default function SignupModal({
             setCookie('memberId', memberId);
 
             // 회원가입 GA 이벤트 전송
+            const attributionParams = getAttributionParams();
+            
             sendGTMEvent({
               event: 'custom_member_join',
               dl_timestamp: new Date().toISOString(),
               dl_member_id: hashValue(memberId),
+              ...attributionParams,
             });
 
             const formData = new FormData();

--- a/src/shared/lib/attribution-tracker.ts
+++ b/src/shared/lib/attribution-tracker.ts
@@ -1,0 +1,205 @@
+/**
+ * 유입경로 추적 유틸리티
+ * First-touch attribution을 위해 첫 방문 시 정보를 저장하고,
+ * 이후 모든 이벤트에 유입경로 정보를 포함시킵니다.
+ */
+
+import { getCookie, setCookie } from '@/shared/tanstack-query/cookie';
+
+const ATTRIBUTION_COOKIE_NAME = 'attribution_data';
+const ATTRIBUTION_COOKIE_MAX_AGE = 30 * 24 * 60 * 60; // 30일
+
+export interface AttributionData {
+  // UTM 파라미터
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_term?: string;
+  utm_content?: string;
+
+  // Referrer 정보
+  referrer?: string;
+  referrer_domain?: string;
+
+  // GA4 자동 추적 파라미터
+  gclid?: string; // Google Ads 클릭 ID
+
+  // 첫 방문 정보
+  first_visit_timestamp: string;
+  first_visit_path: string;
+
+  // 현재 방문 정보 (업데이트 가능)
+  last_visit_timestamp?: string;
+  last_visit_path?: string;
+}
+
+/**
+ * URL에서 UTM 파라미터 추출
+ */
+function extractUTMParams(
+  searchParams: URLSearchParams,
+): Partial<AttributionData> {
+  const utmSource = searchParams.get('utm_source');
+  const utmMedium = searchParams.get('utm_medium');
+  const utmCampaign = searchParams.get('utm_campaign');
+  const utmTerm = searchParams.get('utm_term');
+  const utmContent = searchParams.get('utm_content');
+  const gclid = searchParams.get('gclid');
+
+  const data: Partial<AttributionData> = {};
+
+  if (utmSource) data.utm_source = utmSource;
+  if (utmMedium) data.utm_medium = utmMedium;
+  if (utmCampaign) data.utm_campaign = utmCampaign;
+  if (utmTerm) data.utm_term = utmTerm;
+  if (utmContent) data.utm_content = utmContent;
+  if (gclid) data.gclid = gclid;
+
+  return data;
+}
+
+/**
+ * Referrer에서 도메인 추출
+ */
+function extractReferrerDomain(referrer: string): string | undefined {
+  try {
+    const url = new URL(referrer);
+    return url.hostname.replace(/^www\./, ''); // www 제거
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * 현재 페이지의 유입경로 정보 수집 및 저장
+ * 첫 방문 시에만 저장하고, 이후 방문에서는 업데이트만 수행
+ */
+export function trackAttribution(): AttributionData | null {
+  if (typeof window === 'undefined') return null;
+
+  const searchParams = new URLSearchParams(window.location.search);
+  const currentPath = window.location.pathname;
+  const currentTimestamp = new Date().toISOString();
+  const referrer = document.referrer;
+
+  // 기존 attribution 데이터 확인
+  const existingDataStr = getCookie(ATTRIBUTION_COOKIE_NAME);
+  let existingData: AttributionData | null = null;
+
+  if (existingDataStr) {
+    try {
+      existingData = JSON.parse(existingDataStr);
+    } catch {
+      // 파싱 실패 시 무시
+    }
+  }
+
+  // UTM 파라미터 추출
+  const utmData = extractUTMParams(searchParams);
+
+  // Referrer 정보 추출
+  let referrerData: Partial<AttributionData> = {};
+  if (referrer && !referrer.startsWith(window.location.origin)) {
+    referrerData.referrer = referrer;
+    referrerData.referrer_domain = extractReferrerDomain(referrer);
+  }
+
+  // 첫 방문인 경우 (UTM 파라미터가 있거나 referrer가 있거나 쿠키가 없는 경우)
+  const isFirstVisit =
+    !existingData ||
+    (Object.keys(utmData).length > 0 && !existingData.utm_source) ||
+    (referrerData.referrer && !existingData.referrer);
+
+  let attributionData: AttributionData;
+
+  if (isFirstVisit && !existingData) {
+    // 완전히 새로운 방문
+    attributionData = {
+      ...utmData,
+      ...referrerData,
+      first_visit_timestamp: currentTimestamp,
+      first_visit_path: currentPath,
+      last_visit_timestamp: currentTimestamp,
+      last_visit_path: currentPath,
+    } as AttributionData;
+  } else if (isFirstVisit && existingData) {
+    // 기존 쿠키는 있지만 새로운 UTM/referrer가 있는 경우 (첫 유입경로 업데이트)
+    attributionData = {
+      ...existingData,
+      ...utmData, // UTM 파라미터가 있으면 업데이트
+      ...(referrerData.referrer && !existingData.referrer ? referrerData : {}), // referrer가 없었으면 추가
+      last_visit_timestamp: currentTimestamp,
+      last_visit_path: currentPath,
+    };
+  } else if (existingData) {
+    // 기존 방문자 - last_visit만 업데이트
+    attributionData = {
+      ...existingData,
+      last_visit_timestamp: currentTimestamp,
+      last_visit_path: currentPath,
+    };
+  } else {
+    // 예외 케이스
+    attributionData = {
+      first_visit_timestamp: currentTimestamp,
+      first_visit_path: currentPath,
+      last_visit_timestamp: currentTimestamp,
+      last_visit_path: currentPath,
+    };
+  }
+
+  // 쿠키에 저장
+  setCookie(ATTRIBUTION_COOKIE_NAME, JSON.stringify(attributionData), {
+    maxAge: ATTRIBUTION_COOKIE_MAX_AGE,
+    sameSite: 'Lax', // 외부 사이트에서의 리디렉션을 위해 Lax 사용
+  });
+
+  return attributionData;
+}
+
+/**
+ * 저장된 attribution 데이터 조회
+ */
+export function getAttributionData(): AttributionData | null {
+  if (typeof window === 'undefined') return null;
+
+  const dataStr = getCookie(ATTRIBUTION_COOKIE_NAME);
+  if (!dataStr) return null;
+
+  try {
+    return JSON.parse(dataStr);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * GTM 이벤트에 포함할 attribution 파라미터 생성
+ */
+export function getAttributionParams(): Record<string, string> {
+  const attribution = getAttributionData();
+  if (!attribution) return {};
+
+  const params: Record<string, string> = {};
+
+  // UTM 파라미터
+  if (attribution.utm_source) params.dl_utm_source = attribution.utm_source;
+  if (attribution.utm_medium) params.dl_utm_medium = attribution.utm_medium;
+  if (attribution.utm_campaign)
+    params.dl_utm_campaign = attribution.utm_campaign;
+  if (attribution.utm_term) params.dl_utm_term = attribution.utm_term;
+  if (attribution.utm_content) params.dl_utm_content = attribution.utm_content;
+
+  // Referrer 정보
+  if (attribution.referrer_domain)
+    params.dl_referrer_domain = attribution.referrer_domain;
+
+  // Google Ads 클릭 ID
+  if (attribution.gclid) params.dl_gclid = attribution.gclid;
+
+  // 첫 방문 정보
+  params.dl_first_visit_timestamp = attribution.first_visit_timestamp;
+  params.dl_first_visit_path = attribution.first_visit_path;
+
+  return params;
+}

--- a/src/shared/lib/page-view-tracker.tsx
+++ b/src/shared/lib/page-view-tracker.tsx
@@ -3,6 +3,10 @@
 import { sendGTMEvent } from '@next/third-parties/google';
 import { usePathname } from 'next/navigation';
 import { useEffect } from 'react';
+import {
+  trackAttribution,
+  getAttributionParams,
+} from './attribution-tracker';
 
 export default function PageViewTracker(): null {
   const pathname = usePathname();
@@ -10,11 +14,18 @@ export default function PageViewTracker(): null {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
+    // 유입경로 추적 (첫 방문 시 저장, 이후 방문 시 업데이트)
+    trackAttribution();
+
+    // Attribution 파라미터 가져오기
+    const attributionParams = getAttributionParams();
+
     sendGTMEvent({
       event: 'page_view',
       page_title: document.title || pathname,
       page_location: window.location.href,
       page_path: pathname,
+      ...attributionParams,
     });
   }, [pathname]);
 


### PR DESCRIPTION
### 🌱 연관된 이슈

<!-- 관련 이슈를 적어주세요 -->


### ☘️ 작업 내용
## 📊 Attribution Tracking 개선

### 🔴 기존 방식의 문제점

1. **UTM 파라미터 추적 제한**
   - URL에 UTM 파라미터가 있을 때만 추적 가능
   - 페이지 이동 시 UTM 정보 손실
```
   /?utm_source=google → /login 이동 시 UTM 정보 사라짐
```

2. **이벤트별 유입경로 정보 누락**
   - `login_modal_open`, `signup_modal_open` 등의 이벤트에 유입경로 정보 없음
   - GA4에서 `utm_source`로 필터링해야만 확인 가능

---

### ✅ 개선된 방식의 장점

#### 1. 자동 추적 및 유지
- 첫 방문 시 UTM 파라미터를 쿠키에 저장
- 페이지 이동 후에도 유지되어 모든 이벤트에 자동 포함

**예시 플로우:**
```
1. 사용자 접속: /?utm_source=google&utm_medium=cpc
2. UTM 정보 쿠키 저장
3. /login 이동 → login_modal_open 이벤트 (dl_utm_source: "google" 포함)
4. /sign-up 이동 → signup_modal_open 이벤트 (dl_utm_source: "google" 포함)
5. 회원가입 완료 → custom_member_join 이벤트 (dl_utm_source: "google" 포함)
```

#### 2. GA4에서 즉시 확인 가능
- 커스텀 차원 설정 후 필터링 없이 바로 확인
- 탐색 분석 > 이벤트 > `custom_member_join` → 차원 추가: "UTM Source"

#### 3. UTM 없이도 추적 가능
- Referrer 정보로 유입경로 자동 파악
- 예: Google 검색 → `dl_referrer_domain: "google.com"`

#### 4. First-touch Attribution
- 첫 방문 유입경로를 정확히 추적
```
시나리오: Google 광고 클릭 → Facebook 공유 링크 → 회원가입
- 기존: Facebook으로 잘못 추적될 수 있음
- 개선: Google(최초 유입)으로 정확히 추적
```

---

### 📈 GA4 확인 방법

#### 방법 1: 커스텀 차원 설정 (권장)
1. GA4 관리자 → 커스텀 정의 → 커스텀 차원 생성
   - 차원 이름: `UTM Source`
   - 범위: 이벤트
   - 이벤트 파라미터: `dl_utm_source`

2. 탐색 분석에서 확인
   - 탐색 분석 > 이벤트 > `custom_member_join`
   - 차원 추가: "UTM Source"
   - **필터링 불필요, 바로 확인 가능**

#### 방법 2: 이벤트 파라미터 직접 확인
- 이벤트 > `custom_member_join` → 이벤트 파라미터: `dl_utm_source`
- 값별로 자동 그룹화되어 표시

---

### 💡 실제 사용 예시

**시나리오: Google 광고를 통한 회원가입**
```
1. 사용자 접속
   https://yoursite.com/?utm_source=google&utm_medium=cpc
   → trackAttribution() 실행 → UTM 정보 쿠키 저장

2. /login 페이지 이동
   → login_modal_open 이벤트
   → dl_utm_source: "google" 자동 포함

3. 카카오 로그인 클릭
   → social_login_click 이벤트
   → dl_utm_source: "google" 자동 포함

4. /sign-up 페이지 리디렉션
   → signup_modal_open 이벤트
   → dl_utm_source: "google" 자동 포함

5. 회원가입 완료
   → custom_member_join 이벤트
   → dl_utm_source: "google" 자동 포함
```

**GA4에서 확인:**
- `custom_member_join` 이벤트의 `dl_utm_source` 차원에서 "google" 확인
- **필터링 없이 바로 확인 가능**

---

### 🎯 주요 개선 사항

- ✅ `utm_source` 필터링 불필요 → 모든 이벤트에 자동 포함
- ✅ 페이지 이동 후에도 유지 → 쿠키 기반 저장
- ✅ GA4에서 즉시 확인 → 커스텀 차원 설정 후 바로 사용
- ✅ UTM 없어도 추적 → Referrer 정보로 자동 파악
- ✅ First-touch Attribution → 최초 유입경로 정확 추적

기존에는 `utm_source`로 필터링해야 했지만, 이제는 모든 이벤트에 자동으로 포함되어 GA4에서 바로 확인할 수 있습니다.


### 🍀 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->


#### 스크린샷 (선택)