### PR TITLE
fix: 그룹스터디 종료/삭제 시 라우팅 및 에러 처리 개선 (QNRR-769)

### DIFF
--- a/src/components/pages/group-study-detail-page.tsx
+++ b/src/components/pages/group-study-detail-page.tsx
@@ -86,10 +86,13 @@ export default function StudyDetailPage({
                 group_study_id: String(groupStudyId),
               });
               alert('스터디가 종료되었습니다.');
+              router.push('/group-study');
+            },
+            onError: () => {
+              alert('스터디 종료에 실패하였습니다.');
             },
             onSettled: () => {
               setShowModal(false);
-              router.push('/study');
             },
           },
         );
@@ -114,12 +117,12 @@ export default function StudyDetailPage({
                 group_study_id: String(groupStudyId),
               });
               alert('스터디가 삭제되었습니다.');
+              router.push('/group-study');
             },
             onError: () => {
               alert('스터디 삭제에 실패하였습니다.');
             },
             onSettled: () => {
-              router.push('/study');
               setShowModal(false);
             },
           },


### PR DESCRIPTION
## Summary
- 그룹스터디 종료/삭제 시 발생하던 라우팅 및 에러 처리 문제 수정
- `onSettled`에서 `onSuccess`로 라우팅 이동하여 성공 시에만 페이지 전환되도록 개선
- 스터디 종료 시 `onError` 핸들러 추가하여 실패 케이스 처리
- 라우팅 경로를 `/study`에서 올바른 경로인 `/group-study`로 수정

## Test plan
- [ ] 그룹스터디 종료 기능 테스트 (성공 케이스)
- [ ] 그룹스터디 종료 실패 시 에러 메시지 확인
- [ ] 그룹스터디 삭제 기능 테스트 (성공 케이스)
- [ ] 그룹스터디 삭제 실패 시 에러 메시지 확인
- [ ] 성공 시 `/group-study` 페이지로 정상 이동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- 필요 시 스크린샷 추가 -->
| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/056161a3-20fb-4168-80b3-a275f7310762" /> | <video src="https://github.com/user-attachments/assets/f50bdaf8-ef94-4785-8683-b5ae2ac7a093" /> |







