### PR TITLE
한국 시간 기준으로 스터디 시작일 유효성 검사 로직 수정

### DIFF
--- a/src/features/study/group/model/group-study-form.schema.ts
+++ b/src/features/study/group/model/group-study-form.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { getKoreaDate } from '@/utils/time';
 import {
   BasicInfoCommon,
   GroupStudyCreateRequest,
@@ -108,15 +109,16 @@ export const GroupStudyFormSchema = z
     };
 
     if (ISO_DATE_REGEX.test(data.startDate)) {
-      const start = parseDate(data.startDate);
-      const today = new Date();
-      const tomorrow = new Date(
-        today.getFullYear(),
-        today.getMonth(),
-        today.getDate() + 1,
-      );
+      const todayKst = getKoreaDate();
+      const tomorrow = new Date(todayKst);
+      tomorrow.setDate(todayKst.getDate() + 1);
+      const toYmd = (d: Date) =>
+        `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+          d.getDate(),
+        ).padStart(2, '0')}`;
+      const tomorrowYmd = toYmd(tomorrow);
 
-      if (start < tomorrow) {
+      if (data.startDate < tomorrowYmd) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: '스터디 시작일은 내일부터 설정할 수 있습니다.',


### PR DESCRIPTION
### 🌱 연관된 이슈

<!-- 관련 이슈를 적어주세요 -->

### ☘️ 작업 내용

<!-- 작업한 내용을 적어주세요 -->

### 🍀 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

#### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 스터디 그룹 생성 시 시작 날짜 검증 로직을 개선했습니다. 이제 한국 표준시(KST) 기준으로 정확하게 계산되어, 사용자의 로컬 시간대 설정에 관계없이 일관된 날짜 검증이 이루어집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->