### PR TITLE
그룹스터디 필터링 로직 수정

### DIFF
--- a/src/features/study/group/ui/group-study-form-modal.tsx
+++ b/src/features/study/group/ui/group-study-form-modal.tsx
@@ -87,11 +87,23 @@ export default function GroupStudyFormModal({
   const refineStudyDetail = (value: GroupStudyFullResponseDto) => {
     if (isLoading) return;
 
+    const refinedClassification =
+      value.basicInfo?.classification ?? classification;
+    const originalType = value.basicInfo?.type;
+
+    let refinedType = originalType;
+    if (
+      refinedClassification === 'GROUP_STUDY' &&
+      originalType === 'MENTORING'
+    ) {
+      refinedType = undefined;
+    }
+
     return {
-      classification: value.basicInfo?.classification ?? classification,
+      classification: refinedClassification,
       studyLeaderParticipation:
         value.basicInfo.studyLeaderParticipation ?? false,
-      type: value.basicInfo?.type,
+      type: refinedType,
       targetRoles: value.basicInfo?.targetRoles,
       maxMembersCount: value.basicInfo?.maxMembersCount?.toString() ?? '',
       experienceLevels: value.basicInfo?.experienceLevels,

--- a/src/features/study/group/ui/step/step1-group.tsx
+++ b/src/features/study/group/ui/step/step1-group.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { addDays } from 'date-fns';
+import { useEffect } from 'react';
 import {
   Controller,
   useController,
@@ -58,10 +59,10 @@ export default function Step1OpenGroupStudy() {
     control,
   });
 
-  const shouldFilterMentoring = classification === 'GROUP_STUDY';
-  const filteredStudyTypes = shouldFilterMentoring
-    ? STUDY_TYPES.filter((type) => type !== 'MENTORING')
-    : STUDY_TYPES;
+  const filteredStudyTypes =
+    classification === 'GROUP_STUDY'
+      ? STUDY_TYPES.filter((type) => type !== 'MENTORING')
+      : STUDY_TYPES;
 
   return (
     <>
@@ -86,7 +87,7 @@ export default function Step1OpenGroupStudy() {
                 htmlFor={`study-type-${type}`}
                 className="font-designer-14m text-text-default"
               >
-                {STUDY_TYPE_LABELS[type]}
+                {STUDY_TYPE_LABELS[type as keyof typeof STUDY_TYPE_LABELS]}
               </label>
             </div>
           ))}


### PR DESCRIPTION
### 🌱 연관된 이슈

<!-- 관련 이슈를 적어주세요 -->

### ☘️ 작업 내용

<!-- 작업한 내용을 적어주세요 -->
- 리더 스터디 참여 체크박스 제거
- 그룹 스터디 생성/수정 모달에서 멘토링 라디오 버튼 제거

### 🍀 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
그룹 스터디 수정 시 기존 스터디 유형이 '멘토링' 인 경우 스터디 수정 모달에서 스터디 유형이 선택되지 않은 상태로 변경
<img width="856" height="317" alt="image" src="https://github.com/user-attachments/assets/3c0e9e26-61df-4b24-8d65-7f3a5c2b5b7e" />


#### 스크린샷 (선택)
<img width="867" height="319" alt="image" src="https://github.com/user-attachments/assets/5842e78c-1c92-4c40-8a46-ad1aafa4790a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 그룹 스터디 설정에서 불필요한 리더 참여 여부 항목 제거
  * 분류 변경 시 멘토링이 허용되지 않는 경우(그룹 스터디) 기존 선택된 멘토링 유형이 자동으로 해제되도록 수정

* **New Features**
  * 그룹 스터디로 분류하면 스터디 유형 목록에서 멘토링 옵션을 자동으로 숨김 (선택 불가)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->