### PR TITLE
hotfix : 서버에서는 회원가입 직후 redirect 시 origin이 localhost 로 처리되는 문제 해결시도

### DIFF
--- a/src/app/api/auth/clear-session/route.ts
+++ b/src/app/api/auth/clear-session/route.ts
@@ -11,6 +11,24 @@ export async function GET(request: NextRequest) {
   cookieStore.delete('memberId');
   cookieStore.delete('socialImageURL');
 
+  // 절대 URL 생성: 요청의 origin을 우선 사용 (이미 protocol 포함)
+  // origin이 없으면 host + protocol 조합, 그래도 없으면 환경 변수 사용
+  const origin = request.headers.get('origin');
+  
+  const baseUrl =
+    origin || // origin은 이미 protocol 포함 (예: https://test.zeroone.it.kr)
+    (() => {
+      const host = request.headers.get('host');
+      const protocol = request.headers.get('x-forwarded-proto') || 'https';
+      return host ? `${protocol}://${host}` : null;
+    })() ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.NEXT_PUBLIC_API_PROD_BASE_URL?.replace('/api/v1', '') ||
+    process.env.NEXT_PUBLIC_API_BASE_URL?.replace('/api/v1', '') ||
+    request.url.split('/api')[0];
+
+  console.log('baseUrl', baseUrl);
+  
   // 리다이렉트
-  return NextResponse.redirect(new URL(redirectTo, request.url));
+  return NextResponse.redirect(new URL(redirectTo, baseUrl));
 }


### PR DESCRIPTION
### 🌱 연관된 이슈

<!-- 관련 이슈를 적어주세요 -->

### ☘️ 작업 내용

배포된 넥스트서버에서 /login 하다보니 origin 상대경로를 인프라의 localhost 써버리는듯

### 🍀 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

#### 스크린샷 (선택)
