### PR TITLE
fix: 비회원의 스터디 개설 버튼 비활성화 (QNRR-666)

### DIFF
--- a/src/components/pages/group-study-list-page.tsx
+++ b/src/components/pages/group-study-list-page.tsx
@@ -18,10 +18,13 @@ import { useGetStudies } from '@/hooks/queries/study-query';
 import GroupStudyFormModal from '../../features/study/group/ui/group-study-form-modal';
 import GroupStudyPagination from '../../features/study/group/ui/group-study-pagination';
 import GroupStudyList from '../lists/group-study-list';
+import { useAuth } from '@/hooks/common/use-auth';
 
 const PAGE_SIZE = 15;
 
 export default function GroupStudyListPage() {
+  const { isAuthenticated } = useAuth();
+
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -158,6 +161,7 @@ export default function GroupStudyListPage() {
               size="small"
               icon={<Plus className="h-200 w-200" />}
               iconPosition="left"
+              disabled={!isAuthenticated}
             >
               스터디 개설하기
             </Button>

--- a/src/components/pages/premium-study-list-page.tsx
+++ b/src/components/pages/premium-study-list-page.tsx
@@ -18,10 +18,13 @@ import PremiumStudyPagination from '@/components/premium/premium-study-paginatio
 import Button from '@/components/ui/button';
 import GroupStudyFormModal from '@/features/study/group/ui/group-study-form-modal';
 import { useGetStudies } from '@/hooks/queries/study-query';
+import { useAuth } from '@/hooks/common/use-auth';
 
 const PAGE_SIZE = 15;
 
 export default function PremiumStudyListPage() {
+  const { isAuthenticated } = useAuth();
+
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -158,6 +161,7 @@ export default function PremiumStudyListPage() {
               size="small"
               icon={<Plus className="h-200 w-200" />}
               iconPosition="left"
+              disabled={!isAuthenticated}
             >
               스터디 개설하기
             </Button>


### PR DESCRIPTION
## Summary
- 그룹 스터디 목록 페이지에서 비회원이 스터디 개설 버튼을 클릭할 수 없도록 버튼 비활성화 처리
- 프리미엄 스터디 목록 페이지에서도 동일하게 비회원의 스터디 개설 버튼 비활성화 처리

## Changes
- `group-study-list-page.tsx`: useAuth 훅을 사용하여 인증 상태 확인 후 버튼 비활성화
- `premium-study-list-page.tsx`: useAuth 훅을 사용하여 인증 상태 확인 후 버튼 비활성화

## Test plan
- [x] 비로그인 상태에서 그룹 스터디 목록 페이지 접속 시 "스터디 개설하기" 버튼이 비활성화되는지 확인
- [x] 비로그인 상태에서 프리미엄 스터디 목록 페이지 접속 시 "스터디 개설하기" 버튼이 비활성화되는지 확인
- [x] 로그인 상태에서 두 페이지의 "스터디 개설하기" 버튼이 정상적으로 활성화되는지 확인
- [x] 버튼 클릭 시 스터디 개설 모달이 정상적으로 열리는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- 필요 시 스크린샷 추가 -->
| Before | After |
|--------|-------|
| <img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/b4a704b7-a6ad-4462-9388-c05b6fd022b2" /> | <img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/414284dd-3341-4ddd-9ca6-5507c978c02d" /> |
| <img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/fc33ac2b-99f4-4ace-8e96-da7f53450a24" /> | <img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/b59214fd-f3c7-488e-a98f-423d80725a25" /> |

