### PR TITLE
fix: 계정 간 본인인증 상태 오염 및 Hydration mismatch 콘솔 경고

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -7,6 +7,7 @@ import localFont from 'next/font/local';
 import PageViewTracker from '@/components/analytics/page-view-tracker';
 import AdminSideBar from '@/components/layout/sidebar/admin-sidebar';
 import MainProvider from '@/providers';
+import { getServerCookie } from '@/utils/server-cookie';
 
 export const metadata: Metadata = {
   title: '관리자 - ZERO-ONE',
@@ -28,16 +29,18 @@ const pretendard = localFont({
 
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
 
-export default function AdminLayout({
+export default async function AdminLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const initialAccessToken = await getServerCookie('accessToken');
+
   return (
     <html lang="ko">
       <head>{GTM_ID && <GoogleTagManager gtmId={GTM_ID} />}</head>
       <body className={clsx(pretendard.className, 'h-screen w-screen')}>
-        <MainProvider>
+        <MainProvider initialAccessToken={initialAccessToken ?? undefined}>
           <PageViewTracker />
           <div className="flex min-w-[1200px]">
             <AdminSideBar />

--- a/src/app/(landing)/layout.tsx
+++ b/src/app/(landing)/layout.tsx
@@ -8,6 +8,7 @@ import localFont from 'next/font/local';
 import PageViewTracker from '@/components/analytics/page-view-tracker';
 import MainProvider from '@/providers';
 import { getOrganizationSchema, getWebsiteSchema } from '@/utils/seo';
+import { getServerCookie } from '@/utils/server-cookie';
 import Header from '@/widgets/home/header';
 
 export const metadata: Metadata = {
@@ -55,11 +56,12 @@ const pretendard = localFont({
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
 const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID;
 
-export default function LandingPageLayout({
+export default async function LandingPageLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const initialAccessToken = await getServerCookie('accessToken');
   if (typeof window !== 'undefined' && CLARITY_PROJECT_ID) {
     Clarity.init(CLARITY_PROJECT_ID);
   }
@@ -91,7 +93,7 @@ export default function LandingPageLayout({
         <link rel="manifest" href="/manifest.json" />
       </head>
       <body className={clsx(pretendard.className, 'h-screen w-screen')}>
-        <MainProvider>
+        <MainProvider initialAccessToken={initialAccessToken ?? undefined}>
           <PageViewTracker />
           <div className="w-full overflow-auto">
             {/** 1400 + 48*2 패딩 양옆 48로 임의적용 */}

--- a/src/app/(service)/(my)/layout.tsx
+++ b/src/app/(service)/(my)/layout.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import GlobalToast from '@/components/ui/global-toast';
 import Sidebar from '@/widgets/my-page/sidebar';
 
 export const metadata: Metadata = {
@@ -13,6 +14,7 @@ export default function MyLayout({
 }>) {
   return (
     <div className="flex h-full">
+      <GlobalToast />
       <Sidebar />
       <div className="m-auto pt-500 pb-[100px]">
         <div className="w-[780px]">{children}</div>

--- a/src/app/(service)/(my)/my-study/page.tsx
+++ b/src/app/(service)/(my)/my-study/page.tsx
@@ -8,17 +8,17 @@ import { useMemberStudyListQuery } from '@/features/study/group/model/use-member
 import CompletedGroupStudyList from '@/features/study/group/ui/completed-group-study-list';
 import GroupStudyFormModal from '@/features/study/group/ui/group-study-form-modal';
 import NotCompletedGroupStudyList from '@/features/study/group/ui/not-completed-group-study-list';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 
 interface MemberGroupStudyList extends MemberStudyItem {
   type: 'GROUP_STUDY';
 }
 
 export default function MyStudy() {
-  const { data: authData } = useAuth();
+  const { memberId } = useAuthReady();
 
   const { data, isLoading } = useMemberStudyListQuery({
-    memberId: authData?.memberId,
+    memberId,
     studyType: 'GROUP_STUDY',
     studyStatus: 'BOTH',
   });

--- a/src/app/(service)/group-study/layout.tsx
+++ b/src/app/(service)/group-study/layout.tsx
@@ -1,0 +1,14 @@
+import GlobalToast from '@/components/ui/global-toast';
+
+export default function GroupStudyLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      <GlobalToast />
+      {children}
+    </>
+  );
+}

--- a/src/app/(service)/home/page.tsx
+++ b/src/app/(service)/home/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import StartStudyButton from '@/components/home/start-study-button';
+import GlobalToast from '@/components/ui/global-toast';
 import { generateMetadata as generateSEOMetadata } from '@/utils/seo';
 import Banner from '@/widgets/home/banner';
 import FeedbackLink from '@/widgets/home/feedback-link';
@@ -24,6 +25,7 @@ export default async function Home({
 
   return (
     <div className="mx-auto flex w-[1496px] flex-col gap-500 px-600 py-600">
+      <GlobalToast />
       <Banner />
       <FeedbackLink />
       <StartStudyButton />

--- a/src/app/(service)/layout.tsx
+++ b/src/app/(service)/layout.tsx
@@ -7,8 +7,8 @@ import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import React from 'react';
 import PageViewTracker from '@/components/analytics/page-view-tracker';
-import GlobalToast from '@/components/ui/global-toast';
 import MainProvider from '@/providers';
+import { getServerCookie } from '@/utils/server-cookie';
 import Header from '@/widgets/home/header';
 
 export const metadata: Metadata = {
@@ -28,11 +28,12 @@ const pretendard = localFont({
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
 const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID;
 
-export default function ServiceLayout({
+export default async function ServiceLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const initialAccessToken = await getServerCookie('accessToken');
   if (typeof window !== 'undefined' && CLARITY_PROJECT_ID) {
     Clarity.init(CLARITY_PROJECT_ID);
   }
@@ -41,8 +42,7 @@ export default function ServiceLayout({
     <html lang="ko">
       <head>{GTM_ID && <GoogleTagManager gtmId={GTM_ID} />}</head>
       <body className={clsx(pretendard.className, 'min-h-screen w-screen')}>
-        <MainProvider>
-          <GlobalToast />
+        <MainProvider initialAccessToken={initialAccessToken ?? undefined}>
           <PageViewTracker />
           <div className="flex min-h-screen w-full flex-col overflow-x-auto">
             <Header />

--- a/src/app/(service)/premium-study/layout.tsx
+++ b/src/app/(service)/premium-study/layout.tsx
@@ -1,0 +1,14 @@
+import GlobalToast from '@/components/ui/global-toast';
+
+export default function PremiumStudyLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      <GlobalToast />
+      {children}
+    </>
+  );
+}

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -781,6 +781,38 @@ https://velog.io/@oneook/tailwindcss-4.0-%EB%AC%B4%EC%97%87%EC%9D%B4-%EB%8B%AC%E
   }
 }
 
+@keyframes toast-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes toast-exit {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+}
+
+@layer utilities {
+  .toast-enter {
+    animation: toast-enter 300ms ease-out forwards;
+  }
+
+  .toast-exit {
+    animation: toast-exit 200ms ease-in forwards;
+  }
+}
+
 /* 자동완성이 안되는 문제가 있어 잠시 주석처리 합니다 */
 /* @layer utilities {
   /* typography */

--- a/src/components/home/start-study-button.tsx
+++ b/src/components/home/start-study-button.tsx
@@ -3,12 +3,11 @@
 import Image from 'next/image';
 import { useUserProfileQuery } from '@/entities/user/model/use-user-profile-query';
 import StartStudyModal from '@/features/study/participation/ui/start-study-modal';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 
 export default function StartStudyButton() {
-  const { data: authData } = useAuth();
-  const memberId = authData?.memberId ?? null;
-  const isLoggedIn = !!memberId;
+  const { memberId, isAuthReady } = useAuthReady();
+  const isLoggedIn = isAuthReady && !!memberId;
 
   const { data: userProfile } = useUserProfileQuery(memberId ?? 0);
 

--- a/src/components/home/study-matching-toggle.tsx
+++ b/src/components/home/study-matching-toggle.tsx
@@ -9,20 +9,22 @@ import {
 import { usePhoneVerificationStatus } from '@/features/phone-verification/model/use-phone-verification-status';
 import PhoneVerificationModal from '@/features/phone-verification/ui/phone-verification-modal';
 import StartStudyModal from '@/features/study/participation/ui/start-study-modal';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 
 export default function StudyMatchingToggle() {
-  const { data: authData } = useAuth();
-  const memberId = authData?.memberId ?? null;
-  const isLoggedIn = !!memberId;
+  const { memberId, isAuthReady } = useAuthReady();
+  const isLoggedIn = isAuthReady && !!memberId;
 
   const { data: userProfile } = useUserProfileQuery(memberId ?? 0);
   const { mutate: patchAutoMatching, isPending } =
     usePatchAutoMatchingMutation();
 
-  const { isVerified, setVerified } = usePhoneVerificationStatus(
-    memberId ?? undefined,
-  );
+  const {
+    isVerified,
+    isLoading: isVerificationLoading,
+    isError: isVerificationError,
+    setVerified,
+  } = usePhoneVerificationStatus(memberId ?? undefined);
   const [isVerificationModalOpen, setIsVerificationModalOpen] = useState(false);
 
   const [enabled, setEnabled] = useState(false);
@@ -60,6 +62,12 @@ export default function StudyMatchingToggle() {
   };
 
   const handleToggleChange = (checked: boolean) => {
+    if (isVerificationLoading) return;
+    if (isVerificationError) {
+      alert('인증 상태를 확인할 수 없습니다. 잠시 후 다시 시도해주세요.');
+
+      return;
+    }
     // 토글을 켤 때만 본인인증 체크 (끌 때는 체크 안 함)
     if (checked && !isVerified) {
       setIsVerificationModalOpen(true);
@@ -105,7 +113,7 @@ export default function StudyMatchingToggle() {
           size="md"
           checked={enabled}
           onCheckedChange={handleToggleChange}
-          disabled={isPending}
+          disabled={isPending || isVerificationLoading}
         />
       </div>
     </>

--- a/src/components/home/tab-navigation.tsx
+++ b/src/components/home/tab-navigation.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from 'react';
 import { getCookie } from '@/api/client/cookie';
 import { cn } from '@/components/ui/(shadcn)/lib/utils';
 import Button from '@/components/ui/button';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { useScrollToHomeContent } from '@/hooks/use-scroll-to-home-content';
 
 interface TabNavigationProps {
@@ -55,16 +55,21 @@ const TABS = [
 export default function TabNavigation({ activeTab }: TabNavigationProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { isAuthenticated } = useAuth();
+  const { isAuthReady, isHydrated, memberId } = useAuthReady();
   const [canViewHistory, setCanViewHistory] = useState(false);
   const visibleTabs = canViewHistory
     ? TABS
     : TABS.filter((tab) => tab.id !== 'history');
 
   useEffect(() => {
-    const hasMemberId = !!getCookie('memberId');
-    setCanViewHistory(isAuthenticated && hasMemberId);
-  }, [isAuthenticated]);
+    if (!isHydrated) {
+      setCanViewHistory(false);
+
+      return;
+    }
+    const hasMemberId = !!memberId || !!getCookie('memberId');
+    setCanViewHistory(isAuthReady && hasMemberId);
+  }, [isAuthReady, isHydrated, memberId]);
 
   const scrollToHomeContent = useScrollToHomeContent();
 

--- a/src/components/layout/sidebar/admin-sidebar.tsx
+++ b/src/components/layout/sidebar/admin-sidebar.tsx
@@ -5,12 +5,12 @@ import { usePathname } from 'next/navigation';
 import UserAvatar from '@/components/ui/avatar';
 import TabMenu from '@/components/ui/tab-menu';
 import { useUserProfileQuery } from '@/entities/user/model/use-user-profile-query';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import OutIcon from 'public/icons/out.svg';
 
 export default function AdminSideBar() {
-  const { data: authData } = useAuth();
-  const { data: profile } = useUserProfileQuery(authData?.memberId ?? 0);
+  const { memberId } = useAuthReady();
+  const { data: profile } = useUserProfileQuery(memberId ?? 0);
 
   const pathname = usePathname();
 

--- a/src/components/lists/group-study-list.tsx
+++ b/src/components/lists/group-study-list.tsx
@@ -4,7 +4,7 @@ import { sendGTMEvent } from '@next/third-parties/google';
 import Image from 'next/image';
 
 import { GroupStudyListItemDto } from '@/api/openapi';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { hashValue } from '@/utils/hash';
 
 import StudyCard from '../card/study-card';
@@ -14,15 +14,16 @@ interface GroupStudyListProps {
 }
 
 export default function GroupStudyList({ studies }: GroupStudyListProps) {
-  const { data: authData } = useAuth();
+  const { memberId, isAuthReady } = useAuthReady();
 
   const handleStudyClick = (study: GroupStudyListItemDto) => {
     sendGTMEvent({
       event: 'group_study_detail_view',
       dl_timestamp: new Date().toISOString(),
-      ...(authData?.memberId && {
-        dl_member_id: hashValue(String(authData.memberId)),
-      }),
+      ...(isAuthReady &&
+        memberId && {
+          dl_member_id: hashValue(String(memberId)),
+        }),
       dl_study_id: String(study.basicInfo?.groupStudyId),
       dl_study_title: study.simpleDetailInfo?.title,
     });

--- a/src/components/lists/study-member-list.tsx
+++ b/src/components/lists/study-member-list.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { GetGroupStudyMemberStatusResponseContent } from '@/api/openapi';
 import Pagination from '@/components/ui/pagination';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { useGetGroupStudyMembers } from '@/hooks/queries/group-study-member-api';
 import type { GroupStudyMember } from '../../features/study/group/api/group-study-types';
 
@@ -32,7 +32,7 @@ export default function StudyMemberList({
     pageNumber: pageNumber,
     pageSize: PAGE_SIZE,
   });
-  const { data: authData } = useAuth();
+  const { memberId, isAuthReady } = useAuthReady();
 
   if (isLoading) {
     return null;
@@ -43,7 +43,7 @@ export default function StudyMemberList({
 
   // memberList의 첫 번째 요소는 내 정보
   const myInfo = memberList[0];
-  const isLeader = leaderId === authData?.memberId;
+  const isLeader = isAuthReady && leaderId === memberId;
   const totalPages = Math.ceil((data?.totalMemberCount || 0) / PAGE_SIZE) || 1;
 
   return (

--- a/src/components/pages/group-study-list-page.tsx
+++ b/src/components/pages/group-study-list-page.tsx
@@ -15,7 +15,7 @@ import StudyFilter, {
 import StudySearch from '@/components/filtering/study-search';
 import PageContainer from '@/components/layout/page-container';
 import Button from '@/components/ui/button';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { useGetStudies } from '@/hooks/queries/study-query';
 import GroupStudyFormModal from '../../features/study/group/ui/group-study-form-modal';
 import GroupStudyPagination from '../../features/study/group/ui/group-study-pagination';
@@ -30,7 +30,7 @@ const Banner = dynamic(() => import('@/widgets/home/banner'), {
 const PAGE_SIZE = 15;
 
 export default function GroupStudyListPage() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthReady } = useAuthReady();
 
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -193,7 +193,7 @@ export default function GroupStudyListPage() {
               size="small"
               icon={<Plus className="h-200 w-200" />}
               iconPosition="left"
-              disabled={!isAuthenticated}
+              disabled={!isAuthReady}
             >
               스터디 개설하기
             </Button>

--- a/src/components/pages/mentoring-list-page.tsx
+++ b/src/components/pages/mentoring-list-page.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 import MentorProfileList from '@/components/mentoring/mentor-profile-list';
 import Button from '@/components/ui/button';
 import { Modal } from '@/components/ui/modal';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 
 // Carousel이 클라이언트 전용이므로 dynamic import로 로드
 const Banner = dynamic(() => import('@/widgets/home/banner'), {
@@ -15,7 +15,7 @@ const Banner = dynamic(() => import('@/widgets/home/banner'), {
 });
 
 export default function MentoringListPage() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthReady } = useAuthReady();
   const [isComingSoonModalOpen, setIsComingSoonModalOpen] = useState(false);
 
   return (
@@ -33,13 +33,13 @@ export default function MentoringListPage() {
           size="small"
           icon={<Plus className="h-200 w-200" />}
           iconPosition="left"
-          disabled={!isAuthenticated}
+          disabled={!isAuthReady}
           onClick={() => {
             // GA4 이벤트 전송
             sendGTMEvent({
               event: 'mentor_register_click',
               location: 'mentoring_page',
-              is_authenticated: isAuthenticated,
+              is_authenticated: isAuthReady,
             });
 
             setIsComingSoonModalOpen(true);

--- a/src/components/pages/premium-study-list-page.tsx
+++ b/src/components/pages/premium-study-list-page.tsx
@@ -18,7 +18,7 @@ import PremiumStudyList from '@/components/premium/premium-study-list';
 import PremiumStudyPagination from '@/components/premium/premium-study-pagination';
 import Button from '@/components/ui/button';
 import GroupStudyFormModal from '@/features/study/group/ui/group-study-form-modal';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { useGetStudies } from '@/hooks/queries/study-query';
 import MyParticipatingStudiesSection from '../section/my-participating-studies-section';
 
@@ -30,7 +30,7 @@ const Banner = dynamic(() => import('@/widgets/home/banner'), {
 const PAGE_SIZE = 15;
 
 export default function PremiumStudyListPage() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthReady } = useAuthReady();
 
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -190,7 +190,7 @@ export default function PremiumStudyListPage() {
               size="small"
               icon={<Plus className="h-200 w-200" />}
               iconPosition="left"
-              disabled={!isAuthenticated}
+              disabled={!isAuthReady}
             >
               스터디 개설하기
             </Button>

--- a/src/components/premium/premium-study-list.tsx
+++ b/src/components/premium/premium-study-list.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 
 import { GroupStudyListItemDto } from '@/api/openapi';
 import { GroupStudyData } from '@/features/study/group/api/group-study-types';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { hashValue } from '@/utils/hash';
 
 import StudyCard from '../card/study-card';
@@ -15,15 +15,16 @@ interface PremiumStudyListProps {
 }
 
 export default function PremiumStudyList({ studies }: PremiumStudyListProps) {
-  const { data: authData } = useAuth();
+  const { memberId, isAuthReady } = useAuthReady();
 
   const handleStudyClick = (study: GroupStudyListItemDto) => {
     sendGTMEvent({
       event: 'premium_study_detail_view',
       dl_timestamp: new Date().toISOString(),
-      ...(authData?.memberId && {
-        dl_member_id: hashValue(String(authData.memberId)),
-      }),
+      ...(isAuthReady &&
+        memberId && {
+          dl_member_id: hashValue(String(memberId)),
+        }),
       dl_study_id: String(study.basicInfo?.groupStudyId),
       dl_study_title: study.simpleDetailInfo?.title,
     });

--- a/src/components/section/group-study-info-section.tsx
+++ b/src/components/section/group-study-info-section.tsx
@@ -10,7 +10,7 @@ import Button from '@/components/ui/button';
 import { getSincerityPresetByLevelName } from '@/config/sincerity-temp-presets';
 import UserProfileModal from '@/entities/user/ui/user-profile-modal';
 import { useApplicantsByStatusQuery } from '@/features/study/group/application/model/use-applicant-qeury';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { useIsLeader } from '@/stores/useLeaderStore';
 import { useUserStore } from '@/stores/useUserStore';
 import { hashValue } from '@/utils/hash';
@@ -26,7 +26,7 @@ export default function StudyInfoSection({
 }: StudyInfoSectionProps) {
   const router = useRouter();
   const params = useParams();
-  const { data: authData } = useAuth();
+  const { memberId: authMemberId, isAuthReady } = useAuthReady();
   const memberId = useUserStore((state) => state.memberId);
   const isLeader = useIsLeader(memberId);
 
@@ -160,11 +160,10 @@ export default function StudyInfoSection({
                             sendGTMEvent({
                               event: 'group_study_member_profile_click',
                               dl_timestamp: new Date().toISOString(),
-                              ...(authData?.memberId && {
-                                dl_member_id: hashValue(
-                                  String(authData.memberId),
-                                ),
-                              }),
+                              ...(isAuthReady &&
+                                authMemberId && {
+                                  dl_member_id: hashValue(String(authMemberId)),
+                                }),
                               dl_target_member_id: String(
                                 data.applicantInfo.memberId,
                               ),

--- a/src/components/section/my-participating-studies-section.tsx
+++ b/src/components/section/my-participating-studies-section.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { useMemo } from 'react';
 import StudyCard from '@/components/card/study-card';
 import { useMemberStudyListQuery } from '@/features/study/group/model/use-member-study-list-query';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { useGetStudies } from '@/hooks/queries/study-query';
 import { hashValue } from '@/utils/hash';
 
@@ -17,8 +17,7 @@ interface MyParticipatingStudiesSectionProps {
 export default function MyParticipatingStudiesSection({
   classification,
 }: MyParticipatingStudiesSectionProps) {
-  const { data: authData } = useAuth();
-  const memberId = authData?.memberId;
+  const { memberId } = useAuthReady();
 
   /**
    * TODO : PREMIUM_STUDY 에서도 동작확인 필요 (BE 미구현)

--- a/src/components/section/premium-study-info-section.tsx
+++ b/src/components/section/premium-study-info-section.tsx
@@ -8,7 +8,7 @@ import UserAvatar from '@/components/ui/avatar';
 import Button from '@/components/ui/button';
 import { getSincerityPresetByLevelName } from '@/config/sincerity-temp-presets';
 import UserProfileModal from '@/entities/user/ui/user-profile-modal';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { useIsLeader } from '@/stores/useLeaderStore';
 import { useUserStore } from '@/stores/useUserStore';
 import { hashValue } from '@/utils/hash';
@@ -33,7 +33,7 @@ export default function PremiumStudyInfoSection({
 }: PremiumStudyInfoSectionProps) {
   const router = useRouter();
   const params = useParams();
-  const { data: authData } = useAuth();
+  const { memberId: authMemberId, isAuthReady } = useAuthReady();
   const memberId = useUserStore((state) => state.memberId);
   const isLeader = useIsLeader(memberId);
 
@@ -165,11 +165,10 @@ export default function PremiumStudyInfoSection({
                             sendGTMEvent({
                               event: 'premium_study_member_profile_click',
                               dl_timestamp: new Date().toISOString(),
-                              ...(authData?.memberId && {
-                                dl_member_id: hashValue(
-                                  String(authData.memberId),
-                                ),
-                              }),
+                              ...(isAuthReady &&
+                                authMemberId && {
+                                  dl_member_id: hashValue(String(authMemberId)),
+                                }),
                               dl_target_member_id: String(
                                 data.applicantInfo.memberId,
                               ),

--- a/src/components/summary/study-info-summary.tsx
+++ b/src/components/summary/study-info-summary.tsx
@@ -116,10 +116,6 @@ export default function SummaryStudyInfo({ data }: Props) {
       label: '정기모임 유무',
       value: `${REGULAR_MEETING_LABELS[regularMeeting]}${location ? `, ${location}` : ''}`,
     },
-    {
-      label: '모집인원',
-      value: `${maxMembersCount}명`,
-    },
   ];
 
   const visibleItems = isExpanded ? infoItems : infoItems.slice(0, 4);

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { CheckCircle2, XCircle } from 'lucide-react';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '@/components/ui/(shadcn)/lib/utils';
 
 interface ToastProps {
@@ -19,43 +20,58 @@ export default function Toast({
   duration = 3000,
   variant = 'success',
 }: ToastProps) {
+  const [isRendered, setIsRendered] = useState(isVisible);
+  const [isExiting, setIsExiting] = useState(false);
+  const exitDuration = 200;
+
   useEffect(() => {
     if (isVisible) {
+      setIsRendered(true);
+      setIsExiting(false);
       const timer = setTimeout(() => {
         onClose();
       }, duration);
 
       return () => clearTimeout(timer);
     }
+
+    if (isRendered) {
+      setIsExiting(true);
+      const timer = setTimeout(() => {
+        setIsRendered(false);
+        setIsExiting(false);
+      }, exitDuration);
+
+      return () => clearTimeout(timer);
+    }
   }, [isVisible, duration, onClose]);
 
-  if (!isVisible) return null;
+  if (!isRendered) return null;
+  if (typeof document === 'undefined') return null;
 
   const isSuccess = variant === 'success';
 
-  return (
-    <div
-      className={cn(
-        'fixed top-24 left-1/2 z-99999 -translate-x-1/2',
-        'rounded-200 px-500 py-400',
-        'bg-background-default shadow-2xl',
-        isSuccess ? 'border-2 border-green-500' : 'border-2 border-red-500',
-        'font-designer-15b text-gray-900',
-        'animate-in fade-in-0 slide-in-from-top-4 duration-300',
-        'transition-all',
-        'flex min-w-[280px] items-center gap-300',
-      )}
-      style={{
-        boxShadow:
-          '0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 8px 10px -6px rgba(0, 0, 0, 0.2)',
-      }}
-    >
-      {isSuccess ? (
-        <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600" />
-      ) : (
-        <XCircle className="h-5 w-5 shrink-0 text-red-600" />
-      )}
-      <span className="flex-1">{message}</span>
+  const toast = (
+    <div className="fixed top-400 left-1/2 z-50 -translate-x-1/2">
+      <div
+        className={cn(
+          'rounded-200 px-500 py-400',
+          'bg-background-default shadow-2xl',
+          isSuccess ? 'border-2 border-green-500' : 'border-2 border-red-500',
+          'font-designer-15b text-gray-900',
+          'flex min-w-[280px] items-center gap-300',
+          isExiting ? 'toast-exit' : 'toast-enter',
+        )}
+      >
+        {isSuccess ? (
+          <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600" />
+        ) : (
+          <XCircle className="h-5 w-5 shrink-0 text-red-600" />
+        )}
+        <span className="flex-1">{message}</span>
+      </div>
     </div>
   );
+
+  return createPortal(toast, document.body);
 }

--- a/src/components/voting/voting-detail-view.tsx
+++ b/src/components/voting/voting-detail-view.tsx
@@ -37,7 +37,7 @@ import {
   useBalanceGameDetailQuery,
   useBalanceGameCommentsQuery,
 } from '@/features/study/one-to-one/balance-game/model/use-balance-game-query';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { useUserStore } from '@/stores/useUserStore';
 import { BalanceGameComment } from '@/types/balance-game';
 import {
@@ -64,10 +64,12 @@ export default function VotingDetailView({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [showShareToast, setShowShareToast] = useState(false);
+  const [shareToastMessage, setShareToastMessage] =
+    useState('링크가 복사되었습니다.');
 
   // User Info
   const memberId = useUserStore((state) => state.memberId);
-  const { isAuthenticated } = useAuth();
+  const { isAuthReady } = useAuthReady();
 
   // Queries
   const {
@@ -215,7 +217,19 @@ export default function VotingDetailView({
     }
   };
 
-  const fallbackShare = (shareUrl: string) => {
+  const openShareToast = (message: string) => {
+    setShareToastMessage(message);
+    setShowShareToast(false);
+    requestAnimationFrame(() => setShowShareToast(true));
+  };
+
+  const openManualCopyPrompt = (shareUrl: string) => {
+    const result = window.prompt('링크를 복사해 공유하세요.', shareUrl);
+
+    return typeof result === 'string';
+  };
+
+  const fallbackCopy = (shareUrl: string) => {
     try {
       const textarea = document.createElement('textarea');
       textarea.value = shareUrl;
@@ -226,48 +240,40 @@ export default function VotingDetailView({
       textarea.select();
       const copied = document.execCommand('copy');
       document.body.removeChild(textarea);
-      if (copied) {
-        setShowShareToast(true);
-
-        return;
-      }
+      if (copied) return true;
     } catch (error) {
       // ignore and fallback
     }
 
-    window.prompt('링크를 복사해 공유하세요.', shareUrl);
+    return false;
   };
 
-  const handleShare = () => {
+  const handleShare = async () => {
     if (!voting) return;
     const shareUrl = window.location.href;
 
-    if (navigator.share) {
-      navigator
-        .share({
-          title: voting.title,
-          url: shareUrl,
-        })
-        .catch((error) => {
-          if (error instanceof DOMException && error.name === 'AbortError') {
-            return;
-          }
-          fallbackShare(shareUrl);
-        });
-
-      return;
-    }
-
     if (navigator.clipboard?.writeText) {
-      navigator.clipboard
-        .writeText(shareUrl)
-        .then(() => setShowShareToast(true))
-        .catch(() => fallbackShare(shareUrl));
+      try {
+        await navigator.clipboard.writeText(shareUrl);
+        openShareToast('링크가 복사되었습니다.');
+
+        return;
+      } catch (error) {
+        // continue to fallback
+      }
+    }
+
+    const copied = fallbackCopy(shareUrl);
+    if (copied) {
+      openShareToast('링크가 복사되었습니다.');
 
       return;
     }
 
-    fallbackShare(shareUrl);
+    const manualCopy = openManualCopyPrompt(shareUrl);
+    if (manualCopy) {
+      openShareToast('링크가 복사되었습니다.');
+    }
   };
 
   // Check if current user is author
@@ -325,7 +331,7 @@ export default function VotingDetailView({
     isActive,
   });
 
-  const showVoteOptions = isAuthenticated && !hasVoted && isActive;
+  const showVoteOptions = isAuthReady && !hasVoted && isActive;
 
   return (
     <div className="transition-all duration-300">
@@ -370,7 +376,7 @@ export default function VotingDetailView({
             <button
               onClick={handleShare}
               type="button"
-              className="rounded-100 text-text-subtle hover:bg-fill-neutral-subtle-default p-100 transition-colors"
+              className="rounded-100 text-text-subtle hover:bg-fill-neutral-subtle-default active:bg-fill-neutral-subtle-hover focus-visible:ring-fill-brand-default-default focus-visible:ring-offset-background-default p-100 transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-95"
               aria-label="공유"
             >
               <Share2 className="h-5 w-5" />
@@ -593,14 +599,14 @@ export default function VotingDetailView({
               )}
             </div>
             <div className="relative">
-              <div className={cn(!isAuthenticated && 'blur-[6px]')}>
+              <div className={cn(!isAuthReady && 'blur-[6px]')}>
                 <VoteResultsChart
                   options={votingOptions}
                   myVote={voting.myVote || undefined}
                   totalVotes={voting.totalVotes}
                 />
               </div>
-              {!isAuthenticated && (
+              {!isAuthReady && (
                 <div className="absolute inset-0 flex items-center justify-center">
                   <LoginModal
                     openTrigger={
@@ -618,7 +624,7 @@ export default function VotingDetailView({
       </div>
 
       {/* 일별 통계 (투표 후에만 표시) */}
-      {isAuthenticated &&
+      {isAuthReady &&
         hasVoted &&
         voting.dailyStats &&
         voting.dailyStats.length > 0 && (
@@ -638,47 +644,65 @@ export default function VotingDetailView({
           <span>댓글 {commentTotalCount}</span>
         </div>
 
-        {/* 댓글 목록 (항상 표시) */}
-        <div className="mb-400">
-          <CommentList
-            comments={comments}
-            onDelete={handleDeleteComment}
-            onEdit={handleStartEditComment}
-            votingOptions={votingOptions}
-            editingCommentId={editingCommentId}
-            editingCommentContent={editingCommentContent}
-            onUpdateComment={handleUpdateComment}
-            onCancelEdit={handleCancelEditComment}
-          />
-
-          {hasNextPage && (
-            <button
-              onClick={() => fetchNextPage()}
-              disabled={isFetchingNextPage}
-              className="rounded-100 border-border-subtle font-designer-13r text-text-subtle hover:bg-background-alternative mt-300 w-full border py-200"
-            >
-              {isFetchingNextPage ? '불러오는 중...' : '더 보기'}
-            </button>
-          )}
-        </div>
-
-        {/* 댓글 작성 폼 */}
-        {isAuthenticated && isActive && (
+        {!isAuthReady ? (
+          <div className="rounded-200 border-border-subtle bg-background-alternative flex flex-col items-center justify-center gap-200 border p-400 text-center">
+            <Lock className="text-text-subtlest h-5 w-5" />
+            <p className="font-designer-14m text-text-subtle">
+              회원가입 후 댓글을 확인할 수 있습니다
+            </p>
+            <LoginModal
+              openTrigger={
+                <button className="rounded-100 bg-background-default text-text-strong border-border-subtle flex items-center gap-100 border px-200 py-100 text-[12px] font-medium">
+                  회원가입 후 댓글 보기
+                </button>
+              }
+            />
+          </div>
+        ) : (
           <>
-            {!hasVoted ? (
-              <div className="rounded-200 border-border-subtle bg-background-alternative border p-400 text-center">
-                <p className="font-designer-14m text-text-subtle">
-                  투표 후 댓글을 작성할 수 있습니다
-                </p>
-              </div>
-            ) : editingCommentId === null ? (
-              <div className="rounded-200 border-border-subtle bg-background-alternative border p-300">
-                <CommentForm
-                  onSubmit={handleAddComment}
-                  isSubmitting={createCommentMutation.isPending}
-                />
-              </div>
-            ) : null}
+            {/* 댓글 목록 */}
+            <div className="mb-400">
+              <CommentList
+                comments={comments}
+                onDelete={handleDeleteComment}
+                onEdit={handleStartEditComment}
+                votingOptions={votingOptions}
+                editingCommentId={editingCommentId}
+                editingCommentContent={editingCommentContent}
+                onUpdateComment={handleUpdateComment}
+                onCancelEdit={handleCancelEditComment}
+              />
+
+              {hasNextPage && (
+                <button
+                  onClick={() => fetchNextPage()}
+                  disabled={isFetchingNextPage}
+                  className="rounded-100 border-border-subtle font-designer-13r text-text-subtle hover:bg-background-alternative mt-300 w-full border py-200"
+                >
+                  {isFetchingNextPage ? '불러오는 중...' : '더 보기'}
+                </button>
+              )}
+            </div>
+
+            {/* 댓글 작성 폼 */}
+            {isActive && (
+              <>
+                {!hasVoted ? (
+                  <div className="rounded-200 border-border-subtle bg-background-alternative border p-400 text-center">
+                    <p className="font-designer-14m text-text-subtle">
+                      투표 후 댓글을 작성할 수 있습니다
+                    </p>
+                  </div>
+                ) : editingCommentId === null ? (
+                  <div className="rounded-200 border-border-subtle bg-background-alternative border p-300">
+                    <CommentForm
+                      onSubmit={handleAddComment}
+                      isSubmitting={createCommentMutation.isPending}
+                    />
+                  </div>
+                ) : null}
+              </>
+            )}
           </>
         )}
       </div>
@@ -728,7 +752,7 @@ export default function VotingDetailView({
       </Modal.Root>
 
       <Toast
-        message="링크가 복사되었습니다."
+        message={shareToastMessage}
         isVisible={showShareToast}
         onClose={() => setShowShareToast(false)}
       />

--- a/src/entities/user/model/use-user-profile-query.ts
+++ b/src/entities/user/model/use-user-profile-query.ts
@@ -12,7 +12,7 @@ export const useUserProfileQuery = (memberId: number) => {
     queryKey: ['userProfile', memberId],
     queryFn: () => getUserProfile(memberId),
     enabled: !!memberId,
-    staleTime: 1000 * 60 * 5,
+    staleTime: 0,
   });
 };
 

--- a/src/features/auth/model/use-auth-mutation.ts
+++ b/src/features/auth/model/use-auth-mutation.ts
@@ -5,6 +5,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { deleteCookie, getCookie } from '@/api/client/cookie';
 import { logout, signUp, uploadProfileImage } from '@/features/auth/api/auth';
+// 로그아웃 시 인증 상태 리셋을 위해 store 직접 사용 (mutation 내부 사용)
+import { usePhoneVerificationStore } from '@/features/phone-verification/model/store';
 import { hashValue } from '@/utils/hash';
 import { SignUpRequest, SignUpResponse } from './types';
 import { useUserStore } from '../../../stores/useUserStore';
@@ -31,6 +33,9 @@ export const useLogoutMutation = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
   const resetUserStore = useUserStore((state) => state.reset);
+  const resetPhoneVerification = usePhoneVerificationStore(
+    (state) => state.reset,
+  );
 
   return useMutation({
     mutationFn: logout,
@@ -49,6 +54,7 @@ export const useLogoutMutation = () => {
       deleteCookie('socialImageURL');
 
       resetUserStore();
+      resetPhoneVerification();
       queryClient.clear();
 
       router.push('/home');

--- a/src/features/auth/ui/header-user-dropdown.tsx
+++ b/src/features/auth/ui/header-user-dropdown.tsx
@@ -8,14 +8,14 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/(shadcn)/ui/dropdown-menu';
 import UserAvatar from '@/components/ui/avatar';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { useLogoutMutation } from '../model/use-auth-mutation';
 
 export default function HeaderUserDropdown({ userImg }: { userImg: string }) {
   const { mutateAsync: logout } = useLogoutMutation();
-  const { data: authData } = useAuth();
+  const { data: authData, isAuthReady } = useAuthReady();
 
-  const hasAdminRole = authData?.roleIds.includes('ROLE_ADMIN');
+  const hasAdminRole = isAuthReady && authData?.roleIds.includes('ROLE_ADMIN');
 
   const router = useRouter();
 

--- a/src/features/my-page/ui/profile.tsx
+++ b/src/features/my-page/ui/profile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { cn } from '@/components/ui/(shadcn)/lib/utils';
 import Badge from '@/components/ui/badge';
 import Progress from '@/components/ui/progress';
@@ -15,7 +15,7 @@ import PhoneIcon from '@/features/my-page/ui/icon/phone.svg';
 import TechStackIcon from '@/features/my-page/ui/icon/tech-stack.svg';
 import VerifiedCheckIcon from '@/features/my-page/ui/icon/verified-check.svg';
 import ProfileEditModal from '@/features/my-page/ui/profile-edit-modal';
-import { usePhoneVerificationStore } from '@/features/phone-verification/model/store';
+import { usePhoneVerificationStatus } from '@/features/phone-verification/model/use-phone-verification-status';
 import PhoneVerificationModal from '@/features/phone-verification/ui/phone-verification-modal';
 import { formatPhoneNumber } from '@/utils/format';
 
@@ -34,23 +34,9 @@ export default function Profile({
 }: ProfileProps) {
   const temperPreset = getSincerityPresetByLevelName(sincerityTemp.levelName);
 
-  // Zustand 스토어 사용
-  const { isVerified, phoneNumber, setVerified, reset } =
-    usePhoneVerificationStore();
+  const { isVerified, isLoading, isError, phoneNumber, setVerified } =
+    usePhoneVerificationStatus(memberId);
   const [isVerificationModalOpen, setIsVerificationModalOpen] = useState(false);
-
-  // 서버 데이터를 우선시: 서버에 전화번호가 있으면 인증된 것으로 간주, 없으면 스토어 초기화
-  useEffect(() => {
-    if (memberProfile.tel) {
-      // 서버에 전화번호가 있으면 인증된 것으로 간주
-      if (!isVerified || phoneNumber !== memberProfile.tel) {
-        setVerified(memberProfile.tel);
-      }
-    } else {
-      // 서버에 전화번호가 없으면 스토어 초기화 (로컬 스토리지에 남아있는 이전 값 제거)
-      reset();
-    }
-  }, [memberProfile.tel, isVerified, phoneNumber, setVerified, reset]);
 
   const handleVerificationComplete = (phone: string) => {
     setVerified(phone);
@@ -87,7 +73,7 @@ export default function Profile({
                 <div className="flex items-center gap-50">
                   {memberProfile.nickname ?? '닉네임을 입력해주세요'}
                   {/* 본인 인증 배지 (트위터 스타일) */}
-                  {!hidePhoneNumber && (isVerified || !!memberProfile.tel) && (
+                  {!hidePhoneNumber && !isLoading && !isError && isVerified && (
                     <VerifiedCheckIcon className="shrink-0" />
                   )}
                 </div>
@@ -202,7 +188,7 @@ export default function Profile({
       </div>
 
       {/* 하단 영역: 전화번호 미인증 시에만 인증 요청 블록 표시 (hidePhoneNumber가 true면 숨김) */}
-      {!hidePhoneNumber && !isVerified && (
+      {!hidePhoneNumber && !isLoading && !isError && !isVerified && (
         <div className="rounded-100 bg-background-alternative flex w-full flex-col gap-100 p-200">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-100">

--- a/src/features/phone-verification/model/store.ts
+++ b/src/features/phone-verification/model/store.ts
@@ -4,32 +4,49 @@ import { persist } from 'zustand/middleware';
 interface PhoneVerificationState {
   isVerified: boolean;
   phoneNumber: string | null;
-  verifiedAt: Date | null;
-  setVerified: (phoneNumber: string) => void;
+  verifiedAt: string | null;
+  memberId: number | null;
+  hasHydrated: boolean;
+  setVerified: (phoneNumber: string, memberId?: number) => void;
   reset: () => void;
+  setHasHydrated: (hasHydrated: boolean) => void;
 }
 
 export const usePhoneVerificationStore = create<PhoneVerificationState>()(
   persist(
     (set) => ({
       isVerified: false,
-      phoneNumber: '',
-      verifiedAt: new Date(),
-      setVerified: (phoneNumber) =>
+      phoneNumber: null as string | null,
+      verifiedAt: null as string | null,
+      memberId: null as number | null,
+      hasHydrated: false,
+      setVerified: (phoneNumber, memberId) =>
         set({
           isVerified: true,
           phoneNumber,
-          verifiedAt: new Date(),
+          verifiedAt: new Date().toISOString(),
+          ...(memberId !== undefined ? { memberId } : {}),
         }),
       reset: () =>
         set({
           isVerified: false,
-          phoneNumber: null,
-          verifiedAt: null,
+          phoneNumber: null as string | null,
+          verifiedAt: null as string | null,
+          memberId: null as number | null,
         }),
+      setHasHydrated: (hasHydrated) => set({ hasHydrated }),
     }),
     {
-      name: 'phone-verification-storage', // 로컬 스토리지에 저장
+      name: 'phone-verification-storage',
+      partialize: (state) => ({
+        isVerified: state.isVerified,
+        phoneNumber: state.phoneNumber,
+        verifiedAt: state.verifiedAt,
+        memberId: state.memberId,
+      }),
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+      },
     },
   ),
 );

--- a/src/features/phone-verification/model/use-phone-auth-mutation.ts
+++ b/src/features/phone-verification/model/use-phone-auth-mutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { getCookie } from '@/api/client/cookie';
+// mutation 내부에서는 store 직접 사용 허용 (API 성공 시 즉시 업데이트 목적)
 import { usePhoneVerificationStore } from './store';
 import { sendPhoneVerificationCode, verifyPhoneCode } from '../api/phone-auth';
 import type {
@@ -38,11 +39,11 @@ export const useVerifyPhoneCodeMutation = (memberId?: number) => {
     mutationFn: verifyPhoneCode,
     onSuccess: async (data, variables) => {
       if (data.success) {
-        // 인증 상태 저장
-        setVerified(variables.phoneNumber);
-
         // 현재 사용자의 memberId 가져오기 (쿠키에서)
         const currentMemberId = memberId ?? Number(getCookie('memberId'));
+
+        // 인증 상태 저장 (memberId 포함)
+        setVerified(variables.phoneNumber, currentMemberId || undefined);
 
         // 프로필 정보 쿼리키 갱신
         if (currentMemberId) {

--- a/src/features/phone-verification/model/use-phone-verification-status.ts
+++ b/src/features/phone-verification/model/use-phone-verification-status.ts
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useUserProfileQuery } from '@/entities/user/model/use-user-profile-query';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
+// 내부 구현에서는 store 직접 사용 허용 (서버 상태와 동기화 목적)
 import { usePhoneVerificationStore } from './store';
 
 /**
@@ -17,6 +18,19 @@ import { usePhoneVerificationStore } from './store';
  */
 export { usePhoneVerificationStore } from './store';
 
+interface UsePhoneVerificationStatusReturn {
+  /** 서버 기준 인증 여부 (로딩 중에만 로컬 캐시 fallback) */
+  isVerified: boolean;
+  /** 인증된 전화번호 */
+  phoneNumber: string | null;
+  /** 프로필 쿼리/스토어 하이드레이션 대기 여부 */
+  isLoading: boolean;
+  /** 프로필 쿼리 실패 여부 */
+  isError: boolean;
+  /** 인증 완료 시 스토어 즉시 업데이트용 */
+  setVerified: (phoneNumber: string) => void;
+}
+
 /**
  * 본인인증 상태를 서버 데이터와 동기화하여 반환하는 훅
  *
@@ -29,100 +43,160 @@ export { usePhoneVerificationStore } from './store';
  * - 서버의 userProfile.isVerified 또는 memberProfile.tel을 단일 진실 공급원으로 사용
  * - Zustand 상태는 UI 반응성을 위한 캐시로만 활용
  * - 서버 데이터로 Zustand 상태를 자동 동기화
+ * - memberId 변경(계정 전환) 시 로컬 스토어 자동 리셋
  *
- * @param overrideMemberId - 특정 memberId로 조회할 때 사용 (선택)
+ * 사용법:
+ * ```tsx
+ * const { isVerified, isLoading, isError, setVerified } = usePhoneVerificationStatus(memberId);
+ *
+ * // 로딩 중 처리
+ * if (isLoading) return <Spinner />;
+ *
+ * // 에러 처리
+ * if (isError) return <ErrorMessage />;
+ *
+ * // 인증 여부에 따른 UI
+ * if (!isVerified) {
+ *   return <PhoneVerificationModal onComplete={setVerified} />;
+ * }
+ *
+ * // 인증 완료 후 동작
+ * return <ProtectedContent />;
+ * ```
+ *
+ * @param overrideMemberId - 특정 memberId로 조회할 때 사용 (선택). 미지정 시 현재 로그인 유저
  */
-export function usePhoneVerificationStatus(overrideMemberId?: number) {
-  const { data: authData } = useAuth();
-  const memberId = overrideMemberId ?? authData?.memberId ?? null;
-
-  const { data: userProfile, isLoading: isProfileLoading } =
-    useUserProfileQuery(memberId ?? 0);
+export function usePhoneVerificationStatus(
+  overrideMemberId?: number,
+): UsePhoneVerificationStatusReturn {
+  const { memberId: authMemberId } = useAuthReady();
+  const memberId = overrideMemberId ?? authMemberId ?? null;
 
   const {
-    isVerified: zustandIsVerified,
-    phoneNumber: zustandPhoneNumber,
-    setVerified,
-    reset,
-  } = usePhoneVerificationStore();
+    data: userProfile,
+    isLoading: isProfileLoading,
+    isError: isProfileError,
+    isSuccess: isProfileSuccess,
+  } = useUserProfileQuery(memberId ?? 0);
+
+  const store = usePhoneVerificationStore();
 
   // 서버 데이터 기반 인증 상태 계산
-  const serverIsVerified = userProfile?.isVerified ?? false;
+  const serverHasIsVerified = typeof userProfile?.isVerified === 'boolean';
+  const serverIsVerified = serverHasIsVerified
+    ? userProfile!.isVerified
+    : false;
   const serverPhoneNumber = userProfile?.memberProfile?.tel ?? null;
+
+  // 스토어가 현재 유저 소유인지 확인 (계정 전환 대응)
+  const storeMatchesUser = memberId !== null && store.memberId === memberId;
+  const canUseStoreVerified =
+    storeMatchesUser && store.hasHydrated && store.isVerified;
+  const hasServerProfile = isProfileSuccess && !!userProfile;
 
   // 서버 데이터를 우선시하여 최종 인증 상태 결정
   // 서버에 tel이 있으면 인증된 것으로 간주 (isVerified보다 tel 존재 여부가 더 확실한 지표)
+  const resolvedServerIsVerified = serverHasIsVerified
+    ? serverIsVerified
+    : !!serverPhoneNumber;
+
+  // 프로필 로딩 중일 때는 Zustand 상태를 임시로 사용 (UI 깜빡임 방지)
+  const isLoading =
+    !!memberId && !isProfileError && !hasServerProfile && !canUseStoreVerified;
+
   const isVerified = useMemo(() => {
-    // 프로필 로딩 중일 때는 Zustand 상태를 임시로 사용 (UI 깜빡임 방지)
-    if (isProfileLoading && !userProfile) {
-      return zustandIsVerified;
+    // 비로그인 상태
+    if (!memberId) return false;
+
+    // 서버 데이터 도착 → 서버 기준 (단일 진실 공급원)
+    if (hasServerProfile) {
+      return resolvedServerIsVerified;
     }
 
-    // 서버에 전화번호가 있으면 인증 완료
-    if (serverPhoneNumber) {
-      return true;
-    }
-
-    // 서버의 isVerified 플래그 확인
-    if (serverIsVerified) {
-      return true;
-    }
-
-    // 서버 데이터가 없으면 미인증
-    return false;
+    // 로딩 중 → 같은 유저의 인증 완료 캐시만 fallback (UI 깜빡임 방지)
+    return canUseStoreVerified;
   }, [
-    isProfileLoading,
-    userProfile,
-    zustandIsVerified,
-    serverPhoneNumber,
-    serverIsVerified,
+    memberId,
+    hasServerProfile,
+    resolvedServerIsVerified,
+    canUseStoreVerified,
   ]);
 
   const phoneNumber = useMemo(() => {
-    if (isProfileLoading && !userProfile) {
-      return zustandPhoneNumber;
+    if (!memberId) return null;
+
+    // 서버 데이터 우선
+    if (hasServerProfile) {
+      return serverPhoneNumber;
     }
 
-    return serverPhoneNumber ?? null;
-  }, [isProfileLoading, userProfile, zustandPhoneNumber, serverPhoneNumber]);
+    // 로딩 중 캐시 fallback
+    return canUseStoreVerified ? store.phoneNumber : null;
+  }, [
+    memberId,
+    hasServerProfile,
+    serverPhoneNumber,
+    canUseStoreVerified,
+    store.phoneNumber,
+  ]);
 
-  // 서버 데이터와 Zustand 상태 동기화
+  // 서버 → 스토어 동기화
   useEffect(() => {
-    if (isProfileLoading || !userProfile) return;
+    if (isProfileLoading || !userProfile || !memberId) return;
 
-    if (serverPhoneNumber) {
-      // 서버에 전화번호가 있으면 Zustand도 동기화
-      if (!zustandIsVerified || zustandPhoneNumber !== serverPhoneNumber) {
-        setVerified(serverPhoneNumber);
+    const current = usePhoneVerificationStore.getState();
+
+    if (resolvedServerIsVerified) {
+      // 서버가 인증됨 → 스토어 갱신 (memberId 포함)
+      if (
+        !current.isVerified ||
+        current.memberId !== memberId ||
+        current.phoneNumber !== serverPhoneNumber
+      ) {
+        store.setVerified(serverPhoneNumber ?? '', memberId);
       }
-    } else if (!serverIsVerified) {
-      // 서버에서 인증이 해제되었으면 Zustand도 초기화
-      if (zustandIsVerified) {
-        reset();
+    } else {
+      // 서버가 미인증 → 같은 유저 캐시 제거
+      if (current.isVerified && current.memberId === memberId) {
+        store.reset();
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isProfileLoading,
     userProfile,
-    serverPhoneNumber,
+    memberId,
     serverIsVerified,
-    zustandIsVerified,
-    zustandPhoneNumber,
-    setVerified,
-    reset,
+    serverPhoneNumber,
+    resolvedServerIsVerified,
   ]);
+
+  // memberId 변경(계정 전환 / 로그아웃) 시 스토어 리셋
+  const prevMemberIdRef = useRef(memberId);
+  useEffect(() => {
+    const prev = prevMemberIdRef.current;
+    prevMemberIdRef.current = memberId;
+
+    if (prev !== null && prev !== memberId) {
+      store.reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [memberId]);
+
+  // 인증 완료 시 호출 — memberId를 자동 주입
+  const setVerified = useCallback(
+    (phone: string) => {
+      store.setVerified(phone, memberId ?? undefined);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [memberId],
+  );
 
   return {
     isVerified,
     phoneNumber,
-    isLoading: isProfileLoading,
-    // 원본 상태들 (디버깅용)
-    _serverIsVerified: serverIsVerified,
-    _serverPhoneNumber: serverPhoneNumber,
-    _zustandIsVerified: zustandIsVerified,
-    _zustandPhoneNumber: zustandPhoneNumber,
-    // Zustand 액션 (인증 완료 시 호출용)
+    isLoading,
+    isError: isProfileError,
     setVerified,
-    reset,
   };
 }

--- a/src/features/phone-verification/ui/phone-verification-modal.tsx
+++ b/src/features/phone-verification/ui/phone-verification-modal.tsx
@@ -59,11 +59,15 @@ export default function PhoneVerificationModal({
     if (!open) {
       setTimeout(() => {
         setStep('input');
-        setName(''); // 이름 초기화
+        setName('');
         setPhoneNumber('');
         setCode('');
         setError(null);
         setTimer(180);
+        setFailCount(0);
+        setIsResending(false);
+        setResendMessage(null);
+        setIsShaking(false);
       }, 300);
     }
   }, [open]);

--- a/src/features/study/group/channel/ui/comment-section.tsx
+++ b/src/features/study/group/channel/ui/comment-section.tsx
@@ -47,6 +47,7 @@ export default function CommentSection({ groupStudyId }: CommentProps) {
     (sum, q) => sum + (q.data?.totalElements ?? 0),
     0,
   );
+
   const totalCommentCount = (data?.totalElements ?? 0) + totalReplyCount;
 
   const { mutate: createThread } = usePostThreadMutation();

--- a/src/features/study/group/ui/apply-group-study-modal.tsx
+++ b/src/features/study/group/ui/apply-group-study-modal.tsx
@@ -10,6 +10,7 @@ import Checkbox from '@/components/ui/checkbox';
 import { Modal } from '@/components/ui/modal';
 import { usePhoneVerificationStatus } from '@/features/phone-verification/model/use-phone-verification-status';
 import PhoneVerificationModal from '@/features/phone-verification/ui/phone-verification-modal';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { useToastStore } from '@/stores/use-toast-store';
 import { GroupStudyDetailResponse } from '../api/group-study-types';
 import {
@@ -34,11 +35,16 @@ export default function ApplyGroupStudyModal({
   onSuccess,
 }: ApplyGroupStudyModalProps) {
   const [open, setOpen] = useState<boolean>(false);
-  // 서버 상태와 동기화된 인증 상태 사용
-  const { isVerified, setVerified } = usePhoneVerificationStatus();
+  const { memberId } = useAuthReady();
+  const { isVerified, isLoading, setVerified } = usePhoneVerificationStatus(
+    memberId ?? undefined,
+  );
   const [isVerificationModalOpen, setIsVerificationModalOpen] = useState(false);
 
   const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen && isLoading) {
+      return;
+    }
     if (isOpen && !isVerified) {
       setIsVerificationModalOpen(true);
       setOpen(false);
@@ -50,6 +56,7 @@ export default function ApplyGroupStudyModal({
 
   const handleVerificationComplete = (phoneNumber: string) => {
     setVerified(phoneNumber);
+    setIsVerificationModalOpen(false);
     setOpen(true);
   };
 
@@ -95,6 +102,7 @@ export default function ApplyGroupStudyModal({
         open={isVerificationModalOpen}
         onOpenChange={setIsVerificationModalOpen}
         onVerificationComplete={handleVerificationComplete}
+        memberId={memberId ?? undefined}
       />
     </>
   );

--- a/src/features/study/group/ui/group-study-form-modal.tsx
+++ b/src/features/study/group/ui/group-study-form-modal.tsx
@@ -10,6 +10,7 @@ import { GroupStudyFullResponseDto } from '@/api/openapi';
 import { Modal } from '@/components/ui/modal';
 import { usePhoneVerificationStatus } from '@/features/phone-verification/model/use-phone-verification-status';
 import PhoneVerificationModal from '@/features/phone-verification/ui/phone-verification-modal';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import GroupStudyForm from './group-study-form';
 
 import {
@@ -47,30 +48,42 @@ export default function GroupStudyFormModal({
   const router = useRouter();
   const qc = useQueryClient();
   const [open, setOpen] = useState<boolean>(false);
+  const { memberId } = useAuthReady();
   const { mutateAsync: createGroupStudy } = useCreateGroupStudyMutation();
   const { mutateAsync: updateGroupStudy } = useUpdateGroupStudyMutation(
     groupStudyId!,
   );
   const {
     data: groupStudyInfo,
-    isLoading,
+    isLoading: isGroupStudyLoading,
     refetch: refetchGroupStudyInfo,
   } = useGroupStudyDetailQuery(groupStudyId!);
 
-  // 서버 상태와 동기화된 인증 상태 사용
-  const { isVerified, setVerified } = usePhoneVerificationStatus();
+  const {
+    isVerified,
+    isLoading: isVerificationLoading,
+    isError: isVerificationError,
+    setVerified,
+  } = usePhoneVerificationStatus(memberId ?? undefined);
   const [isVerificationModalOpen, setIsVerificationModalOpen] = useState(false);
 
   const handleVerificationComplete = (phoneNumber: string) => {
     setVerified(phoneNumber);
-    // 인증 완료 후 모달 열기
+    setIsVerificationModalOpen(false);
     if (mode === 'create') {
       setOpen(true);
     }
-    // edit 모드일 때는 외부 제어라 호출자가 처리해야 함 (보통 edit는 이미 인증된 유저)
   };
 
   const handleOpenChange = (isOpen: boolean) => {
+    if (mode === 'create' && isOpen && isVerificationLoading) {
+      return;
+    }
+    if (mode === 'create' && isOpen && isVerificationError) {
+      alert('인증 상태를 확인할 수 없습니다. 잠시 후 다시 시도해주세요.');
+
+      return;
+    }
     if (isOpen && mode === 'create' && !isVerified) {
       setIsVerificationModalOpen(true);
       setOpen(false); // 스터디 모달은 닫힘 유지
@@ -86,7 +99,7 @@ export default function GroupStudyFormModal({
   };
 
   const refineStudyDetail = (value: GroupStudyFullResponseDto) => {
-    if (isLoading) return;
+    if (isGroupStudyLoading) return;
 
     const refinedClassification =
       value.basicInfo?.classification ?? classification;
@@ -253,6 +266,7 @@ export default function GroupStudyFormModal({
         open={isVerificationModalOpen}
         onOpenChange={setIsVerificationModalOpen}
         onVerificationComplete={handleVerificationComplete}
+        memberId={memberId ?? undefined}
       />
     </>
   );

--- a/src/features/study/group/ui/group-study-member-item.tsx
+++ b/src/features/study/group/ui/group-study-member-item.tsx
@@ -9,7 +9,7 @@ import UserAvatar from '@/components/ui/avatar';
 
 import Button from '@/components/ui/button';
 import UserProfileModal from '@/entities/user/ui/user-profile-modal';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import BronzeRankIcon from 'public/icons/bronze-rank.svg';
 import CaretDownIcon from 'public/icons/caret-down.svg';
 import CaretUpIcon from 'public/icons/caret-up.svg';
@@ -31,8 +31,7 @@ export default function GroupStudyMemberItem({
   leaderId,
   ...member
 }: GroupStudyMemberItemProps) {
-  const { data: authData } = useAuth();
-  const myId = authData?.memberId;
+  const { memberId: myId, isAuthReady } = useAuthReady();
 
   const [isProgressHistoryOpen, setIsProgressHistoryOpen] =
     useState<boolean>(false);
@@ -40,7 +39,7 @@ export default function GroupStudyMemberItem({
     useState<boolean>(false);
 
   const isMe = member.id === myId;
-  const isLeader = leaderId === myId;
+  const isLeader = isAuthReady && leaderId === myId;
 
   // 재량 평가 받은 횟수 (3번까지만 받을 수 있음)
   const discretionCount = member.progress.discretionGradeHistory.length;
@@ -212,7 +211,7 @@ function GreetingBox({
 }: Pick<GroupStudyMember, 'id' | 'greeting'> & {
   groupStudyId: number;
 }) {
-  const { data: authData } = useAuth();
+  const { memberId: authMemberId, isAuthReady } = useAuthReady();
 
   // 가입인사를 작성한 경우
   if (greeting) {
@@ -220,7 +219,7 @@ function GreetingBox({
   }
 
   // 가입인사를 작성하지 못한 경우
-  const isMe = id === authData?.memberId;
+  const isMe = isAuthReady && id === authMemberId;
 
   if (isMe) {
     return (

--- a/src/features/study/one-to-one/archive/model/use-archive-actions.ts
+++ b/src/features/study/one-to-one/archive/model/use-archive-actions.ts
@@ -5,14 +5,14 @@ import { useToggleArchiveLikeMutation } from '@/features/study/one-to-one/archiv
 import { useUpdateArchiveMutation } from '@/features/study/one-to-one/archive/model/use-update-archive-mutation';
 import { useRecordArchiveViewMutation } from '@/features/study/one-to-one/archive/model/use-view-mutation';
 import { useToggleArchiveVisibilityMutation } from '@/features/study/one-to-one/archive/model/use-visibility-mutation';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 interface ArchiveViewTarget {
   id: number;
   link: string;
 }
 
 export const useArchiveActions = () => {
-  const { isAuthenticated } = useAuth();
+  const { isAuthReady } = useAuthReady();
   const { mutate: toggleBookmark } = useToggleArchiveBookmarkMutation();
   const { mutate: toggleLike } = useToggleArchiveLikeMutation();
   const { mutate: recordView } = useRecordArchiveViewMutation();
@@ -21,43 +21,43 @@ export const useArchiveActions = () => {
 
   const handleToggleBookmark = useCallback(
     (id: number) => {
-      if (!isAuthenticated) return;
+      if (!isAuthReady) return;
       toggleBookmark(id);
     },
-    [isAuthenticated, toggleBookmark],
+    [isAuthReady, toggleBookmark],
   );
 
   const handleToggleLike = useCallback(
     (id: number) => {
-      if (!isAuthenticated) return;
+      if (!isAuthReady) return;
       toggleLike(id);
     },
-    [isAuthenticated, toggleLike],
+    [isAuthReady, toggleLike],
   );
 
   const openAndRecordView = useCallback(
     (target: ArchiveViewTarget) => {
       window.open(target.link, '_blank');
-      if (!isAuthenticated) return;
+      if (!isAuthReady) return;
       recordView(target.id);
     },
-    [isAuthenticated, recordView],
+    [isAuthReady, recordView],
   );
 
   const handleToggleVisibility = useCallback(
     (id: number, isPrivate: boolean) => {
-      if (!isAuthenticated) return;
+      if (!isAuthReady) return;
       toggleVisibility({ id, isPrivate });
     },
-    [isAuthenticated, toggleVisibility],
+    [isAuthReady, toggleVisibility],
   );
 
   const handleUpdateArchive = useCallback(
     (id: number, request: UpdateArchiveRequest) => {
-      if (!isAuthenticated) return;
+      if (!isAuthReady) return;
       updateArchive({ id, request });
     },
-    [isAuthenticated, updateArchive],
+    [isAuthReady, updateArchive],
   );
 
   return {
@@ -66,6 +66,6 @@ export const useArchiveActions = () => {
     toggleVisibility: handleToggleVisibility,
     updateArchive: handleUpdateArchive,
     openAndRecordView,
-    isAuthenticated,
+    isAuthenticated: isAuthReady,
   };
 };

--- a/src/features/study/one-to-one/archive/ui/archive-tab.tsx
+++ b/src/features/study/one-to-one/archive/ui/archive-tab.tsx
@@ -1,6 +1,8 @@
 import { getArchiveServer } from '@/features/study/one-to-one/archive/api/get-archive.server';
 import { ARCHIVE_PAGE_SIZE } from '@/features/study/one-to-one/archive/const/archive';
 import { GetArchiveParams } from '@/types/archive';
+import { safeServerPrefetch } from '@/utils/safe-server-prefetch';
+import { getServerCookie } from '@/utils/server-cookie';
 import ArchiveTabClient from './archive-tab-client';
 
 export default async function ArchiveTab() {
@@ -10,7 +12,12 @@ export default async function ArchiveTab() {
     sort: 'LATEST',
   };
 
-  const initialData = await getArchiveServer(initialParams);
+  const accessToken = await getServerCookie('accessToken');
+  const initialData = accessToken
+    ? await safeServerPrefetch(() => getArchiveServer(initialParams), {
+        logLabel: 'Archive prefetch',
+      })
+    : undefined;
 
   return (
     <ArchiveTabClient initialData={initialData} initialParams={initialParams} />

--- a/src/features/study/one-to-one/balance-game/ui/community-tab-client.tsx
+++ b/src/features/study/one-to-one/balance-game/ui/community-tab-client.tsx
@@ -15,7 +15,7 @@ import {
   useBalanceGameListQuery,
   useBalanceGameTagSuggestionsQuery,
 } from '@/features/study/one-to-one/balance-game/model/use-balance-game-query';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { useDebounce } from '@/hooks/use-debounce';
 import {
   useScrollToHomeContentOnChange,
@@ -41,7 +41,7 @@ export default function CommunityTabClient({
   const router = useRouter();
   const searchParams = useSearchParams();
   const scrollToHomeContent = useScrollToHomeContentWithStabilize();
-  const { isAuthenticated } = useAuth();
+  const { isAuthReady } = useAuthReady();
   // 상태 관리
   const {
     statusFilter,
@@ -224,6 +224,7 @@ export default function CommunityTabClient({
           title="밸런스게임"
           icon={<MessageSquareText className="text-text-brand h-8 w-8" />}
           description="다양한 주제에 투표하고 댓글로 자유롭게 토론할 수 있습니다."
+          descriptionClassName="font-designer-15r"
         />
 
         <BalanceGameFiltersBar
@@ -242,7 +243,7 @@ export default function CommunityTabClient({
           isTagLoading={isTagLoading}
           sortVariant="dropdown"
           rightSlot={
-            isAuthenticated ? (
+            isAuthReady ? (
               <button
                 onClick={() => setIsCreateModalOpen(true)}
                 className="rounded-100 bg-fill-brand-default-default font-designer-13b text-text-inverse shadow-1 hover:bg-fill-brand-default-hover hover:shadow-2 flex items-center gap-100 px-400 py-200 transition-all hover:scale-105"

--- a/src/features/study/one-to-one/balance-game/ui/community-tab.tsx
+++ b/src/features/study/one-to-one/balance-game/ui/community-tab.tsx
@@ -1,13 +1,18 @@
 import { getBalanceGameListServer } from '@/features/study/one-to-one/balance-game/api/balance-game-api.server';
+import { safeServerPrefetch } from '@/utils/safe-server-prefetch';
 import CommunityTabClient from './community-tab-client';
 
 export default async function CommunityTab() {
-  const initialList = await getBalanceGameListServer({
-    page: 1,
-    size: 10,
-    sort: 'latest',
-    status: 'active',
-  });
+  const initialList = await safeServerPrefetch(
+    () =>
+      getBalanceGameListServer({
+        page: 1,
+        size: 10,
+        sort: 'latest',
+        status: 'active',
+      }),
+    { logLabel: 'Balance game prefetch' },
+  );
 
   return <CommunityTabClient initialList={initialList} />;
 }

--- a/src/features/study/one-to-one/hall-of-fame/ui/hall-of-fame-tab.tsx
+++ b/src/features/study/one-to-one/hall-of-fame/ui/hall-of-fame-tab.tsx
@@ -1,8 +1,11 @@
 import { getHallOfFameServer } from '@/features/study/one-to-one/hall-of-fame/api/hall-of-fame-api.server';
+import { safeServerPrefetch } from '@/utils/safe-server-prefetch';
 import HallOfFameTabClient from './hall-of-fame-tab-client';
 
 export default async function HallOfFameTab() {
-  const initialData = await getHallOfFameServer();
+  const initialData = await safeServerPrefetch(() => getHallOfFameServer(), {
+    logLabel: 'Hall of fame prefetch',
+  });
 
   return <HallOfFameTabClient initialData={initialData} />;
 }

--- a/src/features/study/one-to-one/schedule/ui/study-card.tsx
+++ b/src/features/study/one-to-one/schedule/ui/study-card.tsx
@@ -10,7 +10,7 @@ import {
 import DateSelector from '@/features/study/one-to-one/schedule/ui/data-selector';
 import TodayStudyCard from '@/features/study/one-to-one/schedule/ui/today-study-card';
 import ReservationList from '@/features/study/participation/ui/reservation-list';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import {
   formatKoreaYMD,
   getKoreaDate,
@@ -82,8 +82,8 @@ export default function StudyCard({
   const studyDate = formatKoreaYMD(selectedDate);
 
   // 로그인 여부 확인
-  const { data: authData } = useAuth();
-  const isLoggedIn = !!authData?.memberId;
+  const { isAuthReady, memberId } = useAuthReady();
+  const isLoggedIn = isAuthReady && !!memberId;
 
   // 공개 API
   const { data: status } = useStudyStatusQuery();

--- a/src/features/study/one-to-one/schedule/ui/today-study-card.tsx
+++ b/src/features/study/one-to-one/schedule/ui/today-study-card.tsx
@@ -14,7 +14,7 @@ import { getStatusBadge } from '@/features/study/interview/ui/status-badge-map';
 import StudyDoneModal from '@/features/study/interview/ui/study-done-modal';
 import StudyReadyModal from '@/features/study/interview/ui/study-ready-modal';
 import { TUTORIAL_DAILY_STUDY_MOCK } from '@/features/study/one-to-one/schedule/model/tutorial-mock';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 
 interface TodayStudyCardProps {
   studyDate: string;
@@ -31,12 +31,12 @@ export default function TodayStudyCard({
   forceOpenReadyModal,
   forceOpenDoneModal,
 }: TodayStudyCardProps) {
-  const { data: authData } = useAuth();
+  const { memberId: authMemberId } = useAuthReady();
   const memberId = tutorialMode
     ? forcedRole === 'INTERVIEWER'
       ? TUTORIAL_DAILY_STUDY_MOCK.interviewerId
       : TUTORIAL_DAILY_STUDY_MOCK.intervieweeId
-    : (authData?.memberId ?? null);
+    : (authMemberId ?? null);
 
   const queryStudyDate = tutorialMode ? '' : studyDate;
   const { data: todayStudyData } = useDailyStudyDetailQuery(queryStudyDate);

--- a/src/features/study/participation/ui/reservation-list.tsx
+++ b/src/features/study/participation/ui/reservation-list.tsx
@@ -12,7 +12,7 @@ import { usePhoneVerificationStatus } from '@/features/phone-verification/model/
 import PhoneVerificationModal from '@/features/phone-verification/ui/phone-verification-modal';
 import ReservationCard from '@/features/study/participation/ui/reservation-user-card';
 import StartStudyModal from '@/features/study/participation/ui/start-study-modal';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import { useInfiniteReservation } from '../model/use-participation-query';
 
 interface ReservationListProps {
@@ -29,17 +29,18 @@ export default function ReservationList({
   week,
 }: ReservationListProps) {
   const sentinelRef = useRef<HTMLDivElement | null>(null);
-  const { data: authData } = useAuth();
-  const memberId = authData?.memberId ?? null;
+  const { memberId } = useAuthReady();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { data: userProfile } = useUserProfileQuery(memberId ?? 0);
   const autoMatching = userProfile?.autoMatching ?? false;
 
-  // 서버 상태와 동기화된 인증 상태 사용
-  const { isVerified, setVerified } = usePhoneVerificationStatus(
-    memberId ?? undefined,
-  );
+  const {
+    isVerified,
+    isLoading: isVerificationLoading,
+    isError: isVerificationError,
+    setVerified,
+  } = usePhoneVerificationStatus(memberId ?? undefined);
   const [isVerificationModalOpen, setIsVerificationModalOpen] = useState(false);
 
   const firstMemberId = useMemo(
@@ -47,8 +48,13 @@ export default function ReservationList({
     [autoMatching, memberId],
   );
 
-  const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } =
-    useInfiniteReservation(firstMemberId ?? undefined, pageSize);
+  const {
+    data,
+    isLoading: isReservationLoading,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+  } = useInfiniteReservation(firstMemberId ?? undefined, pageSize);
   const { mutate: patchAutoMatching, isPending } =
     usePatchAutoMatchingMutation();
 
@@ -92,6 +98,12 @@ export default function ReservationList({
 
   const handleApplyClick = () => {
     if (!memberId) return;
+    if (isVerificationLoading) return;
+    if (isVerificationError) {
+      alert('인증 상태를 확인할 수 없습니다. 잠시 후 다시 시도해주세요.');
+
+      return;
+    }
 
     // 본인인증이 안되어 있으면 본인인증 모달 먼저 열기
     if (!isVerified) {
@@ -108,7 +120,7 @@ export default function ReservationList({
     }
   };
 
-  if (isLoading) {
+  if (isReservationLoading) {
     return (
       <div className="py-10 text-center text-sm text-gray-500">
         불러오는 중…

--- a/src/features/study/participation/ui/start-study-modal.tsx
+++ b/src/features/study/participation/ui/start-study-modal.tsx
@@ -100,14 +100,22 @@ export default function StartStudyModal({
   open,
   onOpenChange,
 }: StartStudyModalProps) {
-  // 서버 상태와 동기화된 인증 상태 사용
-  const { isVerified, setVerified } = usePhoneVerificationStatus(memberId);
+  const { isVerified, isLoading, isError, setVerified } =
+    usePhoneVerificationStatus(memberId);
   const [isVerificationModalOpen, setIsVerificationModalOpen] = useState(false);
 
   const [internalOpen, setInternalOpen] = useState(false);
   const isModalOpen = open ?? internalOpen;
 
   const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen && isLoading) {
+      return;
+    }
+    if (isOpen && isError) {
+      alert('인증 상태를 확인할 수 없습니다. 잠시 후 다시 시도해주세요.');
+
+      return;
+    }
     if (isOpen && !isVerified) {
       setIsVerificationModalOpen(true);
       if (onOpenChange) onOpenChange(false);
@@ -132,7 +140,18 @@ export default function StartStudyModal({
 
   // 모달이 열릴 때 인증 여부 체크 (외부 제어 open prop 대응)
   useEffect(() => {
-    if (isModalOpen && !isVerified) {
+    if (!isModalOpen || isLoading) return;
+    if (isError) {
+      alert('인증 상태를 확인할 수 없습니다. 잠시 후 다시 시도해주세요.');
+      if (onOpenChange) {
+        onOpenChange(false);
+      } else {
+        setInternalOpen(false);
+      }
+
+      return;
+    }
+    if (!isVerified) {
       setIsVerificationModalOpen(true);
       if (onOpenChange) {
         onOpenChange(false);
@@ -140,7 +159,7 @@ export default function StartStudyModal({
         setInternalOpen(false);
       }
     }
-  }, [isModalOpen, isVerified, onOpenChange]);
+  }, [isModalOpen, isVerified, isLoading, isError, onOpenChange]);
 
   const handleVerificationComplete = (phoneNumber: string) => {
     setVerified(phoneNumber);

--- a/src/hooks/common/auth-hydration-context.tsx
+++ b/src/hooks/common/auth-hydration-context.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React, { createContext, useContext } from 'react';
+
+interface AuthHydrationContextValue {
+  initialAccessToken?: string;
+}
+
+const AuthHydrationContext = createContext<AuthHydrationContextValue>({});
+
+export function AuthHydrationProvider({
+  initialAccessToken,
+  children,
+}: {
+  initialAccessToken?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <AuthHydrationContext.Provider value={{ initialAccessToken }}>
+      {children}
+    </AuthHydrationContext.Provider>
+  );
+}
+
+export function useAuthHydration() {
+  return useContext(AuthHydrationContext);
+}

--- a/src/hooks/common/use-auth.ts
+++ b/src/hooks/common/use-auth.ts
@@ -4,10 +4,11 @@
 // 한편, prefetchQuery 는 서버컴포넌트에서 사용하는 함수로 데이터를 미리 가져와서 캐시에 저장함
 
 import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { getCookie } from '@/api/client/cookie';
 import { getMemberId } from '@/features/auth/api/auth';
 import { decodeJwt } from '@/utils/jwt';
+import { useAuthHydration } from './auth-hydration-context';
 
 // 회원 Id 조회
 export const useMemberId = () => {
@@ -35,6 +36,7 @@ interface UseAuthReturn {
   accessToken: string | undefined;
   data: DecodedToken | undefined;
   isAuthenticated: boolean;
+  isHydrated: boolean;
 }
 
 function isDecodedToken(value: unknown): value is DecodedToken {
@@ -64,9 +66,17 @@ function isDecodedToken(value: unknown): value is DecodedToken {
 }
 
 export function useAuth(): UseAuthReturn {
+  const { initialAccessToken } = useAuthHydration();
+  const [accessToken, setAccessToken] = useState<string | undefined>(
+    initialAccessToken,
+  );
+  const [isHydrated, setIsHydrated] = useState(!!initialAccessToken);
+
   // getCookie는 클라이언트 사이드에서만 실행되어야 함
-  const accessToken =
-    typeof window !== 'undefined' ? getCookie('accessToken') : undefined;
+  useEffect(() => {
+    setAccessToken(getCookie('accessToken'));
+    setIsHydrated(true);
+  }, []);
 
   const decodedToken: DecodedToken | undefined = useMemo(() => {
     if (!accessToken) return undefined;
@@ -94,6 +104,30 @@ export function useAuth(): UseAuthReturn {
   return {
     accessToken,
     data: decodedToken,
-    isAuthenticated: !!accessToken && !!decodedToken && !isGuest,
+    isAuthenticated: isHydrated && !!accessToken && !!decodedToken && !isGuest,
+    isHydrated,
+  };
+}
+
+export interface UseAuthReadyReturn {
+  isHydrated: boolean;
+  isAuthenticated: boolean;
+  isAuthReady: boolean;
+  memberId?: number;
+  data?: DecodedToken;
+  accessToken?: string;
+}
+
+export function useAuthReady(): UseAuthReadyReturn {
+  const { accessToken, data, isAuthenticated, isHydrated } = useAuth();
+  const isAuthReady = isHydrated && isAuthenticated;
+
+  return {
+    accessToken,
+    data,
+    isAuthenticated,
+    isHydrated,
+    isAuthReady,
+    memberId: isHydrated ? data?.memberId : undefined,
   };
 }

--- a/src/hooks/queries/group-study-member-api.ts
+++ b/src/hooks/queries/group-study-member-api.ts
@@ -7,7 +7,7 @@ import type {
 } from '@/api/openapi/models';
 // TEMPORARY: Keep until OpenAPI types fixed
 import type { GroupStudyMembersResponse } from '@/features/study/group/api/group-study-types';
-import { useAuth } from '../common/use-auth';
+import { useAuthReady } from '../common/use-auth';
 
 const groupStudyMemberApi = createApiInstance(GroupStudyMemberApi);
 
@@ -58,7 +58,7 @@ export const useGetGroupStudyMyStatus = ({
   groupStudyId: number;
   isLeader: boolean;
 }) => {
-  const { data } = useAuth();
+  const { memberId, isAuthReady } = useAuthReady();
 
   return useQuery({
     queryKey: ['groupStudyMemberStatus', groupStudyId],
@@ -67,7 +67,8 @@ export const useGetGroupStudyMyStatus = ({
 
       return data.content;
     },
-    enabled: !!groupStudyId && !isLeader && data?.memberId !== undefined,
+    enabled:
+      !!groupStudyId && !isLeader && isAuthReady && memberId !== undefined,
   });
 };
 

--- a/src/hooks/queries/notification-api.ts
+++ b/src/hooks/queries/notification-api.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createApiInstance } from '@/api/client/open-api-instance';
 import { NotificationApi } from '@/api/openapi';
 import type { GetMemberNotificationsTopicTypeEnum } from '@/api/openapi/api/notification-api';
-import { useAuth } from '../common/use-auth';
+import { useAuthReady } from '../common/use-auth';
 
 const notificationApi = createApiInstance(NotificationApi);
 
@@ -19,7 +19,7 @@ export const useGetNotifications = ({
   hasRead,
   topicType,
 }: NotificationsParams = {}) => {
-  const { isAuthenticated } = useAuth();
+  const { isAuthReady } = useAuthReady();
 
   return useQuery({
     queryKey: ['notifications', page, size, hasRead, topicType],
@@ -34,12 +34,12 @@ export const useGetNotifications = ({
       return data.content;
     },
     refetchInterval: 60000, // 1 minute
-    enabled: !!isAuthenticated,
+    enabled: isAuthReady,
   });
 };
 
 export const useGetNotificationCategories = () => {
-  const { isAuthenticated } = useAuth();
+  const { isAuthReady } = useAuthReady();
 
   return useQuery({
     queryKey: ['notificationCategories'],
@@ -48,12 +48,12 @@ export const useGetNotificationCategories = () => {
 
       return data.content;
     },
-    enabled: !!isAuthenticated,
+    enabled: isAuthReady,
   });
 };
 
 export const useHasNewNotification = () => {
-  const { isAuthenticated } = useAuth();
+  const { isAuthReady } = useAuthReady();
 
   return useQuery({
     queryKey: ['hasNewNotification'],
@@ -63,7 +63,7 @@ export const useHasNewNotification = () => {
       return data.content;
     },
     refetchInterval: 60000, // 1 minute
-    enabled: !!isAuthenticated,
+    enabled: isAuthReady,
   });
 };
 

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -2,37 +2,41 @@
 
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useEffect } from 'react';
-import { useAuth } from '@/hooks/common/use-auth';
+import { AuthHydrationProvider } from '@/hooks/common/auth-hydration-context';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import QueryProvider from '@/providers/query-provider';
 import { useUserStore } from '@/stores/useUserStore';
 
 interface ProviderProps {
   children: React.ReactNode;
+  initialAccessToken?: string;
 }
 
 function UserInitializer({ children }: ProviderProps) {
-  const { data: authData, isAuthenticated } = useAuth();
+  const { memberId: authMemberId, isAuthReady } = useAuthReady();
   const { memberId, fetchAndSetUser } = useUserStore();
 
   useEffect(() => {
-    if (isAuthenticated && authData?.memberId && !memberId) {
-      fetchAndSetUser(authData.memberId).catch(console.error);
+    if (isAuthReady && authMemberId && !memberId) {
+      fetchAndSetUser(authMemberId).catch(console.error);
     }
-  }, [isAuthenticated, authData?.memberId, memberId, fetchAndSetUser]);
+  }, [isAuthReady, authMemberId, memberId, fetchAndSetUser]);
 
   return <>{children}</>;
 }
 
-function MainProvider({ children }: ProviderProps) {
+function MainProvider({ children, initialAccessToken }: ProviderProps) {
   return (
-    <QueryProvider>
-      <UserInitializer>
-        {children}
-        {process.env.NODE_ENV === 'development' && (
-          <ReactQueryDevtools initialIsOpen={false} />
-        )}
-      </UserInitializer>
-    </QueryProvider>
+    <AuthHydrationProvider initialAccessToken={initialAccessToken}>
+      <QueryProvider>
+        <UserInitializer>
+          {children}
+          {process.env.NODE_ENV === 'development' && (
+            <ReactQueryDevtools initialIsOpen={false} />
+          )}
+        </UserInitializer>
+      </QueryProvider>
+    </AuthHydrationProvider>
   );
 }
 

--- a/src/utils/safe-server-prefetch.ts
+++ b/src/utils/safe-server-prefetch.ts
@@ -1,0 +1,22 @@
+type AsyncFn<T> = () => Promise<T>;
+
+interface SafeServerPrefetchOptions {
+  logLabel?: string;
+}
+
+export async function safeServerPrefetch<T>(
+  fn: AsyncFn<T>,
+  options: SafeServerPrefetchOptions = {},
+): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (options.logLabel) {
+      console.warn(`${options.logLabel} failed on server.`, error);
+    } else {
+      console.warn('Server prefetch failed.', error);
+    }
+
+    return undefined;
+  }
+}

--- a/src/widgets/home/todo-list.tsx
+++ b/src/widgets/home/todo-list.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Button from '@/components/ui/button';
 import { usePhoneVerificationStatus } from '@/features/phone-verification/model/use-phone-verification-status';
 import PhoneVerificationModal from '@/features/phone-verification/ui/phone-verification-modal';
+import { useAuthReady } from '@/hooks/common/use-auth';
 import CheckIcon from 'public/icons/check.svg';
 
 interface TodoListProps {
@@ -17,7 +18,9 @@ const todoItems = [
 ] as const;
 
 export default function TodoList({ statusList }: TodoListProps) {
-  const { isVerified, setVerified } = usePhoneVerificationStatus();
+  const { memberId } = useAuthReady();
+  const { isVerified, isLoading, isError, setVerified } =
+    usePhoneVerificationStatus(memberId);
   const [isVerificationModalOpen, setIsVerificationModalOpen] = useState(false);
 
   const handleVerificationComplete = (phoneNumber: string) => {
@@ -28,7 +31,21 @@ export default function TodoList({ statusList }: TodoListProps) {
     <section className="rounded-200 border-border-subtle bg-background-default flex flex-col gap-150 border p-250">
       <h4 className="font-designer-18b text-text-default">오늘 할 일</h4>
 
-      {isVerified ? (
+      {isLoading ? (
+        <div className="flex flex-col items-center justify-center gap-100 py-200">
+          <p className="font-designer-14m text-text-subtle text-center">
+            인증 상태를 확인하고 있어요
+          </p>
+        </div>
+      ) : isError ? (
+        <div className="flex flex-col items-center justify-center gap-100 py-200">
+          <p className="font-designer-14m text-text-subtle text-center">
+            인증 상태를 불러오지 못했어요.
+            <br />
+            잠시 후 다시 시도해주세요.
+          </p>
+        </div>
+      ) : isVerified ? (
         <ul>
           {todoItems.map((item, idx) => {
             const done = statusList[idx];
@@ -77,6 +94,7 @@ export default function TodoList({ statusList }: TodoListProps) {
         open={isVerificationModalOpen}
         onOpenChange={setIsVerificationModalOpen}
         onVerificationComplete={handleVerificationComplete}
+        memberId={memberId ?? undefined}
       />
     </section>
   );

--- a/src/widgets/my-page/sidebar.tsx
+++ b/src/widgets/my-page/sidebar.tsx
@@ -4,16 +4,16 @@ import { usePathname, useRouter } from 'next/navigation';
 import { cn } from '@/components/ui/(shadcn)/lib/utils';
 import { useUserProfileQuery } from '@/entities/user/model/use-user-profile-query';
 import { useLogoutMutation } from '@/features/auth/model/use-auth-mutation';
-import { useAuth } from '@/hooks/common/use-auth';
+import { useAuthReady } from '@/hooks/common/use-auth';
 
 export default function Sidebar() {
   const router = useRouter();
   const pathname = usePathname();
 
-  const { data: authData } = useAuth();
+  const { memberId } = useAuthReady();
   const { mutateAsync: logout } = useLogoutMutation();
 
-  const { data: profile } = useUserProfileQuery(authData?.memberId || 0);
+  const { data: profile } = useUserProfileQuery(memberId ?? 0);
 
   const handleLogout = async () => {
     await logout();


### PR DESCRIPTION
# fix: SSR/CSR Hydration 불일치 및 UX 개선

  

## 🎯 Summary

  

서버 사이드 렌더링(SSR)과 클라이언트 사이드 렌더링(CSR) 간의 hydration 불일치 문제를 해결하고, 토스트 및 공유 기능의 사용자 경험을 개선했습니다.

  

## 📋 주요 변경사항

  

### 1. Auth Hydration 아키텍처 개선 ⚡️

  

**문제:**

- `useAuth()`가 클라이언트에서 쿠키를 읽기 전까지 `undefined`를 반환하여 SSR/CSR 간 불일치 발생

- Hydration mismatch로 인한 콘솔 경고 및 잠재적 렌더링 이슈

- 인증 상태 확인 시점이 명확하지 않아 race condition 발생 가능

  

**해결:**

- **AuthHydrationProvider** 도입: 서버에서 읽은 `initialAccessToken`을 클라이언트로 전달하여 초기 렌더링 일관성 보장

- **useAuth()** 개선:

- `isHydrated` 상태 추가로 hydration 완료 여부 추적

- `useState`와 `useEffect`로 클라이언트 쿠키 읽기를 안전하게 처리

- **useAuthReady()** 훅 추가:

- `isAuthReady = isHydrated && isAuthenticated`로 인증 체크 시점 명확화

- 컴포넌트에서 안전하게 인증 상태 확인 가능

  

**영향 범위:**

- 30개 이상의 컴포넌트를 `useAuthReady()`로 업데이트

- Auth-gated 쿼리 (`notification-api`, `group-study-member-api`) 수정

- 모든 레이아웃 (`(admin)`, `(landing)`, `(service)`) 업데이트

  

**업데이트된 컴포넌트:** ([전체 목록](docs/HYDRATION_AUTH_CHECKLIST.md))

- 페이지: `group-study-list-page`, `mentoring-list-page`, `premium-study-list-page`, `my-study/page`

- 위젯: `todo-list`, `my-page/sidebar`

- 기능: `start-study-modal`, `reservation-list`, `study-matching-toggle`, `phone-verification-modal`

- 그룹 스터디: `apply-group-study-modal`, `group-study-form-modal`, `group-study-member-item`

- 기타: `voting-detail-view`, `tab-navigation`, `admin-sidebar` 등

  

**파일:**

- 추가: `src/hooks/common/auth-hydration-context.tsx`

- 수정: `src/hooks/common/use-auth.ts` (+ `useAuthReady()` 훅)

- 수정: `src/providers/index.tsx` (AuthHydrationProvider 적용)

- 문서: `docs/HYDRATION_AUTH_CHECKLIST.md`

  

### 2. Phone Verification Store 개선 🔐

  

**문제:**

- 계정 간 본인인증 상태 오염 가능 (A 계정 인증 → B 계정 로그인 시 인증된 것처럼 보임)

- `verifiedAt`이 Date 객체로 localStorage에 직렬화 불가능

- Hydration 완료 여부 추적 불가

  

**해결:**

- `memberId` 필드 추가: 인증 상태가 특정 계정에만 유효하도록 보장

- `verifiedAt`을 Date → ISO string으로 변경하여 직렬화 문제 해결

- `hasHydrated` 상태 추가 및 `onRehydrateStorage` 콜백 구현

- `partialize`로 필요한 필드만 persist 대상으로 지정

  

**파일:**

- 수정: `src/features/phone-verification/model/store.ts`

  

### 3. Toast 컴포넌트 UX 개선 🎨

  

**문제:**

- z-index 충돌로 다른 요소에 가려질 수 있음

- 퇴장 애니메이션 없이 갑자기 사라짐

- 렌더링 타이밍 이슈

  

**해결:**

- **React Portal** 사용: `document.body`에 직접 렌더링하여 z-index 문제 완전 해결

- **부드러운 애니메이션** 추가:

- 진입: `toast-enter` (300ms fade-in + slide-down)

- 퇴장: `toast-exit` (200ms fade-out + slide-up)

- 상태 관리 개선: `isRendered`, `isExiting` 분리로 애니메이션 완료까지 DOM 유지

  

**파일:**

- 수정: `src/components/ui/toast.tsx`

- 수정: `src/app/global.css` (keyframes 애니메이션 정의)

  

### 4. Voting 공유 기능 개선 📤

  

**문제:**

- Web Share API 실패 시 fallback 로직 미흡

- Clipboard API 실패 시 사용자 피드백 부족

- 에러 처리가 복잡하고 불명확

  

**해결:**

- **3단계 Fallback 전략** 구현:

1. `navigator.clipboard.writeText()` (최신 브라우저)

2. `document.execCommand('copy')` (레거시 지원)

3. `window.prompt()` (수동 복사)

- 각 단계별 성공/실패 처리 명확화

- Toast 메시지 동적 처리 (`openShareToast`)

  

**파일:**

- 수정: `src/components/voting/voting-detail-view.tsx`

  

### 5. 유틸리티 및 문서 추가 📚

  

**새 유틸리티:**

- `src/utils/safe-server-prefetch.ts`: 서버 사이드 prefetch 에러를 안전하게 처리

  

**새 문서:**

- `docs/HYDRATION_AUTH_CHECKLIST.md`: Auth hydration 업데이트 추적 체크리스트

- `docs/PRODUCTION_DEPLOYMENT_VERIFICATION.md`: 프로덕션 배포 검증 가이드 (작성 중)

  

## 🧪 테스트 시나리오

  

### Auth Hydration

- [ ] 비로그인 상태에서 페이지 접근 시 hydration 경고 없음

- [ ] 로그인 상태에서 페이지 새로고침 시 인증 상태 즉시 반영

- [ ] 서버 렌더링과 클라이언트 렌더링 결과 일치 확인

- [ ] 토큰 만료 시 자동 갱신 후 상태 정상 동작

  

### Phone Verification

- [ ] A 계정 인증 → 로그아웃 → B 계정 로그인 시 미인증 상태로 표시

- [ ] 본인인증 완료 후 새로고침해도 인증 상태 유지

- [ ] `memberId` 불일치 시 자동으로 미인증 처리

  

### Toast

- [ ] Toast가 모든 요소보다 위에 표시됨 (z-index 문제 없음)

- [ ] 진입/퇴장 애니메이션이 부드럽게 작동

- [ ] 여러 Toast가 연속으로 표시될 때 정상 동작

  

### Voting 공유

- [ ] 최신 브라우저에서 Clipboard API로 복사 성공

- [ ] Clipboard API 미지원 브라우저에서 fallback 동작

- [ ] 복사 성공 시 Toast 표시

- [ ] 수동 복사 프롬프트에서 취소 시 Toast 미표시

  

## 📊 영향 분석

  

### 변경된 파일 통계

- **51개 파일 수정** (+1,768줄, -360줄)

- **3개 파일 추가** (문서 2개, 유틸리티 1개)

  

### 영향받는 도메인

- 인증 (Auth) ⚡️ 높음

- 본인인증 (Phone Verification) ⚡️ 높음

- UI 컴포넌트 (Toast) 🔧 중간

- 커뮤니티 (Voting 공유) 🔧 중간

  

## 🔄 Migration Guide

  

### 기존 `useAuth()` 사용하던 컴포넌트

  

**Before:**

```tsx

const { data, isAuthenticated } = useAuth();

  

if (!isAuthenticated) return null; // ❌ Hydration mismatch

```

  

**After:**

```tsx

const { memberId, isAuthReady } = useAuthReady();

  

if (!isAuthReady) return null; // ✅ Hydration-safe

```

  

### Phone Verification 체크

  

**Before:**

```tsx

const { isVerified } = usePhoneVerificationStore();

// 계정 간 오염 가능

```

  

**After:**

```tsx

const { isVerified } = usePhoneVerificationStatus(memberId);

// memberId 기반 안전한 체크

```

  

## 🚀 배포 전 확인사항

  

- [ ] `yarn typecheck` 통과

- [ ] `yarn lint` 통과

- [ ] `yarn build` 성공

- [ ] Hydration 경고 없음 확인

- [ ] 개발/스테이징 환경 테스트 완료

  

## 📝 Breaking Changes

  

**없음** - 기존 API 호환성 유지됨

  

## 🔗 관련 이슈

  

- Fixes: Hydration mismatch 콘솔 경고

- Fixes: 계정 간 본인인증 상태 오염

- Improves: Toast z-index 및 애니메이션

- Improves: Voting 공유 신뢰성

  

---

  

**🤖 Co-Authored-By:** Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 글로벌 토스트 시스템 확장 및 복사/공유 토스트 추가
  * 주요 서비스 페이지에 토스트 렌더링 추가

* **버그 수정**
  * 전화 인증 모달 닫기 시 상태 초기화 범위 확대
  * 인증/권한 관련 표시·동작의 준비(readiness) 처리 개선

* **UI/UX 개선**
  * 토스트 진입/종료 애니메이션 추가
  * 전화 인증에 로딩·오류 피드백 추가 및 안내 메시지 강화
  * 일부 목록의 표시 항목(모집인원 중복) 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->