### PR TITLE
fix : 회원가입 직후서버사이드 getUserProfile 404 문제해결

### DIFF
--- a/src/app/api/auth/clear-session/route.ts
+++ b/src/app/api/auth/clear-session/route.ts
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const redirectTo = searchParams.get('redirect') || '/login';
+
+  // 쿠키 삭제
+  const cookieStore = await cookies();
+  cookieStore.delete('accessToken');
+  cookieStore.delete('memberId');
+  cookieStore.delete('socialImageURL');
+
+  // 리다이렉트
+  return NextResponse.redirect(new URL(redirectTo, request.url));
+}

--- a/src/entities/user/api/get-user-profile.server.ts
+++ b/src/entities/user/api/get-user-profile.server.ts
@@ -1,10 +1,27 @@
+import { isAxiosError } from 'axios';
+import { redirect } from 'next/navigation';
 import { axiosServerInstance } from '@/api/client/axios.server';
 import { GetUserProfileResponse } from './types';
 
 export const getUserProfileInServer = async (
   memberId: number,
 ): Promise<GetUserProfileResponse> => {
-  const res = await axiosServerInstance.get(`/members/${memberId}/profile`);
+  try {
+    const res = await axiosServerInstance.get(`/members/${memberId}/profile`);
 
-  return res.data.content;
+    return res.data.content;
+  } catch (error) {
+    // 회원가입 직후 프로필이 아직 생성되지 않았거나 인증 문제인 경우
+    // Route Handler로 리다이렉트하여 쿠키 삭제 후 로그인 페이지로 이동
+    if (isAxiosError(error)) {
+      const status = error.response?.status;
+
+      if (status === 404 || status === 401 || status === 403) {
+        redirect('/api/auth/clear-session?redirect=/login');
+      }
+    }
+
+    // 예상치 못한 에러는 다시 throw
+    throw error;
+  }
 };


### PR DESCRIPTION
### 🌱 연관된 이슈

<!-- 관련 이슈를 적어주세요 -->

### ☘️ 작업 내용

회원가입 직후엔 프로필이 만들어지지 않은 상태에서 요청을 날려 404응답을 반환받는것으로 보임.. 우선 에러 발생시 임시로 next Route handler 를 거쳐서 쿠키를 지우고 로그인 다시하도록 처리함.. 추후 쿼리캐시나 더 깔끔하게 바로 로그인하는 방법을 강구할수있을듯함

### 🍀 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

#### 스크린샷 (선택)
