### PR TITLE
신청하기 버튼 활성화 로직 수정

### DIFF
--- a/src/components/summary/study-info-summary.tsx
+++ b/src/components/summary/study-info-summary.tsx
@@ -204,7 +204,7 @@ export default function SummaryStudyInfo({ data }: Props) {
       <div className="flex flex-col gap-100">
         {/* 스터디 신청 모달 (유료/무료 공통) */}
 
-        {isLoggedIn ? (
+        {isLeader ? (
           <ApplyGroupStudyModal
             groupStudyId={groupStudyId}
             title={title}


### PR DESCRIPTION
### ☘️ 작업 내용

<!-- 작업한 내용을 적어주세요 -->
- `study-info-summary.tsx`에서 `isLoggedIn`을 조건부로 하여 활성화 여부를 판별하고 있었는데, 콘솔로 확인해보니 스터디를 개설한 사람과 개설하지 않은 사람 입장에서 모두 true로 나오고 있었습니다.
- 스터디를 개설한 사람을 판별하는 로직이 `const isLeader = leader?.memberId === memberId;` 인 것 같아서 isLeader로 판별하는 것으로 변경했습니다.


#### 스크린샷 (선택)
