### PR TITLE
[Hotfix] 랜딩 페이지 푸터에 사업자 정보 추가

### DIFF
--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -285,12 +285,12 @@ export default async function Landing() {
             <span className="text-white/60">|</span>
             <span>대표자명: 조성진</span>
             <span className="text-white/60">|</span>
-            <span>사업자번호: 798-31-01774</span>
+            <span>전화번호: 010-6856-6609</span>
           </div>
           <div className="flex flex-wrap items-center justify-center gap-200">
-            <span>사업장 주소: 서울시 강남구 역삼동 620-17 203호</span>
+            <span>사업자번호: 798-31-01774</span>
             <span className="text-white/60">|</span>
-            <span>전화번호: 010-6856-6609</span>
+            <span>사업장 주소: 서울시 강남구 역삼동 620-17 203호</span>
           </div>
           <div className="text-text-inverse font-designer-11m text-white/80 mt-100">
             © 2024 ZERO-ONE. All rights reserved.


### PR DESCRIPTION
### 🌱 연관된 이슈

<!-- 관련 이슈를 적어주세요 -->


### ☘️ 작업 내용

카카오 비즈앱  (알림, 소셜로그인 추가정보 등) 심사시 사업자 푸터 정보를 요구해서 임시로 main 에 추가하였습니다.
추후 디자인팀 작업 반영해서 디벨롭하고 PG사 카드심사에 적용될 예정입니다.


### 🍀 참고사항

랜딩 푸터에만 작게 올라감

#### 스크린샷 (선택)
<img width="867" height="825" alt="image" src="https://github.com/user-attachments/assets/adfced01-7dc7-4160-b93a-5e0bbb538308" />
