### PR TITLE
fix: 스크롤 문제 해결 (메인)

### DIFF
--- a/src/app/(service)/layout.tsx
+++ b/src/app/(service)/layout.tsx
@@ -39,12 +39,12 @@ export default function ServiceLayout({
   return (
     <html lang="ko">
       <head>{GTM_ID && <GoogleTagManager gtmId={GTM_ID} />}</head>
-      <body className={clsx(pretendard.className, 'h-screen w-screen')}>
+      <body className={clsx(pretendard.className, 'min-h-screen w-screen')}>
         <MainProvider>
           <PageViewTracker />
-          <div className="flex h-screen w-full flex-col overflow-hidden">
+          <div className="flex min-h-screen w-full flex-col overflow-x-auto">
             <Header />
-            <main className="w-full flex-1 overflow-auto">{children}</main>
+            <main className="w-full flex-1">{children}</main>
           </div>
         </MainProvider>
       </body>

--- a/src/widgets/home/header.tsx
+++ b/src/widgets/home/header.tsx
@@ -28,8 +28,8 @@ export default async function Header() {
     : undefined;
 
   return (
-    <header className="mx-auto w-[1496px] bg-white px-600 py-[11px] mix-blend-multiply">
-      <div className="flex w-full items-center justify-between">
+    <header className="bg-white py-[11px] mix-blend-multiply">
+      <div className="mx-auto flex w-[1496px] items-center justify-between px-600">
         <div className="flex items-center gap-[7.5px] px-[8px] py-[11px]">
           <Image src="/icons/logo.svg" alt="Logo" width={18} height={18} />
           <Link href="/">


### PR DESCRIPTION
.

.

### 🌱 연관된 이슈

<!-- 관련 이슈를 적어주세요 -->

### ☘️ 작업 내용

# 헤더 확대 시 스크롤 문제 해결

## 문제점
- 사이트를 확대했을 때 헤더가 뷰포트를 벗어나 오른쪽 요소에 접근할 수 없었음
- 헤더와 본문에서 가로 스크롤이 중복되거나 내부 스크롤이 생기는 문제 발생

## 해결 방법
- 헤더를 **고정 너비(`w-[1496px]`)**로 유지하여 기존 디자인 유지
- 페이지 전체 레이아웃에 **가로 스크롤을 단일화**하여 확대 시 헤더와 본문을 함께 이동하도록 구성
- 내부 `main` 스크롤 제거로 스크롤 중복 방지

## 변경 사항
- `src/widgets/home/header.tsx`: 헤더 고정 너비 유지
- `src/app/(service)/layout.tsx`: 가로 스크롤 단일화, 내부 스크롤 제거

## 테스트
- [x] 브라우저 확대 시 헤더 오른쪽 요소 클릭 가능 여부 확인
- [x] 가로 스크롤이 1개만 생기는지 확인
- [x] 본문 스크롤 정상 동작 확인


### 🍀 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

#### 스크린샷 (선택)
