### PR TITLE
fix: QNRR-741 로그인한 상태에서 로그인 페이지 접근 방지

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -81,7 +81,10 @@ export async function middleware(request: NextRequest) {
   }
 
   // 회원가입 페이지는 accessToken만 체크 (memberId는 회원가입 후에 생성됨)
-  if (request.nextUrl.pathname === '/sign-up' || request.nextUrl.pathname === '/login') {
+  if (
+    request.nextUrl.pathname === '/sign-up' ||
+    request.nextUrl.pathname === '/login'
+  ) {
     if (hasAccessToken && hasMemberId) {
       // 이미 회원가입 완료된 사용자는 홈으로 리디렉션
       const mainUrl = new URL('/home', request.url);


### PR DESCRIPTION
## Summary
- 로그인한 사용자(accessToken, memberId 존재)가 /login 페이지 접근 시 /home으로 리디렉션
- middleware matcher에 /login 경로 추가하여 미들웨어 적용

## Test plan
- [x] 로그인하지 않은 상태에서 /login 페이지 접근 가능 확인
- [x] 로그인한 상태에서 /login 페이지 접근 시 /home으로 리디렉션 확인
- [x] 회원가입 페이지 리디렉션 동작 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- 필요 시 스크린샷 추가 -->
| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/5d5cea2c-8ca1-4ca2-a1e6-65d73f17b2b3" /> | <video src="https://github.com/user-attachments/assets/0457aedb-519e-4600-8bd8-25f16aa781e4" /> |







