### PR TITLE
refactor : 커뮤니티 게시글 상세 헤더/본문/반응 레이아웃 개선

### DIFF
--- a/src/app/(service)/community/[postId]/page.tsx
+++ b/src/app/(service)/community/[postId]/page.tsx
@@ -9,7 +9,10 @@ import { generateMetadata as generateSEOMetadata } from '@/utils/seo';
 
 interface CommunityDetailPageProps {
   params: Promise<{ postId: string }>;
-  searchParams: Promise<{ page?: string | string[] }>;
+  searchParams: Promise<{
+    page?: string | string[];
+    board?: string | string[];
+  }>;
 }
 
 const parsePostId = (rawPostId: string) => {
@@ -47,7 +50,7 @@ export default async function CommunityDetailPage({
   searchParams,
 }: CommunityDetailPageProps) {
   const { postId: rawPostId } = await params;
-  const { page } = await searchParams;
+  const { page, board } = await searchParams;
   const normalizedPostId = parsePostId(rawPostId);
 
   if (!normalizedPostId) {
@@ -58,6 +61,7 @@ export default async function CommunityDetailPage({
     <CommunityDetailPageClient
       postId={normalizedPostId}
       returnPage={normalizeCommunityPageParam(page)}
+      returnBoard={normalizeCommunityBoardParam(board)}
     />
   );
 }

--- a/src/app/(service)/community/[postId]/page.tsx
+++ b/src/app/(service)/community/[postId]/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { normalizeCommunityPageParam } from '@/features/community/model/community-route';
+import {
+  normalizeCommunityBoardParam,
+  normalizeCommunityPageParam,
+} from '@/features/community/model/community-route';
 import CommunityDetailPageClient from '@/features/community/ui/pages/community-detail-page-client';
 import { generateMetadata as generateSEOMetadata } from '@/utils/seo';
 

--- a/src/app/(service)/community/questions/[questionId]/page.tsx
+++ b/src/app/(service)/community/questions/[questionId]/page.tsx
@@ -1,12 +1,16 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { normalizeCommunityPageParam } from '@/features/community/model/community-route';
+import {
+  normalizeCommunityBoardParam,
+  normalizeCommunityPageParam,
+} from '@/features/community/model/community-route';
 import CommunityQnaDetailPageClient from '@/features/community/ui/pages/community-qna-detail-page-client';
 import { generateMetadata as generateSEOMetadata } from '@/utils/seo';
 
 interface CommunityQuestionDetailPageProps {
   params: Promise<{ questionId: string }>;
   searchParams: Promise<{
+    board?: string | string[];
     page?: string | string[];
     answerPage?: string | string[];
     commentPage?: string | string[];
@@ -48,7 +52,7 @@ export default async function CommunityQuestionDetailPage({
   searchParams,
 }: CommunityQuestionDetailPageProps) {
   const { questionId: rawQuestionId } = await params;
-  const { page, answerPage, commentPage } = await searchParams;
+  const { board, page, answerPage, commentPage } = await searchParams;
   const normalizedQuestionId = parseQuestionId(rawQuestionId);
 
   if (!normalizedQuestionId) {
@@ -59,6 +63,7 @@ export default async function CommunityQuestionDetailPage({
     <CommunityQnaDetailPageClient
       questionId={normalizedQuestionId}
       returnPage={normalizeCommunityPageParam(page)}
+      returnBoard={normalizeCommunityBoardParam(board)}
       initialAnswerPage={normalizeCommunityPageParam(answerPage)}
       initialCommentPage={normalizeCommunityPageParam(commentPage)}
     />

--- a/src/components/common/ui/rich-text/markdown-content-core.tsx
+++ b/src/components/common/ui/rich-text/markdown-content-core.tsx
@@ -232,15 +232,15 @@ export default function MarkdownContentCore({
       ref={containerRef}
       className={cn(
         'break-words',
-        '[&_p]:font-designer-14r [&_p]:text-text-default [&_p]:mb-150 [&_p]:leading-relaxed',
+        '[&_p]:font-designer-18r [&_p]:text-text-default [&_p]:mb-150 [&_p]:leading-relaxed',
         '[&_h1]:font-designer-24b [&_h1]:text-text-strong [&_h1]:mt-250 [&_h1]:mb-150',
         '[&_h2]:font-designer-20b [&_h2]:text-text-strong [&_h2]:mt-250 [&_h2]:mb-125',
         '[&_h3]:font-designer-18b [&_h3]:text-text-default [&_h3]:mt-200 [&_h3]:mb-100',
         '[&_ul]:mb-150 [&_ul]:list-disc [&_ul]:space-y-50 [&_ul]:pl-250',
         '[&_ol]:mb-150 [&_ol]:list-decimal [&_ol]:space-y-50 [&_ol]:pl-250',
-        '[&_li]:font-designer-14r [&_li]:text-text-default [&_li]:leading-relaxed',
+        '[&_li]:font-designer-18r [&_li]:text-text-default [&_li]:leading-relaxed',
         '[&_blockquote]:rounded-100 [&_blockquote]:bg-background-alternative [&_blockquote]:border-border-subtle [&_blockquote]:mb-150 [&_blockquote]:border-l-4 [&_blockquote]:px-150 [&_blockquote]:py-125',
-        '[&_blockquote_p]:font-designer-14r [&_blockquote_p]:text-text-subtle [&_blockquote_p]:leading-relaxed',
+        '[&_blockquote_p]:font-designer-16r [&_blockquote_p]:text-text-subtle [&_blockquote_p]:leading-relaxed',
         '[&_a]:text-text-brand [&_a]:underline',
         '[&_img]:rounded-100 [&_img]:border-border-subtle [&_img]:mb-150 [&_img]:block [&_img]:h-auto [&_img]:max-h-rich-text-image [&_img]:max-w-rich-text-image [&_img]:border [&_img]:object-contain',
         '[&_code]:rounded-50 [&_code]:bg-background-alternative [&_code]:font-designer-13r [&_code]:px-75 [&_code]:py-25',

--- a/src/features/community/api/community-qna-api.ts
+++ b/src/features/community/api/community-qna-api.ts
@@ -19,6 +19,7 @@ import type {
   CommunityQnaQuestionListQueryParams,
   CommunityQnaQuestionUpsertRequest,
   CommunityQnaQuestionViewEventApiResponse,
+  CommunityQnaReactionApiResponse,
 } from './community-qna-api.types';
 
 const unwrap = <T>(response: { data: CommunityQnaBaseResponse<T> }) =>
@@ -453,6 +454,28 @@ export const recordCommunityQnaQuestionView = async (questionId: number) => {
   const response = await axiosInstance.post<
     CommunityQnaBaseResponse<CommunityQnaQuestionViewEventApiResponse>
   >(`/community/questions/${questionId}/views`);
+
+  return unwrap(response);
+};
+
+export const assignCommunityQnaQuestionReaction = async (
+  questionId: number,
+  body: { type: string },
+) => {
+  const response = await axiosInstance.post<
+    CommunityQnaBaseResponse<CommunityQnaReactionApiResponse>
+  >(`/community/questions/${questionId}/reactions`, body);
+
+  return unwrap(response);
+};
+
+export const assignCommunityQnaAnswerReaction = async (
+  answerId: number,
+  body: { type: string },
+) => {
+  const response = await axiosInstance.post<
+    CommunityQnaBaseResponse<CommunityQnaReactionApiResponse>
+  >(`/community/answers/${answerId}/reactions`, body);
 
   return unwrap(response);
 };

--- a/src/features/community/api/community-qna-api.types.ts
+++ b/src/features/community/api/community-qna-api.types.ts
@@ -24,6 +24,7 @@ export interface CommunityQnaQuestionStatsApiResponse {
   viewCount: number;
   answerCount: number;
   questionCommentCount: number;
+  likeCount?: number;
 }
 
 export interface CommunityQnaQuestionSummaryApiResponse {
@@ -63,6 +64,7 @@ export interface CommunityQnaQuestionViewerApiResponse {
   canCreateAnswer: boolean;
   canAcceptAnswer: boolean;
   myAnswerId?: number | null;
+  questionReaction?: string | null;
 }
 
 export interface CommunityQnaCommentApiResponse {
@@ -88,12 +90,14 @@ export interface CommunityQnaAnswerApiResponse {
   author: CommunityQnaAuthorApiResponse;
   stats: {
     commentCount: number;
+    likeCount?: number;
   };
   isAccepted: boolean;
   viewer: {
     canEdit: boolean;
     canDelete: boolean;
     canComment: boolean;
+    reaction?: string | null;
   };
   createdAt: string;
   updatedAt: string;
@@ -184,6 +188,11 @@ export interface CommunityQnaAcceptanceApiResponse {
   questionId: number;
   acceptedAnswerId?: number | null;
   acceptedAt?: string | null;
+}
+
+export interface CommunityQnaReactionApiResponse {
+  likeCount: number;
+  reaction: string;
 }
 
 export interface CommunityQnaQuestionViewEventApiResponse {

--- a/src/features/community/model/community-feed-item.ts
+++ b/src/features/community/model/community-feed-item.ts
@@ -1,6 +1,8 @@
 import {
   COMMUNITY_BOARD,
+  type CommunityBoard,
   type CommunityPostBoard,
+  isCommunityBoard,
 } from '@/types/community/domain';
 import {
   buildCommunityPostHref,
@@ -26,7 +28,12 @@ export const buildCommunityFeedItemDetailHref = (
   itemId: number,
   board: CommunityPostBoard,
   page?: number,
-) =>
-  getCommunityFeedItemKind(board) === COMMUNITY_FEED_ITEM_KIND.QNA
-    ? buildCommunityQuestionHref(itemId, page)
-    : buildCommunityPostHref(itemId, page);
+  activeFilter?: string,
+) => {
+  const resolvedBoard: CommunityBoard | undefined =
+    activeFilter && isCommunityBoard(activeFilter) ? activeFilter : undefined;
+
+  return getCommunityFeedItemKind(board) === COMMUNITY_FEED_ITEM_KIND.QNA
+    ? buildCommunityQuestionHref(itemId, page, resolvedBoard)
+    : buildCommunityPostHref(itemId, page, resolvedBoard);
+};

--- a/src/features/community/model/community-qna-api.mapper.ts
+++ b/src/features/community/model/community-qna-api.mapper.ts
@@ -16,6 +16,7 @@ import {
   type CommunityQnaQuestionDetailData,
   type CommunityQnaQuestionSummary,
   type CommunityQnaQuestionViewEvent,
+  type CommunityQnaReactionResult,
 } from '@/types/community/qna-domain';
 import { formatKoreaRelativeTime } from '@/utils/time';
 import type {
@@ -35,6 +36,7 @@ import type {
   CommunityQnaQuestionListApiResponse,
   CommunityQnaQuestionSummaryApiResponse,
   CommunityQnaQuestionViewEventApiResponse,
+  CommunityQnaReactionApiResponse,
 } from '../api/community-qna-api.types';
 
 const COMMUNITY_QNA_AUTHOR_FALLBACK_NAME = '알 수 없는 사용자';
@@ -83,6 +85,7 @@ export const mapCommunityQnaQuestionSummary = (
     viewCount: response.stats.viewCount,
     answerCount: response.stats.answerCount,
     questionCommentCount: response.stats.questionCommentCount,
+    likeCount: response.stats.likeCount ?? 0,
   },
   accepted: response.accepted,
   myAnswerExists: response.myAnswerExists,
@@ -105,6 +108,7 @@ export const mapCommunityQnaQuestionDetail = (
     viewCount: response.stats.viewCount,
     answerCount: response.stats.answerCount,
     questionCommentCount: response.stats.questionCommentCount,
+    likeCount: response.stats.likeCount ?? 0,
   },
   acceptedAnswerId: response.acceptedAnswerId ?? undefined,
   createdAt: toDisplayTime(response.createdAt),
@@ -141,12 +145,14 @@ export const mapCommunityQnaAnswerItem = (
   author: mapCommunityQnaAuthor(response.author),
   stats: {
     commentCount: response.stats.commentCount,
+    likeCount: response.stats.likeCount ?? 0,
   },
   isAccepted: response.isAccepted,
   viewer: {
     canEdit: response.viewer.canEdit,
     canDelete: response.viewer.canDelete,
     canComment: response.viewer.canComment,
+    reaction: response.viewer.reaction ?? 'none',
   },
   createdAt: toDisplayTime(response.createdAt),
   updatedAt: response.updatedAt,
@@ -188,6 +194,7 @@ export const mapCommunityQnaQuestionDetailAggregate = (
     canCreateAnswer: response.viewer.canCreateAnswer,
     canAcceptAnswer: response.viewer.canAcceptAnswer,
     myAnswerId: response.viewer.myAnswerId ?? undefined,
+    questionReaction: response.viewer.questionReaction ?? 'none',
   },
   acceptedAnswer: response.acceptedAnswer
     ? mapCommunityQnaAnswerItem(response.acceptedAnswer)
@@ -240,6 +247,13 @@ export const mapCommunityQnaAcceptance = (
   questionId: response.questionId,
   acceptedAnswerId: response.acceptedAnswerId ?? undefined,
   acceptedAt: response.acceptedAt ?? undefined,
+});
+
+export const mapCommunityQnaReactionResult = (
+  response: CommunityQnaReactionApiResponse,
+): CommunityQnaReactionResult => ({
+  likeCount: response.likeCount,
+  reaction: response.reaction,
 });
 
 export const mapCommunityQnaQuestionViewEvent = (

--- a/src/features/community/model/community-route.ts
+++ b/src/features/community/model/community-route.ts
@@ -26,11 +26,25 @@ export const resolveCommunityPage = (
   fallback = COMMUNITY_DEFAULT_PAGE,
 ) => normalizeCommunityPageParam(value) ?? fallback;
 
-export const buildCommunityListHref = (page?: number) => {
+export const buildCommunityListHref = (
+  page?: number,
+  board?: CommunityBoard,
+) => {
   const normalizedPage =
     typeof page === 'number' ? normalizeCommunityPageNumber(page) : undefined;
+  const searchParams = new URLSearchParams();
 
-  return normalizedPage ? `/community?page=${normalizedPage}` : '/community';
+  if (normalizedPage) {
+    searchParams.set('page', String(normalizedPage));
+  }
+
+  if (board && isCommunityBoard(board)) {
+    searchParams.set('board', board);
+  }
+
+  const query = searchParams.toString();
+
+  return query ? `/community?${query}` : '/community';
 };
 
 export const normalizeCommunityBoardParam = (
@@ -66,23 +80,50 @@ export const buildCommunityWriteHref = (
   return query ? `/community/write?${query}` : '/community/write';
 };
 
-export const buildCommunityPostHref = (postId: number, page?: number) => {
+export const buildCommunityPostHref = (
+  postId: number,
+  page?: number,
+  board?: CommunityBoard,
+) => {
   const normalizedPage =
     typeof page === 'number' ? normalizeCommunityPageNumber(page) : undefined;
   const detailPath = `/community/${postId}`;
+  const searchParams = new URLSearchParams();
 
-  return normalizedPage ? `${detailPath}?page=${normalizedPage}` : detailPath;
+  if (normalizedPage) {
+    searchParams.set('page', String(normalizedPage));
+  }
+
+  if (board && isCommunityBoard(board)) {
+    searchParams.set('board', board);
+  }
+
+  const query = searchParams.toString();
+
+  return query ? `${detailPath}?${query}` : detailPath;
 };
 
 export const buildCommunityQuestionHref = (
   questionId: number,
   page?: number,
+  board?: CommunityBoard,
 ) => {
   const normalizedPage =
     typeof page === 'number' ? normalizeCommunityPageNumber(page) : undefined;
   const detailPath = `/community/questions/${questionId}`;
+  const searchParams = new URLSearchParams();
 
-  return normalizedPage ? `${detailPath}?page=${normalizedPage}` : detailPath;
+  if (normalizedPage) {
+    searchParams.set('page', String(normalizedPage));
+  }
+
+  if (board && isCommunityBoard(board)) {
+    searchParams.set('board', board);
+  }
+
+  const query = searchParams.toString();
+
+  return query ? `${detailPath}?${query}` : detailPath;
 };
 
 export const buildCommunityQuestionWriteHref = (page?: number) => {

--- a/src/features/community/model/use-community-detail-controller.ts
+++ b/src/features/community/model/use-community-detail-controller.ts
@@ -430,7 +430,6 @@ export const useCommunityDetailController = ({
         await navigator.share({ title, url });
         return;
       } catch {
-        // 사용자가 공유 시트를 닫은 경우 무시
         return;
       }
     }

--- a/src/features/community/model/use-community-detail-controller.ts
+++ b/src/features/community/model/use-community-detail-controller.ts
@@ -77,13 +77,8 @@ export const useCommunityDetailController = ({
     enabled: postQuery.isSuccess,
   });
 
-  const [commentDraft, setCommentDraft] = useState('');
-  const [replyTargetId, setReplyTargetId] = useState<number | undefined>();
-  const [replyDraft, setReplyDraft] = useState('');
-  const [editingCommentId, setEditingCommentId] = useState<
-    number | undefined
-  >();
-  const [editingDraft, setEditingDraft] = useState('');
+  const [commentInteractionResetKey, setCommentInteractionResetKey] =
+    useState(0);
 
   const post = postQuery.data;
   const comments = commentsQuery.data?.items ?? EMPTY_COMMENTS;
@@ -109,28 +104,13 @@ export const useCommunityDetailController = ({
       )
     : '';
 
-  const resetReplyState = () => {
-    setReplyTargetId(undefined);
-    setReplyDraft('');
-  };
-
-  const resetEditingState = () => {
-    setEditingCommentId(undefined);
-    setEditingDraft('');
-  };
-
-  const resetPagedCommentInteractionState = () => {
-    resetReplyState();
-    resetEditingState();
+  const resetCommentInteraction = () => {
+    setCommentInteractionResetKey((prev) => prev + 1);
   };
 
   useEffect(() => {
     setCommentsPage(COMMUNITY_COMMENTS_PAGE);
-    setCommentDraft('');
-    setReplyTargetId(undefined);
-    setReplyDraft('');
-    setEditingCommentId(undefined);
-    setEditingDraft('');
+    resetCommentInteraction();
     viewedPostIdRef.current = undefined;
   }, [postId]);
 
@@ -140,10 +120,7 @@ export const useCommunityDetailController = ({
       !commentsQuery.isPending &&
       !commentsQuery.isError
     ) {
-      setReplyTargetId(undefined);
-      setReplyDraft('');
-      setEditingCommentId(undefined);
-      setEditingDraft('');
+      resetCommentInteraction();
       setCommentsPage(totalCommentPages);
     }
   }, [
@@ -152,16 +129,6 @@ export const useCommunityDetailController = ({
     commentsQuery.isPending,
     totalCommentPages,
   ]);
-
-  useEffect(() => {
-    if (replyTargetId && !findCommentById(comments, replyTargetId)) {
-      resetReplyState();
-    }
-
-    if (editingCommentId && !findCommentById(comments, editingCommentId)) {
-      resetEditingState();
-    }
-  }, [comments, editingCommentId, replyTargetId]);
 
   useEffect(() => {
     if (!post || viewedPostIdRef.current === post.id) {
@@ -196,22 +163,8 @@ export const useCommunityDetailController = ({
     }
   };
 
-  const handleCommentDraftChange = (nextValue: string) => {
-    setCommentDraft(nextValue);
-  };
-
-  const handleReplyDraftChange = (nextValue: string) => {
-    setReplyDraft(nextValue);
-  };
-
-  const handleEditingDraftChange = (nextValue: string) => {
-    setEditingDraft(nextValue);
-  };
-
-  const handleSubmitComment = async () => {
-    const normalizedComment = commentDraft.trim();
-
-    if (!post || !normalizedComment) {
+  const handleSubmitComment = async (content: string) => {
+    if (!post) {
       return;
     }
 
@@ -221,51 +174,20 @@ export const useCommunityDetailController = ({
       return;
     }
 
-    try {
-      await createCommentMutation.mutateAsync({
-        postId: post.id,
-        content: normalizedComment,
-        idempotencyKey: createCommunityIdempotencyKey('community-comment'),
-      });
-      setCommentDraft('');
-      if (commentsPage !== COMMUNITY_COMMENTS_PAGE) {
-        resetPagedCommentInteractionState();
-        setCommentsPage(COMMUNITY_COMMENTS_PAGE);
-      }
-    } catch (error) {
-      showToast(
-        getCommunityErrorMessage(error, '댓글 등록에 실패했습니다.'),
-        'error',
-      );
+    await createCommentMutation.mutateAsync({
+      postId: post.id,
+      content,
+      idempotencyKey: createCommunityIdempotencyKey('community-comment'),
+    });
+
+    if (commentsPage !== COMMUNITY_COMMENTS_PAGE) {
+      resetCommentInteraction();
+      setCommentsPage(COMMUNITY_COMMENTS_PAGE);
     }
   };
 
-  const handleOpenReply = (commentId: number) => {
-    const targetComment = findCommentById(comments, commentId);
-
-    if (!targetComment?.canReply) {
-      if (!isAuthenticated) {
-        showToast('로그인 후 답글을 작성할 수 있습니다.', 'info');
-      }
-
-      return;
-    }
-
-    setReplyTargetId(commentId);
-    setReplyDraft('');
-    setEditingCommentId(undefined);
-    setEditingDraft('');
-  };
-
-  const handleCloseReply = () => {
-    setReplyTargetId(undefined);
-    setReplyDraft('');
-  };
-
-  const handleSubmitReply = async () => {
-    const normalizedReply = replyDraft.trim();
-
-    if (!post || !replyTargetId || !normalizedReply) {
+  const handleSubmitReply = async (commentId: number, content: string) => {
+    if (!post) {
       return;
     }
 
@@ -275,69 +197,29 @@ export const useCommunityDetailController = ({
       return;
     }
 
-    try {
-      await createReplyMutation.mutateAsync({
-        postId: post.id,
-        commentId: replyTargetId,
-        content: normalizedReply,
-        idempotencyKey: createCommunityIdempotencyKey('community-reply'),
-      });
-      setReplyDraft('');
-      setReplyTargetId(undefined);
-    } catch (error) {
-      showToast(
-        getCommunityErrorMessage(error, '답글 등록에 실패했습니다.'),
-        'error',
-      );
-    }
+    await createReplyMutation.mutateAsync({
+      postId: post.id,
+      commentId,
+      content,
+      idempotencyKey: createCommunityIdempotencyKey('community-reply'),
+    });
   };
 
-  const handleStartEditingComment = (commentId: number) => {
-    const targetComment = findCommentById(comments, commentId);
-
-    if (!targetComment?.canEdit) {
+  const handleSubmitEditedComment = async (
+    commentId: number,
+    revision: number,
+    content: string,
+  ) => {
+    if (!post) {
       return;
     }
 
-    setEditingCommentId(commentId);
-    setEditingDraft(targetComment.content);
-    setReplyTargetId(undefined);
-    setReplyDraft('');
-  };
-
-  const handleCancelEditingComment = () => {
-    setEditingCommentId(undefined);
-    setEditingDraft('');
-  };
-
-  const handleSubmitEditedComment = async () => {
-    const normalizedContent = editingDraft.trim();
-
-    if (!post || !editingCommentId || !normalizedContent) {
-      return;
-    }
-
-    const targetComment = findCommentById(comments, editingCommentId);
-
-    if (!targetComment?.revision) {
-      return;
-    }
-
-    try {
-      await updateCommentMutation.mutateAsync({
-        postId: post.id,
-        commentId: editingCommentId,
-        revision: targetComment.revision,
-        content: normalizedContent,
-      });
-      setEditingCommentId(undefined);
-      setEditingDraft('');
-    } catch (error) {
-      showToast(
-        getCommunityErrorMessage(error, '댓글 수정에 실패했습니다.'),
-        'error',
-      );
-    }
+    await updateCommentMutation.mutateAsync({
+      postId: post.id,
+      commentId,
+      revision,
+      content,
+    });
   };
 
   const handleDeleteComment = async (commentId: number) => {
@@ -351,28 +233,11 @@ export const useCommunityDetailController = ({
       return;
     }
 
-    try {
-      await deleteCommentMutation.mutateAsync({
-        postId: post.id,
-        commentId,
-        revision: targetComment.revision,
-      });
-
-      if (editingCommentId === commentId) {
-        setEditingCommentId(undefined);
-        setEditingDraft('');
-      }
-
-      if (replyTargetId === commentId) {
-        setReplyTargetId(undefined);
-        setReplyDraft('');
-      }
-    } catch (error) {
-      showToast(
-        getCommunityErrorMessage(error, '댓글 삭제에 실패했습니다.'),
-        'error',
-      );
-    }
+    await deleteCommentMutation.mutateAsync({
+      postId: post.id,
+      commentId,
+      revision: targetComment.revision,
+    });
   };
 
   const handleToggleCommentReaction = async (
@@ -417,7 +282,7 @@ export const useCommunityDetailController = ({
       return;
     }
 
-    resetPagedCommentInteractionState();
+    resetCommentInteraction();
     setCommentsPage(normalizedPage);
   };
 
@@ -444,45 +309,31 @@ export const useCommunityDetailController = ({
 
   return {
     state: {
-      commentDraft,
-      editingCommentId,
-      editingDraft,
+      commentInteractionResetKey,
       commentsErrorMessage,
       isAuthenticated,
       isCommentsLoading: commentsQuery.isPending,
       isResolved,
       errorMessage: postErrorMessage,
       post: isNotFound ? undefined : post,
-      replyDraft,
-      replyTargetId,
     },
     actions: {
-      handleCancelEditingComment,
       handleCommentPageChange,
-      handleCloseReply,
-      handleCommentDraftChange,
       handleDeleteComment,
-      handleEditingDraftChange,
-      handleOpenReply,
-      handleReplyDraftChange,
-      handleStartEditingComment,
+      handleSharePost,
       handleSubmitComment,
       handleSubmitEditedComment,
       handleSubmitReply,
       handleToggleCommentReaction,
       handleToggleLike,
-      handleSharePost,
     },
     viewModel: {
       commentCount:
         commentsQuery.data?.totalCommentCount ?? post?.commentCount ?? 0,
       comments,
       currentCommentsPage,
-      editingSubmitEnabled: editingDraft.trim().length > 0,
-      isCommentSubmitEnabled: commentDraft.trim().length > 0,
       isLikedByViewer: post?.viewerReaction === 'like',
       isPostReactionEnabled: isAuthenticated,
-      isReplySubmitEnabled: replyDraft.trim().length > 0,
       reactionCount: post?.reactionCount ?? 0,
       showCommentPagination: totalCommentPages > COMMUNITY_COMMENTS_PAGE,
       totalCommentPages,

--- a/src/features/community/model/use-community-detail-controller.ts
+++ b/src/features/community/model/use-community-detail-controller.ts
@@ -294,8 +294,10 @@ export const useCommunityDetailController = ({
       try {
         await navigator.share({ title, url });
         return;
-      } catch {
-        return;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
       }
     }
 
@@ -333,7 +335,6 @@ export const useCommunityDetailController = ({
       comments,
       currentCommentsPage,
       isLikedByViewer: post?.viewerReaction === 'like',
-      isPostReactionEnabled: isAuthenticated,
       reactionCount: post?.reactionCount ?? 0,
       showCommentPagination: totalCommentPages > COMMUNITY_COMMENTS_PAGE,
       totalCommentPages,

--- a/src/features/community/model/use-community-detail-controller.ts
+++ b/src/features/community/model/use-community-detail-controller.ts
@@ -421,6 +421,28 @@ export const useCommunityDetailController = ({
     setCommentsPage(normalizedPage);
   };
 
+  const handleSharePost = async () => {
+    const url = window.location.href;
+    const title = post?.title ?? '';
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, url });
+        return;
+      } catch {
+        // 사용자가 공유 시트를 닫은 경우 무시
+        return;
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      showToast('링크가 복사되었습니다.', 'success');
+    } catch {
+      showToast('링크 복사에 실패했습니다.', 'error');
+    }
+  };
+
   return {
     state: {
       commentDraft,
@@ -450,6 +472,7 @@ export const useCommunityDetailController = ({
       handleSubmitReply,
       handleToggleCommentReaction,
       handleToggleLike,
+      handleSharePost,
     },
     viewModel: {
       commentCount:

--- a/src/features/community/model/use-community-page-controller.ts
+++ b/src/features/community/model/use-community-page-controller.ts
@@ -22,6 +22,7 @@ import {
   COMMUNITY_FEED_VIEW,
   type CommunityFeedFilter,
   type CommunityFeedView,
+  isCommunityBoard,
 } from '@/types/community/domain';
 import { COMMUNITY_QNA_QUESTION_STATUS } from '@/types/community/qna-domain';
 import {
@@ -75,14 +76,26 @@ export const useCommunityPageController = ({
   const searchParams = useSearchParams();
   const viewerQueryScope = useCommunityViewerQueryScope();
   const rawPageParam = searchParams.get('page');
+  const rawBoardParam = searchParams.get('board');
   const requestedPage =
     rawPageParam === null
       ? COMMUNITY_DEFAULT_PAGE
       : (normalizeCommunityPageParam(rawPageParam) ?? initialPage);
 
-  const [activeFilter, setActiveFilter] = useState<CommunityFeedFilter>(
-    COMMUNITY_FEED_FILTER.ALL,
-  );
+  const resolveInitialFilter = (): CommunityFeedFilter => {
+    if (!rawBoardParam) {
+      return COMMUNITY_FEED_FILTER.ALL;
+    }
+
+    if (isCommunityBoard(rawBoardParam)) {
+      return rawBoardParam as CommunityFeedFilter;
+    }
+
+    return COMMUNITY_FEED_FILTER.ALL;
+  };
+
+  const [activeFilter, setActiveFilter] =
+    useState<CommunityFeedFilter>(resolveInitialFilter);
   const [activeView, setActiveView] = useState<CommunityFeedView>(
     COMMUNITY_FEED_VIEW.LIST,
   );
@@ -176,19 +189,38 @@ export const useCommunityPageController = ({
     : mergeCommunityFeedQnaPreviewImages(feed.items, qnaPreviewByQuestionId);
   const currentPage = isQnaFilter ? qnaQuestionList.page : feed.page;
 
-  useEffect(() => {
-    if (rawPageParam === null || rawPageParam === String(currentPage)) {
-      return;
+  const replaceUrlParams = (
+    nextPage: number,
+    nextFilter: CommunityFeedFilter,
+  ) => {
+    const nextSearchParams = new URLSearchParams();
+    const normalizedPage = Math.max(nextPage, COMMUNITY_DEFAULT_PAGE);
+
+    if (normalizedPage > COMMUNITY_DEFAULT_PAGE) {
+      nextSearchParams.set('page', String(normalizedPage));
     }
 
-    const nextSearchParams = new URLSearchParams(searchParams.toString());
-    nextSearchParams.set('page', String(currentPage));
+    if (
+      nextFilter !== COMMUNITY_FEED_FILTER.ALL &&
+      isCommunityBoard(nextFilter)
+    ) {
+      nextSearchParams.set('board', nextFilter);
+    }
+
     const nextQuery = nextSearchParams.toString();
 
     router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, {
       scroll: false,
     });
-  }, [currentPage, pathname, rawPageParam, router, searchParams]);
+  };
+
+  useEffect(() => {
+    if (rawPageParam === null || rawPageParam === String(currentPage)) {
+      return;
+    }
+
+    replaceUrlParams(currentPage, activeFilter);
+  }, [currentPage, pathname, rawPageParam, router, searchParams, activeFilter]);
 
   const replacePage = (nextPage: number) => {
     const normalizedPage = Math.max(nextPage, COMMUNITY_DEFAULT_PAGE);
@@ -197,13 +229,7 @@ export const useCommunityPageController = ({
       return false;
     }
 
-    const nextSearchParams = new URLSearchParams(searchParams.toString());
-    nextSearchParams.set('page', String(normalizedPage));
-    const nextQuery = nextSearchParams.toString();
-
-    router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, {
-      scroll: false,
-    });
+    replaceUrlParams(normalizedPage, activeFilter);
 
     return true;
   };
@@ -217,7 +243,7 @@ export const useCommunityPageController = ({
       setActiveFilter(nextFilter);
     });
 
-    replacePage(COMMUNITY_DEFAULT_PAGE);
+    replaceUrlParams(COMMUNITY_DEFAULT_PAGE, nextFilter);
     scrollToCommunityFeedOnFilterChange();
   };
 

--- a/src/features/community/model/use-community-page-controller.ts
+++ b/src/features/community/model/use-community-page-controller.ts
@@ -2,7 +2,7 @@
 
 import { useQueries } from '@tanstack/react-query';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { startTransition, useEffect, useState } from 'react';
+import { startTransition, useCallback, useEffect, useState } from 'react';
 import { getCommunityErrorMessage } from '@/features/community/api/community-api';
 import {
   getCommunityQnaErrorMessage,
@@ -189,30 +189,30 @@ export const useCommunityPageController = ({
     : mergeCommunityFeedQnaPreviewImages(feed.items, qnaPreviewByQuestionId);
   const currentPage = isQnaFilter ? qnaQuestionList.page : feed.page;
 
-  const replaceUrlParams = (
-    nextPage: number,
-    nextFilter: CommunityFeedFilter,
-  ) => {
-    const nextSearchParams = new URLSearchParams();
-    const normalizedPage = Math.max(nextPage, COMMUNITY_DEFAULT_PAGE);
+  const replaceUrlParams = useCallback(
+    (nextPage: number, nextFilter: CommunityFeedFilter) => {
+      const nextSearchParams = new URLSearchParams();
+      const normalizedPage = Math.max(nextPage, COMMUNITY_DEFAULT_PAGE);
 
-    if (normalizedPage > COMMUNITY_DEFAULT_PAGE) {
-      nextSearchParams.set('page', String(normalizedPage));
-    }
+      if (normalizedPage > COMMUNITY_DEFAULT_PAGE) {
+        nextSearchParams.set('page', String(normalizedPage));
+      }
 
-    if (
-      nextFilter !== COMMUNITY_FEED_FILTER.ALL &&
-      isCommunityBoard(nextFilter)
-    ) {
-      nextSearchParams.set('board', nextFilter);
-    }
+      if (
+        nextFilter !== COMMUNITY_FEED_FILTER.ALL &&
+        isCommunityBoard(nextFilter)
+      ) {
+        nextSearchParams.set('board', nextFilter);
+      }
 
-    const nextQuery = nextSearchParams.toString();
+      const nextQuery = nextSearchParams.toString();
 
-    router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, {
-      scroll: false,
-    });
-  };
+      router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, {
+        scroll: false,
+      });
+    },
+    [pathname, router],
+  );
 
   useEffect(() => {
     if (rawPageParam === null || rawPageParam === String(currentPage)) {
@@ -220,7 +220,7 @@ export const useCommunityPageController = ({
     }
 
     replaceUrlParams(currentPage, activeFilter);
-  }, [currentPage, pathname, rawPageParam, router, searchParams, activeFilter]);
+  }, [currentPage, rawPageParam, activeFilter, replaceUrlParams]);
 
   const replacePage = (nextPage: number) => {
     const normalizedPage = Math.max(nextPage, COMMUNITY_DEFAULT_PAGE);

--- a/src/features/community/model/use-community-qna-detail-controller.ts
+++ b/src/features/community/model/use-community-qna-detail-controller.ts
@@ -1,8 +1,17 @@
 'use client';
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { isCommunityQnaNotFoundError } from '@/features/community/api/community-qna-api';
+import { useAuth } from '@/features/auth/model/use-auth';
+import {
+  getCommunityQnaErrorMessage,
+  isCommunityQnaNotFoundError,
+} from '@/features/community/api/community-qna-api';
+import {
+  useAssignCommunityQnaAnswerReactionMutation,
+  useAssignCommunityQnaQuestionReactionMutation,
+} from '@/features/community/model/use-community-qna-mutation';
 import { useCommunityQnaQuestionDetailQuery } from '@/features/community/model/use-community-qna-query';
+import { useToastStore } from '@/stores/use-toast-store';
 import { analyzeError, ErrorType, type ErrorInfo } from '@/utils/error-handler';
 import {
   COMMUNITY_DEFAULT_PAGE,
@@ -54,6 +63,11 @@ export const useCommunityQnaDetailController = ({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const { isAuthenticated } = useAuth();
+  const showToast = useToastStore((state) => state.showToast);
+  const questionReactionMutation =
+    useAssignCommunityQnaQuestionReactionMutation();
+  const answerReactionMutation = useAssignCommunityQnaAnswerReactionMutation();
   const answerPage =
     normalizeCommunityPageParam(searchParams.get('answerPage')) ??
     initialAnswerPage;
@@ -123,6 +137,63 @@ export const useCommunityQnaDetailController = ({
           ? undefined
           : '개발자 등록 사용자만 답변을 작성할 수 있습니다.';
 
+  const handleToggleQuestionLike = async () => {
+    if (!question || !viewer || questionReactionMutation.isPending) {
+      return;
+    }
+
+    if (!isAuthenticated) {
+      showToast('로그인 후 좋아요를 누를 수 있습니다.', 'info');
+
+      return;
+    }
+
+    try {
+      await questionReactionMutation.mutateAsync({
+        questionId: question.id,
+        type: viewer.questionReaction === 'like' ? 'none' : 'like',
+      });
+    } catch (error) {
+      showToast(
+        getCommunityQnaErrorMessage(error, '좋아요 처리에 실패했습니다.'),
+        'error',
+      );
+    }
+  };
+
+  const handleToggleAnswerLike = async (answerId: number) => {
+    if (!question || answerReactionMutation.isPending) {
+      return;
+    }
+
+    if (!isAuthenticated) {
+      showToast('로그인 후 좋아요를 누를 수 있습니다.', 'info');
+
+      return;
+    }
+
+    const targetAnswer = answersPageData?.items.find(
+      (answer) => answer.id === answerId,
+    );
+
+    if (!targetAnswer) {
+      return;
+    }
+
+    try {
+      await answerReactionMutation.mutateAsync({
+        questionId: question.id,
+        answerId,
+        type: targetAnswer.viewer.reaction === 'like' ? 'none' : 'like',
+      });
+    } catch (error) {
+      showToast(
+        getCommunityQnaErrorMessage(error, '좋아요 처리에 실패했습니다.'),
+        'error',
+      );
+    }
+  };
+
   return {
     state: {
       question,
@@ -130,6 +201,7 @@ export const useCommunityQnaDetailController = ({
       acceptedAnswer,
       questionCommentsPageData,
       answersPageData,
+      isAuthenticated,
       isResolved: detailQuery.isSuccess || detailQuery.isError,
       isNotFound,
       errorInfo,
@@ -141,6 +213,8 @@ export const useCommunityQnaDetailController = ({
       handleCommentPageChange: (nextPage: number) => {
         replacePages({ nextCommentPage: nextPage });
       },
+      handleToggleQuestionLike,
+      handleToggleAnswerLike,
       refetchQuestionDetail: () => detailQuery.refetch(),
     },
     viewModel: {
@@ -150,6 +224,10 @@ export const useCommunityQnaDetailController = ({
       answerCount: question?.stats.answerCount ?? 0,
       myAnswerId: viewer?.myAnswerId,
       questionCommentCount: question?.stats.questionCommentCount ?? 0,
+      questionLikeCount: question?.stats.likeCount ?? 0,
+      isQuestionLikedByViewer: viewer?.questionReaction === 'like',
+      isQuestionReactionPending: questionReactionMutation.isPending,
+      isAnswerReactionPending: answerReactionMutation.isPending,
       answerTotalPages: Math.max(
         answersPageData?.totalPages ?? COMMUNITY_DEFAULT_PAGE,
         COMMUNITY_DEFAULT_PAGE,

--- a/src/features/community/model/use-community-qna-detail-controller.ts
+++ b/src/features/community/model/use-community-qna-detail-controller.ts
@@ -194,6 +194,29 @@ export const useCommunityQnaDetailController = ({
     }
   };
 
+  const handleShareQuestion = async () => {
+    const url = window.location.href;
+    const title = question?.title ?? '';
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, url });
+        return;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      showToast('링크가 복사되었습니다.', 'success');
+    } catch {
+      showToast('링크 복사에 실패했습니다.', 'error');
+    }
+  };
+
   return {
     state: {
       question,
@@ -213,6 +236,7 @@ export const useCommunityQnaDetailController = ({
       handleCommentPageChange: (nextPage: number) => {
         replacePages({ nextCommentPage: nextPage });
       },
+      handleShareQuestion,
       handleToggleQuestionLike,
       handleToggleAnswerLike,
       refetchQuestionDetail: () => detailQuery.refetch(),

--- a/src/features/community/model/use-community-qna-mutation.ts
+++ b/src/features/community/model/use-community-qna-mutation.ts
@@ -7,6 +7,8 @@ import {
 } from '@tanstack/react-query';
 import {
   acceptCommunityQnaAnswer,
+  assignCommunityQnaAnswerReaction,
+  assignCommunityQnaQuestionReaction,
   clearCommunityQnaAnswerAcceptance,
   createCommunityQnaAnswer,
   createCommunityQnaAnswerComment,
@@ -28,7 +30,13 @@ import {
   mapCommunityQnaCommentDeleteResult,
   mapCommunityQnaQuestionDeleteResult,
   mapCommunityQnaQuestionDetail,
+  mapCommunityQnaReactionResult,
 } from '@/features/community/model/community-qna-api.mapper';
+import type {
+  CommunityQnaQuestionDetailData,
+  CommunityQnaQuestionSummary,
+} from '@/types/community/qna-domain';
+import type { CommunityQnaQuestionListData } from '@/types/community/qna-query';
 import { communityQnaQueryKeys } from '@/types/community/qna-query';
 
 const invalidateCommunityQnaQuestionListQueries = (
@@ -468,6 +476,144 @@ export const useDeleteCommunityQnaAnswerCommentMutation = () => {
           variables.answerId,
         ),
       ]);
+    },
+  });
+};
+
+const updateQuestionDetailReaction = (
+  current: CommunityQnaQuestionDetailData | undefined,
+  likeCount: number,
+  reaction: string,
+): CommunityQnaQuestionDetailData | undefined => {
+  if (!current) {
+    return current;
+  }
+
+  return {
+    ...current,
+    question: {
+      ...current.question,
+      stats: { ...current.question.stats, likeCount },
+    },
+    viewer: { ...current.viewer, questionReaction: reaction },
+  };
+};
+
+const updateAnswerDetailReaction = (
+  current: CommunityQnaQuestionDetailData | undefined,
+  answerId: number,
+  likeCount: number,
+  reaction: string,
+): CommunityQnaQuestionDetailData | undefined => {
+  if (!current) {
+    return current;
+  }
+
+  return {
+    ...current,
+    answersPage: {
+      ...current.answersPage,
+      items: current.answersPage.items.map((answer) =>
+        answer.id === answerId
+          ? {
+              ...answer,
+              stats: { ...answer.stats, likeCount },
+              viewer: { ...answer.viewer, reaction },
+            }
+          : answer,
+      ),
+    },
+  };
+};
+
+const updateQuestionListReaction = (
+  current: CommunityQnaQuestionListData | undefined,
+  questionId: number,
+  likeCount: number,
+): CommunityQnaQuestionListData | undefined => {
+  if (!current) {
+    return current;
+  }
+
+  return {
+    ...current,
+    items: current.items.map((question: CommunityQnaQuestionSummary) =>
+      question.id === questionId
+        ? { ...question, stats: { ...question.stats, likeCount } }
+        : question,
+    ),
+  };
+};
+
+export const useAssignCommunityQnaQuestionReactionMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ questionId, type }: { questionId: number; type: string }) =>
+      assignCommunityQnaQuestionReaction(questionId, { type }).then(
+        mapCommunityQnaReactionResult,
+      ),
+    onError: () => {},
+    onSuccess: (response, variables) => {
+      queryClient.setQueriesData<CommunityQnaQuestionDetailData>(
+        {
+          queryKey: communityQnaQueryKeys.questionDetailRoot(
+            variables.questionId,
+          ),
+        },
+        (current) =>
+          updateQuestionDetailReaction(
+            current,
+            response.likeCount,
+            response.reaction,
+          ),
+      );
+
+      queryClient.setQueriesData<CommunityQnaQuestionListData>(
+        { queryKey: communityQnaQueryKeys.questions() },
+        (current) =>
+          updateQuestionListReaction(
+            current,
+            variables.questionId,
+            response.likeCount,
+          ),
+      );
+    },
+  });
+};
+
+export const useAssignCommunityQnaAnswerReactionMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      questionId,
+      answerId,
+      type,
+    }: {
+      questionId: number;
+      answerId: number;
+      type: string;
+    }) =>
+      assignCommunityQnaAnswerReaction(answerId, { type }).then(
+        mapCommunityQnaReactionResult,
+      ),
+    onError: () => {},
+    onSuccess: (response, variables) => {
+      queryClient.setQueriesData<CommunityQnaQuestionDetailData>(
+        {
+          queryKey: communityQnaQueryKeys.questionDetailRoot(
+            variables.questionId,
+          ),
+        },
+        (current) =>
+          updateAnswerDetailReaction(
+            current,
+            variables.answerId,
+            response.likeCount,
+            response.reaction,
+          ),
+      );
     },
   });
 };

--- a/src/features/community/ui/community-comment-form.tsx
+++ b/src/features/community/ui/community-comment-form.tsx
@@ -40,47 +40,53 @@ export default function CommunityCommentForm({
   };
 
   return (
-    <div className={cn('flex items-start gap-150', isCompact && 'gap-100')}>
-      <Avatar image={authorImage} alt="댓글 작성자 프로필" size={36} />
+    <div
+      className={cn(
+        'border-b border-border-default pb-100 focus-within:border-border-brand',
+        disabled && 'border-border-disabled',
+      )}
+    >
+      <div className={cn('flex items-start gap-150', isCompact && 'gap-100')}>
+        <Avatar image={authorImage} alt="댓글 작성자 프로필" size={36} />
 
-      <div className="min-w-0 flex-1">
-        <textarea
-          value={value}
-          placeholder={placeholder}
-          rows={isCompact ? 2 : 1}
-          autoFocus={autoFocus}
-          disabled={disabled}
-          onChange={(event) => onChange(event.target.value)}
-          onFocus={() => setIsExpanded(true)}
-          onBlur={() => {
-            if (!isCompact && value.trim().length === 0) {
-              setIsExpanded(false);
-            }
-          }}
-          className={cn(
-            'w-full resize-none border-b border-border-default bg-transparent py-100 font-designer-15r leading-250 text-text-default placeholder:text-text-subtlest focus:border-border-brand focus:outline-none',
-            disabled &&
-              'cursor-not-allowed border-border-disabled text-text-disabled',
-          )}
-        />
+        <div className="min-w-0 flex-1">
+          <textarea
+            value={value}
+            placeholder={placeholder}
+            rows={isCompact ? 2 : 1}
+            autoFocus={autoFocus}
+            disabled={disabled}
+            onChange={(event) => onChange(event.target.value)}
+            onFocus={() => setIsExpanded(true)}
+            onBlur={() => {
+              if (!isCompact && value.trim().length === 0) {
+                setIsExpanded(false);
+              }
+            }}
+            className={cn(
+              'w-full resize-none bg-transparent py-100 font-designer-15r leading-250 text-text-default placeholder:text-text-subtlest focus:outline-none',
+              disabled && 'cursor-not-allowed text-text-disabled',
+            )}
+          />
 
-        {shouldShowActions ? (
-          <div className="mt-150 flex flex-wrap items-center justify-end gap-100">
-            {onCancel ? (
-              <Button color="secondary" size="small" onClick={handleCancel}>
-                취소
+          {shouldShowActions ? (
+            <div className="mt-150 flex flex-wrap items-center justify-end gap-100">
+              {onCancel ? (
+                <Button color="secondary" size="small" onClick={handleCancel}>
+                  취소
+                </Button>
+              ) : null}
+              <Button
+                color="primary"
+                size="small"
+                disabled={isSubmitDisabled}
+                onClick={onSubmit}
+              >
+                {submitLabel}
               </Button>
-            ) : null}
-            <Button
-              color="primary"
-              size="small"
-              disabled={isSubmitDisabled}
-              onClick={onSubmit}
-            >
-              {submitLabel}
-            </Button>
-          </div>
-        ) : null}
+            </div>
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/src/features/community/ui/community-comment-section.tsx
+++ b/src/features/community/ui/community-comment-section.tsx
@@ -75,7 +75,7 @@ export default function CommunityCommentSection({
 }: CommunityCommentSectionProps) {
   return (
     <CommunitySectionShell className="gap-250">
-      <div className="border-b border-border-default pb-150">
+      <div className="pb-150">
         <p className="font-designer-24b text-text-strong">
           댓글{' '}
           <span className="font-designer-13r text-text-subtle">

--- a/src/features/community/ui/community-comment-section.tsx
+++ b/src/features/community/ui/community-comment-section.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import Pagination from '@/components/common/ui/pagination';
+import { useToastStore } from '@/stores/use-toast-store';
 import type {
   CommunityComment,
   CommunityCommentReactionSelection,
@@ -8,6 +10,26 @@ import type {
 import CommunityCommentForm from './community-comment-form';
 import CommunityCommentItem from './community-comment-item';
 import CommunitySectionShell from './community-section-shell';
+import { getCommunityErrorMessage } from '../api/community-api';
+
+const findCommentById = (
+  comments: readonly CommunityComment[],
+  commentId: number,
+): CommunityComment | undefined => {
+  for (const comment of comments) {
+    if (comment.id === commentId) {
+      return comment;
+    }
+
+    const nestedComment = findCommentById(comment.replies, commentId);
+
+    if (nestedComment) {
+      return nestedComment;
+    }
+  }
+
+  return undefined;
+};
 
 interface CommunityCommentSectionProps {
   comments: readonly CommunityComment[];
@@ -15,28 +37,22 @@ interface CommunityCommentSectionProps {
   commentPlaceholder?: string;
   currentPage: number;
   errorMessage?: string;
+  isAuthenticated: boolean;
   isLoading?: boolean;
   isCommentDisabled?: boolean;
+  resetKey: number;
   showPagination: boolean;
   totalPages: number;
   viewerImage: string;
-  commentDraft: string;
-  editingCommentId?: number;
-  editingDraft: string;
-  replyDraft: string;
-  replyTargetId?: number;
-  onCancelEditing: () => void;
-  onCloseReply: () => void;
-  onCommentDraftChange: (nextValue: string) => void;
-  onDeleteComment: (commentId: number) => void;
-  onEditingDraftChange: (nextValue: string) => void;
-  onOpenReply: (commentId: number) => void;
-  onReplyDraftChange: (nextValue: string) => void;
-  onStartEditing: (commentId: number) => void;
-  onSubmitComment: () => void;
-  onSubmitEditedComment: () => void;
-  onSubmitReply: () => void;
   onChangePage: (page: number) => void;
+  onDeleteComment: (commentId: number) => Promise<void>;
+  onSubmitComment: (content: string) => Promise<void>;
+  onSubmitEditedComment: (
+    commentId: number,
+    revision: number,
+    content: string,
+  ) => Promise<void>;
+  onSubmitReply: (commentId: number, content: string) => Promise<void>;
   onToggleCommentReaction: (
     commentId: number,
     nextReaction: CommunityCommentReactionSelection,
@@ -49,30 +65,176 @@ export default function CommunityCommentSection({
   commentPlaceholder = '댓글을 남겨보세요.',
   currentPage,
   errorMessage,
+  isAuthenticated,
   isLoading = false,
   isCommentDisabled = false,
+  resetKey,
   showPagination,
   totalPages,
   viewerImage,
-  commentDraft,
-  editingCommentId,
-  editingDraft,
-  replyDraft,
-  replyTargetId,
-  onCancelEditing,
-  onCloseReply,
-  onCommentDraftChange,
+  onChangePage,
   onDeleteComment,
-  onEditingDraftChange,
-  onOpenReply,
-  onReplyDraftChange,
-  onStartEditing,
   onSubmitComment,
   onSubmitEditedComment,
   onSubmitReply,
-  onChangePage,
   onToggleCommentReaction,
 }: CommunityCommentSectionProps) {
+  const showToast = useToastStore((state) => state.showToast);
+  const [commentDraft, setCommentDraft] = useState('');
+  const [replyTargetId, setReplyTargetId] = useState<number | undefined>();
+  const [replyDraft, setReplyDraft] = useState('');
+  const [editingCommentId, setEditingCommentId] = useState<
+    number | undefined
+  >();
+  const [editingDraft, setEditingDraft] = useState('');
+
+  useEffect(() => {
+    setCommentDraft('');
+    setReplyTargetId(undefined);
+    setReplyDraft('');
+    setEditingCommentId(undefined);
+    setEditingDraft('');
+  }, [resetKey]);
+
+  useEffect(() => {
+    if (replyTargetId && !findCommentById(comments, replyTargetId)) {
+      setReplyTargetId(undefined);
+      setReplyDraft('');
+    }
+
+    if (editingCommentId && !findCommentById(comments, editingCommentId)) {
+      setEditingCommentId(undefined);
+      setEditingDraft('');
+    }
+  }, [comments, editingCommentId, replyTargetId]);
+
+  const handleSubmitComment = async () => {
+    const normalizedContent = commentDraft.trim();
+
+    if (!normalizedContent) {
+      return;
+    }
+
+    try {
+      await onSubmitComment(normalizedContent);
+      setCommentDraft('');
+    } catch (error) {
+      showToast(
+        getCommunityErrorMessage(error, '댓글 등록에 실패했습니다.'),
+        'error',
+      );
+    }
+  };
+
+  const handleOpenReply = (commentId: number) => {
+    const targetComment = findCommentById(comments, commentId);
+
+    if (!targetComment?.canReply) {
+      if (!isAuthenticated) {
+        showToast('로그인 후 답글을 작성할 수 있습니다.', 'info');
+      }
+
+      return;
+    }
+
+    setReplyTargetId(commentId);
+    setReplyDraft('');
+    setEditingCommentId(undefined);
+    setEditingDraft('');
+  };
+
+  const handleCloseReply = () => {
+    setReplyTargetId(undefined);
+    setReplyDraft('');
+  };
+
+  const handleSubmitReply = async () => {
+    const normalizedContent = replyDraft.trim();
+
+    if (!replyTargetId || !normalizedContent) {
+      return;
+    }
+
+    try {
+      await onSubmitReply(replyTargetId, normalizedContent);
+      setReplyDraft('');
+      setReplyTargetId(undefined);
+    } catch (error) {
+      showToast(
+        getCommunityErrorMessage(error, '답글 등록에 실패했습니다.'),
+        'error',
+      );
+    }
+  };
+
+  const handleStartEditing = (commentId: number) => {
+    const targetComment = findCommentById(comments, commentId);
+
+    if (!targetComment?.canEdit) {
+      return;
+    }
+
+    setEditingCommentId(commentId);
+    setEditingDraft(targetComment.content);
+    setReplyTargetId(undefined);
+    setReplyDraft('');
+  };
+
+  const handleCancelEditing = () => {
+    setEditingCommentId(undefined);
+    setEditingDraft('');
+  };
+
+  const handleSubmitEditedComment = async () => {
+    const normalizedContent = editingDraft.trim();
+
+    if (!editingCommentId || !normalizedContent) {
+      return;
+    }
+
+    const targetComment = findCommentById(comments, editingCommentId);
+
+    if (!targetComment?.revision) {
+      return;
+    }
+
+    try {
+      await onSubmitEditedComment(
+        editingCommentId,
+        targetComment.revision,
+        normalizedContent,
+      );
+      setEditingCommentId(undefined);
+      setEditingDraft('');
+    } catch (error) {
+      showToast(
+        getCommunityErrorMessage(error, '댓글 수정에 실패했습니다.'),
+        'error',
+      );
+    }
+  };
+
+  const handleDeleteComment = async (commentId: number) => {
+    try {
+      await onDeleteComment(commentId);
+
+      if (editingCommentId === commentId) {
+        setEditingCommentId(undefined);
+        setEditingDraft('');
+      }
+
+      if (replyTargetId === commentId) {
+        setReplyTargetId(undefined);
+        setReplyDraft('');
+      }
+    } catch (error) {
+      showToast(
+        getCommunityErrorMessage(error, '댓글 삭제에 실패했습니다.'),
+        'error',
+      );
+    }
+  };
+
   return (
     <CommunitySectionShell className="gap-250">
       <div className="pb-150">
@@ -90,8 +252,8 @@ export default function CommunityCommentSection({
         submitLabel="등록하기"
         value={commentDraft}
         disabled={isCommentDisabled}
-        onChange={onCommentDraftChange}
-        onSubmit={onSubmitComment}
+        onChange={setCommentDraft}
+        onSubmit={handleSubmitComment}
       />
 
       {errorMessage ? (
@@ -113,15 +275,15 @@ export default function CommunityCommentSection({
               editingDraft={editingDraft}
               replyDraft={replyDraft}
               replyTargetId={replyTargetId}
-              onCancelEditing={onCancelEditing}
-              onCloseReply={onCloseReply}
-              onDeleteComment={onDeleteComment}
-              onEditingDraftChange={onEditingDraftChange}
-              onOpenReply={onOpenReply}
-              onReplyDraftChange={onReplyDraftChange}
-              onStartEditing={onStartEditing}
-              onSubmitEditedComment={onSubmitEditedComment}
-              onSubmitReply={onSubmitReply}
+              onCancelEditing={handleCancelEditing}
+              onCloseReply={handleCloseReply}
+              onDeleteComment={handleDeleteComment}
+              onEditingDraftChange={setEditingDraft}
+              onOpenReply={handleOpenReply}
+              onReplyDraftChange={setReplyDraft}
+              onStartEditing={handleStartEditing}
+              onSubmitEditedComment={handleSubmitEditedComment}
+              onSubmitReply={handleSubmitReply}
               onToggleCommentReaction={onToggleCommentReaction}
             />
           ))}

--- a/src/features/community/ui/community-detail-body-section.tsx
+++ b/src/features/community/ui/community-detail-body-section.tsx
@@ -75,7 +75,7 @@ function CommunityDetailBodySection({
           {content.map((paragraph, index) => (
             <p
               key={`${postId}-${index}`}
-              className="font-designer-16r leading-300 text-text-default"
+              className="font-designer-20r leading-400 text-text-default"
             >
               {paragraph}
             </p>

--- a/src/features/community/ui/community-feed-section.tsx
+++ b/src/features/community/ui/community-feed-section.tsx
@@ -161,6 +161,7 @@ export default function CommunityFeedSection({
               {featuredTopPosts.map((post, index) => (
                 <CommunityPostCard
                   key={post.id}
+                  activeFilter={activeFilter}
                   currentPage={currentPage}
                   featuredLabel={`TOP ${index + 1}`}
                   post={post}
@@ -173,6 +174,7 @@ export default function CommunityFeedSection({
               {featuredTopPosts.map((post, index) => (
                 <CommunityPostListItem
                   key={post.id}
+                  activeFilter={activeFilter}
                   currentPage={currentPage}
                   featuredFrame={true}
                   featuredLabel={`TOP ${index + 1}`}
@@ -205,6 +207,7 @@ export default function CommunityFeedSection({
             {qnaQuestions.map((question) => (
               <CommunityQnaQuestionListItem
                 key={question.id}
+                activeFilter={activeFilter}
                 currentPage={currentPage}
                 question={question}
               />
@@ -215,6 +218,7 @@ export default function CommunityFeedSection({
             {posts.map((post) => (
               <CommunityPostListItem
                 key={post.id}
+                activeFilter={activeFilter}
                 currentPage={currentPage}
                 post={post}
               />
@@ -240,6 +244,7 @@ export default function CommunityFeedSection({
           {qnaQuestions.map((question) => (
             <CommunityQnaQuestionCard
               key={question.id}
+              activeFilter={activeFilter}
               currentPage={currentPage}
               question={question}
             />
@@ -250,6 +255,7 @@ export default function CommunityFeedSection({
           {posts.map((post) => (
             <CommunityPostCard
               key={post.id}
+              activeFilter={activeFilter}
               currentPage={currentPage}
               post={post}
             />

--- a/src/features/community/ui/community-post-card.tsx
+++ b/src/features/community/ui/community-post-card.tsx
@@ -18,6 +18,7 @@ import CommunityPostOwnerActions from './community-post-owner-actions';
 import CommunityPostStats from './community-post-stats';
 
 interface CommunityPostCardProps {
+  activeFilter?: string;
   currentPage?: number;
   featuredLabel?: string;
   post: CommunityPost;
@@ -25,6 +26,7 @@ interface CommunityPostCardProps {
 }
 
 export default function CommunityPostCard({
+  activeFilter,
   currentPage,
   featuredLabel,
   post,
@@ -36,6 +38,7 @@ export default function CommunityPostCard({
     post.id,
     post.board,
     currentPage,
+    activeFilter,
   );
 
   const handleCardClick = (event: MouseEvent<HTMLElement>) => {

--- a/src/features/community/ui/community-post-list-item.tsx
+++ b/src/features/community/ui/community-post-list-item.tsx
@@ -21,6 +21,7 @@ import CommunityPostOwnerActions from './community-post-owner-actions';
 import CommunityPostStats from './community-post-stats';
 
 interface CommunityPostListItemProps {
+  activeFilter?: string;
   currentPage?: number;
   featuredFrame?: boolean;
   featuredLabel?: string;
@@ -29,6 +30,7 @@ interface CommunityPostListItemProps {
 }
 
 export default function CommunityPostListItem({
+  activeFilter,
   currentPage,
   featuredFrame = false,
   featuredLabel,
@@ -44,6 +46,7 @@ export default function CommunityPostListItem({
     post.id,
     post.board,
     currentPage,
+    activeFilter,
   );
   const mediaBadge =
     featuredLabel || showBoardBadge ? (

--- a/src/features/community/ui/community-qna-answer-item.tsx
+++ b/src/features/community/ui/community-qna-answer-item.tsx
@@ -10,6 +10,7 @@ import CommunityQnaAuthorSummary from './community-qna-author-summary';
 interface CommunityQnaAnswerItemProps {
   answer: CommunityQnaAnswerItemType;
   actionSlot?: ReactNode;
+  reactionSlot?: ReactNode;
   isMine?: boolean;
   commentSection?: ReactNode;
 }
@@ -17,6 +18,7 @@ interface CommunityQnaAnswerItemProps {
 export default function CommunityQnaAnswerItem({
   answer,
   actionSlot,
+  reactionSlot,
   isMine = false,
   commentSection,
 }: CommunityQnaAnswerItemProps) {
@@ -52,6 +54,8 @@ export default function CommunityQnaAnswerItem({
         />
 
         <CommunityMarkdownContent content={answer.contentHtml} />
+
+        {reactionSlot}
 
         {commentSection}
       </div>

--- a/src/features/community/ui/community-qna-question-card.tsx
+++ b/src/features/community/ui/community-qna-question-card.tsx
@@ -6,7 +6,11 @@ import { useRouter } from 'next/navigation';
 import { useState, type MouseEvent } from 'react';
 import Avatar from '@/components/common/ui/avatar';
 import { buildCommunityQuestionHref } from '@/features/community/model/community-route';
-import { COMMUNITY_BOARD } from '@/types/community/domain';
+import {
+  COMMUNITY_BOARD,
+  type CommunityBoard,
+  isCommunityBoard,
+} from '@/types/community/domain';
 import type { CommunityQnaQuestionSummary } from '@/types/community/qna-domain';
 import CommunityAuthorNameTrigger from './community-author-name-trigger';
 import { isCommunityCardNestedInteraction } from './community-card-navigation';
@@ -20,6 +24,7 @@ import {
 } from './community-qna-question-meta';
 
 interface CommunityQnaQuestionCardProps {
+  activeFilter?: string;
   currentPage?: number;
   question: CommunityQnaQuestionSummary;
 }
@@ -77,6 +82,7 @@ const isAllowedCommunityPreviewImageSrc = (value?: string) => {
 };
 
 export default function CommunityQnaQuestionCard({
+  activeFilter,
   currentPage,
   question,
 }: CommunityQnaQuestionCardProps) {
@@ -84,7 +90,13 @@ export default function CommunityQnaQuestionCard({
   const [failedPreviewImageSrc, setFailedPreviewImageSrc] = useState<
     string | undefined
   >();
-  const detailHref = buildCommunityQuestionHref(question.id, currentPage);
+  const resolvedBoard: CommunityBoard | undefined =
+    activeFilter && isCommunityBoard(activeFilter) ? activeFilter : undefined;
+  const detailHref = buildCommunityQuestionHref(
+    question.id,
+    currentPage,
+    resolvedBoard,
+  );
   const previewImageSrc = isAllowedCommunityPreviewImageSrc(
     question.previewImage,
   )

--- a/src/features/community/ui/community-qna-question-list-item.tsx
+++ b/src/features/community/ui/community-qna-question-list-item.tsx
@@ -80,7 +80,7 @@ export default function CommunityQnaQuestionListItem({
             </div>
           ) : (
             <div className="flex h-600 w-600 items-center justify-center rounded-150 border border-border-default bg-background-default">
-              <CircleHelp className="h-225 w-225 text-text-brand" />
+              <CircleHelp className="h-225 w-225 text-text-subtle" />
             </div>
           )}
         </Link>

--- a/src/features/community/ui/community-qna-question-list-item.tsx
+++ b/src/features/community/ui/community-qna-question-list-item.tsx
@@ -6,6 +6,10 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import type { MouseEvent } from 'react';
 import { buildCommunityQuestionHref } from '@/features/community/model/community-route';
+import {
+  type CommunityBoard,
+  isCommunityBoard,
+} from '@/types/community/domain';
 import { COMMUNITY_BOARD } from '@/types/community/domain';
 import type { CommunityQnaQuestionSummary } from '@/types/community/qna-domain';
 import { isCommunityCardNestedInteraction } from './community-card-navigation';
@@ -18,16 +22,24 @@ import {
 } from './community-qna-question-meta';
 
 interface CommunityQnaQuestionListItemProps {
+  activeFilter?: string;
   currentPage?: number;
   question: CommunityQnaQuestionSummary;
 }
 
 export default function CommunityQnaQuestionListItem({
+  activeFilter,
   currentPage,
   question,
 }: CommunityQnaQuestionListItemProps) {
   const router = useRouter();
-  const detailHref = buildCommunityQuestionHref(question.id, currentPage);
+  const resolvedBoard: CommunityBoard | undefined =
+    activeFilter && isCommunityBoard(activeFilter) ? activeFilter : undefined;
+  const detailHref = buildCommunityQuestionHref(
+    question.id,
+    currentPage,
+    resolvedBoard,
+  );
 
   const handleCardClick = (event: MouseEvent<HTMLElement>) => {
     if (isCommunityCardNestedInteraction(event.target)) {

--- a/src/features/community/ui/community-qna-question-meta.tsx
+++ b/src/features/community/ui/community-qna-question-meta.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CheckCircle2, Eye, MessageCircle } from 'lucide-react';
+import { CheckCircle2, Eye, Heart, MessageCircle } from 'lucide-react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import Badge from '@/components/common/ui/badge';
 import type { CommunityQnaQuestionSummary } from '@/types/community/qna-domain';
@@ -61,6 +61,12 @@ export function CommunityQnaQuestionStats({
         <MessageCircle className="h-200 w-200" />
         {formatCompactCount(question.stats.answerCount)}
       </span>
+      {question.stats.likeCount > 0 ? (
+        <span className="flex items-center gap-50">
+          <Heart className="h-200 w-200" />
+          {formatCompactCount(question.stats.likeCount)}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/src/features/community/ui/community-reaction-button.tsx
+++ b/src/features/community/ui/community-reaction-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ThumbsUp } from 'lucide-react';
+import { Heart } from 'lucide-react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 
 interface CommunityReactionButtonProps {
@@ -26,17 +26,15 @@ export default function CommunityReactionButton({
       aria-label={ariaLabel}
       aria-pressed={isActive}
       className={cn(
-        'inline-flex items-center gap-75 font-designer-13m transition-colors focus-visible:ring-fill-brand-default-default focus-visible:ring-offset-background-default rounded-50 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:text-text-disabled',
+        'inline-flex items-center gap-75 font-designer-14m transition-colors focus-visible:ring-fill-brand-default-default focus-visible:ring-offset-background-default rounded-100 p-100 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:text-text-disabled',
         isActive
           ? 'text-text-brand'
           : 'text-text-subtle hover:text-text-default',
       )}
     >
-      <span className="flex items-center">
-        <ThumbsUp
-          className={cn('h-16 w-16 shrink-0', isActive && 'fill-current')}
-        />
-      </span>
+      <Heart
+        className={cn('h-200 w-200 shrink-0', isActive && 'fill-current')}
+      />
       <span>{count.toLocaleString()}</span>
     </button>
   );

--- a/src/features/community/ui/pages/community-detail-page-client.tsx
+++ b/src/features/community/ui/pages/community-detail-page-client.tsx
@@ -124,7 +124,7 @@ export default function CommunityDetailPageClient({
           커뮤니티로 돌아가기
         </Link>
 
-        <div className="self-start">
+        <div className="mt-50 self-start">
           <CommunityBoardBadge board={state.post.board} />
         </div>
 
@@ -202,28 +202,18 @@ export default function CommunityDetailPageClient({
         }
         currentPage={viewModel.currentCommentsPage}
         errorMessage={state.commentsErrorMessage}
+        isAuthenticated={state.isAuthenticated}
         isLoading={state.isCommentsLoading}
         isCommentDisabled={!state.isAuthenticated}
+        resetKey={state.commentInteractionResetKey}
         showPagination={viewModel.showCommentPagination}
         totalPages={viewModel.totalCommentPages}
         viewerImage={viewerImage ?? '/profile-default.svg'}
-        commentDraft={state.commentDraft}
-        editingCommentId={state.editingCommentId}
-        editingDraft={state.editingDraft}
-        replyDraft={state.replyDraft}
-        replyTargetId={state.replyTargetId}
-        onCancelEditing={actions.handleCancelEditingComment}
-        onCloseReply={actions.handleCloseReply}
-        onCommentDraftChange={actions.handleCommentDraftChange}
+        onChangePage={actions.handleCommentPageChange}
         onDeleteComment={actions.handleDeleteComment}
-        onEditingDraftChange={actions.handleEditingDraftChange}
-        onOpenReply={actions.handleOpenReply}
-        onReplyDraftChange={actions.handleReplyDraftChange}
-        onStartEditing={actions.handleStartEditingComment}
         onSubmitComment={actions.handleSubmitComment}
         onSubmitEditedComment={actions.handleSubmitEditedComment}
         onSubmitReply={actions.handleSubmitReply}
-        onChangePage={actions.handleCommentPageChange}
         onToggleCommentReaction={actions.handleToggleCommentReaction}
       />
 

--- a/src/features/community/ui/pages/community-detail-page-client.tsx
+++ b/src/features/community/ui/pages/community-detail-page-client.tsx
@@ -1,18 +1,22 @@
 'use client';
 
-import { ChevronLeft } from 'lucide-react';
+import { ChevronLeft, Eye, MessageCircle, Share } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import Avatar from '@/components/common/ui/avatar';
 import PageContainer from '@/components/common/ui/page-container';
 import { buildCommunityListHref } from '@/features/community/model/community-route';
 import { useCommunityDetailController } from '@/features/community/model/use-community-detail-controller';
 import { useIntersectionObserver } from '@/hooks/common/use-intersection-observer';
 import { useUserStore } from '@/stores/useUserStore';
-import CommunityAuthorProfileCard from '../community-author-profile-card';
+import CommunityAuthorNameTrigger from '../community-author-name-trigger';
 import CommunityCommentSection from '../community-comment-section';
 import CommunityDetailBodySection from '../community-detail-body-section';
 import CommunityDetailFeedSection from '../community-detail-feed-section';
-import { CommunityBoardBadge } from '../community-meta-badge';
+import {
+  CommunityBoardBadge,
+  CommunityMemberRoleBadge,
+} from '../community-meta-badge';
 import CommunityPostOwnerActions from '../community-post-owner-actions';
 import CommunityReactionButton from '../community-reaction-button';
 import CommunitySectionShell from '../community-section-shell';
@@ -111,7 +115,7 @@ export default function CommunityDetailPageClient({
 
   return (
     <PageContainer className="flex flex-col gap-400 xl:gap-500">
-      <CommunitySectionShell className="gap-250 border-b border-border-default pb-300">
+      <CommunitySectionShell className="gap-200 border-b border-border-default pb-300">
         <Link
           href={backHref}
           className="inline-flex items-center gap-75 font-designer-14m text-text-subtle transition-colors hover:text-text-default"
@@ -120,41 +124,44 @@ export default function CommunityDetailPageClient({
           커뮤니티로 돌아가기
         </Link>
 
-        <div className="flex flex-wrap items-center gap-100">
+        <div className="self-start">
           <CommunityBoardBadge board={state.post.board} />
-          <span className="font-designer-14r text-text-subtlest">
-            {state.post.createdAt}
-          </span>
         </div>
 
-        <div className="flex flex-col gap-200">
-          <div className="flex items-start justify-between gap-150">
-            <h1 className="min-w-0 flex-1 font-designer-28b text-text-strong">
-              {state.post.title}
-            </h1>
-            <CommunityPostOwnerActions
-              currentPage={returnPage}
-              post={state.post}
-            />
-          </div>
+        <div className="flex items-start justify-between gap-150">
+          <h1 className="min-w-0 flex-1 font-designer-32b text-text-strong">
+            {state.post.title}
+          </h1>
+          <CommunityPostOwnerActions
+            currentPage={returnPage}
+            post={state.post}
+          />
+        </div>
 
-          <CommunityAuthorProfileCard post={state.post} />
-
-          <div className="flex flex-wrap items-center gap-150">
-            <span className="font-designer-14r text-text-subtle">
-              조회 {state.post.viewCount}
-            </span>
-            <span className="font-designer-14r text-text-subtle">
-              댓글 {viewModel.commentCount}
-            </span>
-            <CommunityReactionButton
-              isActive={viewModel.isLikedByViewer}
-              count={viewModel.reactionCount}
-              onClick={actions.handleToggleLike}
-              disabled={!viewModel.isPostReactionEnabled}
-              ariaLabel={viewModel.isLikedByViewer ? '좋아요 취소' : '좋아요'}
-            />
-          </div>
+        <div className="flex flex-wrap items-center gap-100 font-designer-14r text-text-subtle">
+          <Avatar
+            image={state.post.authorImage}
+            alt={state.post.authorName}
+            size={24}
+          />
+          <CommunityAuthorNameTrigger
+            memberId={state.post.authorMemberId}
+            name={state.post.authorName}
+            className="font-designer-14m text-text-default"
+          />
+          <CommunityMemberRoleBadge role={state.post.role} />
+          <span className="text-text-subtlest">·</span>
+          <span>{state.post.createdAt}</span>
+          <span className="text-text-subtlest">·</span>
+          <span className="flex items-center gap-50">
+            <Eye className="h-200 w-200" />
+            {state.post.viewCount}
+          </span>
+          <span className="text-text-subtlest">·</span>
+          <span className="flex items-center gap-50">
+            <MessageCircle className="h-200 w-200" />
+            {viewModel.commentCount}
+          </span>
         </div>
       </CommunitySectionShell>
 
@@ -166,6 +173,24 @@ export default function CommunityDetailPageClient({
         previewImage={state.post.previewImage}
         previewImageAlt={state.post.previewImageAlt}
       />
+
+      <div className="flex items-center gap-200 self-start rounded-100">
+        <CommunityReactionButton
+          isActive={viewModel.isLikedByViewer}
+          count={viewModel.reactionCount}
+          onClick={actions.handleToggleLike}
+          disabled={!viewModel.isPostReactionEnabled}
+          ariaLabel={viewModel.isLikedByViewer ? '좋아요 취소' : '좋아요'}
+        />
+        <button
+          type="button"
+          onClick={actions.handleSharePost}
+          className="inline-flex items-center gap-75 font-designer-14m text-text-subtle transition-colors hover:text-text-default"
+        >
+          <Share className="h-200 w-200" />
+          공유
+        </button>
+      </div>
 
       <CommunityCommentSection
         comments={viewModel.comments}

--- a/src/features/community/ui/pages/community-detail-page-client.tsx
+++ b/src/features/community/ui/pages/community-detail-page-client.tsx
@@ -124,7 +124,7 @@ export default function CommunityDetailPageClient({
           커뮤니티로 돌아가기
         </Link>
 
-        <div className="mt-100 self-start">
+        <div className="mt-200 self-start">
           <CommunityBoardBadge board={state.post.board} />
         </div>
 

--- a/src/features/community/ui/pages/community-detail-page-client.tsx
+++ b/src/features/community/ui/pages/community-detail-page-client.tsx
@@ -179,7 +179,6 @@ export default function CommunityDetailPageClient({
           isActive={viewModel.isLikedByViewer}
           count={viewModel.reactionCount}
           onClick={actions.handleToggleLike}
-          disabled={!viewModel.isPostReactionEnabled}
           ariaLabel={viewModel.isLikedByViewer ? '좋아요 취소' : '좋아요'}
         />
         <button

--- a/src/features/community/ui/pages/community-detail-page-client.tsx
+++ b/src/features/community/ui/pages/community-detail-page-client.tsx
@@ -9,6 +9,7 @@ import { buildCommunityListHref } from '@/features/community/model/community-rou
 import { useCommunityDetailController } from '@/features/community/model/use-community-detail-controller';
 import { useIntersectionObserver } from '@/hooks/common/use-intersection-observer';
 import { useUserStore } from '@/stores/useUserStore';
+import type { CommunityBoard } from '@/types/community/domain';
 import CommunityAuthorNameTrigger from '../community-author-name-trigger';
 import CommunityCommentSection from '../community-comment-section';
 import CommunityDetailBodySection from '../community-detail-body-section';
@@ -23,11 +24,13 @@ import CommunitySectionShell from '../community-section-shell';
 
 interface CommunityDetailPageClientProps {
   postId: number;
+  returnBoard?: CommunityBoard;
   returnPage?: number;
 }
 
 export default function CommunityDetailPageClient({
   postId,
+  returnBoard,
   returnPage,
 }: CommunityDetailPageClientProps) {
   const { state, actions, viewModel } = useCommunityDetailController({
@@ -35,7 +38,7 @@ export default function CommunityDetailPageClient({
   });
   const viewerImage = useUserStore((store) => store.profileImageUrl);
   const [isFeedVisible, setIsFeedVisible] = useState(false);
-  const backHref = buildCommunityListHref(returnPage);
+  const backHref = buildCommunityListHref(returnPage, returnBoard);
   const feedTriggerRef = useIntersectionObserver(
     () => {
       setIsFeedVisible(true);

--- a/src/features/community/ui/pages/community-detail-page-client.tsx
+++ b/src/features/community/ui/pages/community-detail-page-client.tsx
@@ -124,7 +124,7 @@ export default function CommunityDetailPageClient({
           커뮤니티로 돌아가기
         </Link>
 
-        <div className="mt-50 self-start">
+        <div className="mt-100 self-start">
           <CommunityBoardBadge board={state.post.board} />
         </div>
 

--- a/src/features/community/ui/pages/community-qna-detail-page-client.tsx
+++ b/src/features/community/ui/pages/community-qna-detail-page-client.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { ChevronLeft } from 'lucide-react';
+import { ChevronLeft, Eye, MessageCircle } from 'lucide-react';
 import Link from 'next/link';
+import Avatar from '@/components/common/ui/avatar';
 import PageContainer from '@/components/common/ui/page-container';
 import Pagination from '@/components/common/ui/pagination';
 import { buildCommunityListHref } from '@/features/community/model/community-route';
@@ -9,13 +10,16 @@ import { useCommunityQnaDetailController } from '@/features/community/model/use-
 import { useUserStore } from '@/stores/useUserStore';
 import { COMMUNITY_BOARD } from '@/types/community/domain';
 import { ErrorType } from '@/utils/error-handler';
+import CommunityAuthorNameTrigger from '../community-author-name-trigger';
 import CommunityMarkdownContent from '../community-markdown-content';
-import { CommunityBoardBadge } from '../community-meta-badge';
+import {
+  CommunityBoardBadge,
+  CommunityMemberRoleBadge,
+} from '../community-meta-badge';
 import CommunityQnaAnswerAcceptanceActions from '../community-qna-answer-acceptance-actions';
 import CommunityQnaAnswerCommentsSection from '../community-qna-answer-comments-section';
 import CommunityQnaAnswerComposeSection from '../community-qna-answer-compose-section';
 import CommunityQnaAnswerItem from '../community-qna-answer-item';
-import CommunityQnaAuthorSummary from '../community-qna-author-summary';
 import CommunityQnaQuestionCommentsSection from '../community-qna-question-comments-section';
 import CommunityQnaQuestionOwnerActions from '../community-qna-question-owner-actions';
 import {
@@ -23,6 +27,7 @@ import {
   CommunityQnaRouteErrorState,
   CommunityQnaRouteLoading,
 } from '../community-qna-route-fallback';
+import CommunityReactionButton from '../community-reaction-button';
 import CommunitySectionShell from '../community-section-shell';
 
 interface CommunityQnaDetailPageClientProps {
@@ -84,7 +89,7 @@ export default function CommunityQnaDetailPageClient({
 
   return (
     <PageContainer className="flex flex-col gap-400 xl:gap-500">
-      <CommunitySectionShell className="gap-250 border-b border-border-default pb-300">
+      <CommunitySectionShell className="gap-200 border-b border-border-default pb-300">
         <Link
           href={backHref}
           className="inline-flex items-center gap-75 font-designer-14m text-text-subtle transition-colors hover:text-text-default"
@@ -93,8 +98,35 @@ export default function CommunityQnaDetailPageClient({
           커뮤니티로 돌아가기
         </Link>
 
-        <div className="flex flex-wrap items-center gap-100">
+        <div className="mt-200 self-start">
           <CommunityBoardBadge board={COMMUNITY_BOARD.QNA} showIcon={false} />
+        </div>
+
+        <div className="flex items-start justify-between gap-150">
+          <h1 className="min-w-0 flex-1 font-designer-32b text-text-strong">
+            {state.question.title}
+          </h1>
+          <CommunityQnaQuestionOwnerActions
+            canDelete={state.viewer.canDeleteQuestion}
+            canEdit={state.viewer.canEditQuestion}
+            currentPage={returnPage}
+            questionId={state.question.id}
+            revision={state.question.revision}
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-100 font-designer-14r text-text-subtle">
+          <Avatar
+            image={state.question.author.profileImageUrl}
+            alt={state.question.author.name}
+            size={24}
+          />
+          <CommunityAuthorNameTrigger
+            memberId={state.question.author.memberId}
+            name={state.question.author.name}
+            className="font-designer-14m text-text-default"
+          />
+          <CommunityMemberRoleBadge role={state.question.author.role} />
           {state.question.acceptedAnswerId ? (
             <span className="rounded-full bg-fill-brand-subtle-default px-100 py-50 font-designer-12b text-text-brand">
               채택 완료
@@ -104,40 +136,35 @@ export default function CommunityQnaDetailPageClient({
               답변 대기
             </span>
           )}
-          <span className="font-designer-14r text-text-subtlest">
-            {state.question.createdAt}
+          <span className="text-text-subtlest">·</span>
+          <span>{state.question.createdAt}</span>
+          <span className="text-text-subtlest">·</span>
+          <span className="flex items-center gap-50">
+            <Eye className="h-200 w-200" />
+            {state.question.stats.viewCount}
           </span>
-        </div>
-
-        <div className="flex flex-col gap-200">
-          <div className="flex items-start justify-between gap-150">
-            <h1 className="font-designer-28b text-text-strong">
-              {state.question.title}
-            </h1>
-            <CommunityQnaQuestionOwnerActions
-              canDelete={state.viewer.canDeleteQuestion}
-              canEdit={state.viewer.canEditQuestion}
-              currentPage={returnPage}
-              questionId={state.question.id}
-              revision={state.question.revision}
-            />
-          </div>
-
-          <CommunityQnaAuthorSummary author={state.question.author} />
-
-          <div className="flex flex-wrap items-center gap-150">
-            <span className="font-designer-14r text-text-subtle">
-              조회 {state.question.stats.viewCount}
-            </span>
-            <span className="font-designer-14r text-text-subtle">
-              답변 {state.question.stats.answerCount}
-            </span>
-          </div>
+          <span className="text-text-subtlest">·</span>
+          <span className="flex items-center gap-50">
+            <MessageCircle className="h-200 w-200" />
+            {state.question.stats.answerCount}
+          </span>
         </div>
       </CommunitySectionShell>
 
       <CommunitySectionShell className="gap-300">
         <CommunityMarkdownContent content={state.question.contentHtml} />
+
+        <div className="self-start">
+          <CommunityReactionButton
+            isActive={viewModel.isQuestionLikedByViewer}
+            count={viewModel.questionLikeCount}
+            onClick={actions.handleToggleQuestionLike}
+            disabled={viewModel.isQuestionReactionPending}
+            ariaLabel={
+              viewModel.isQuestionLikedByViewer ? '좋아요 취소' : '좋아요'
+            }
+          />
+        </div>
 
         <CommunityQnaQuestionCommentsSection
           comments={state.questionCommentsPageData?.items ?? []}
@@ -231,6 +258,21 @@ export default function CommunityQnaDetailPageClient({
                     <CommunityQnaAnswerItem
                       key={answer.id}
                       answer={answer}
+                      reactionSlot={
+                        <CommunityReactionButton
+                          isActive={answer.viewer.reaction === 'like'}
+                          count={answer.stats.likeCount}
+                          onClick={() =>
+                            actions.handleToggleAnswerLike(answer.id)
+                          }
+                          disabled={viewModel.isAnswerReactionPending}
+                          ariaLabel={
+                            answer.viewer.reaction === 'like'
+                              ? '좋아요 취소'
+                              : '좋아요'
+                          }
+                        />
+                      }
                       actionSlot={
                         isMyAnswer || canAcceptThisAnswer ? (
                           <div className="flex flex-wrap items-center justify-end gap-75">

--- a/src/features/community/ui/pages/community-qna-detail-page-client.tsx
+++ b/src/features/community/ui/pages/community-qna-detail-page-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronLeft, Eye, MessageCircle } from 'lucide-react';
+import { ChevronLeft, Eye, MessageCircle, Share } from 'lucide-react';
 import Link from 'next/link';
 import Avatar from '@/components/common/ui/avatar';
 import PageContainer from '@/components/common/ui/page-container';
@@ -154,7 +154,7 @@ export default function CommunityQnaDetailPageClient({
       <CommunitySectionShell className="gap-300">
         <CommunityMarkdownContent content={state.question.contentHtml} />
 
-        <div className="self-start">
+        <div className="flex items-center gap-200 self-start rounded-100">
           <CommunityReactionButton
             isActive={viewModel.isQuestionLikedByViewer}
             count={viewModel.questionLikeCount}
@@ -164,6 +164,14 @@ export default function CommunityQnaDetailPageClient({
               viewModel.isQuestionLikedByViewer ? '좋아요 취소' : '좋아요'
             }
           />
+          <button
+            type="button"
+            onClick={actions.handleShareQuestion}
+            className="inline-flex items-center gap-75 font-designer-14m text-text-subtle transition-colors hover:text-text-default"
+          >
+            <Share className="h-200 w-200" />
+            공유
+          </button>
         </div>
 
         <CommunityQnaQuestionCommentsSection

--- a/src/features/community/ui/pages/community-qna-detail-page-client.tsx
+++ b/src/features/community/ui/pages/community-qna-detail-page-client.tsx
@@ -8,7 +8,7 @@ import Pagination from '@/components/common/ui/pagination';
 import { buildCommunityListHref } from '@/features/community/model/community-route';
 import { useCommunityQnaDetailController } from '@/features/community/model/use-community-qna-detail-controller';
 import { useUserStore } from '@/stores/useUserStore';
-import { COMMUNITY_BOARD } from '@/types/community/domain';
+import { COMMUNITY_BOARD, type CommunityBoard } from '@/types/community/domain';
 import { ErrorType } from '@/utils/error-handler';
 import CommunityAuthorNameTrigger from '../community-author-name-trigger';
 import CommunityMarkdownContent from '../community-markdown-content';
@@ -32,6 +32,7 @@ import CommunitySectionShell from '../community-section-shell';
 
 interface CommunityQnaDetailPageClientProps {
   questionId: number;
+  returnBoard?: CommunityBoard;
   returnPage?: number;
   initialAnswerPage?: number;
   initialCommentPage?: number;
@@ -39,6 +40,7 @@ interface CommunityQnaDetailPageClientProps {
 
 export default function CommunityQnaDetailPageClient({
   questionId,
+  returnBoard,
   returnPage,
   initialAnswerPage,
   initialCommentPage,
@@ -49,7 +51,7 @@ export default function CommunityQnaDetailPageClient({
     initialCommentPage,
   });
   const viewerImage = useUserStore((store) => store.profileImageUrl);
-  const backHref = buildCommunityListHref(returnPage);
+  const backHref = buildCommunityListHref(returnPage, returnBoard);
 
   if (!state.isResolved) {
     return <CommunityQnaRouteLoading />;

--- a/src/types/community/qna-domain.ts
+++ b/src/types/community/qna-domain.ts
@@ -29,6 +29,7 @@ export interface CommunityQnaQuestionStats {
   viewCount: number;
   answerCount: number;
   questionCommentCount: number;
+  likeCount: number;
 }
 
 export interface CommunityQnaQuestionSummary {
@@ -68,6 +69,7 @@ export interface CommunityQnaQuestionViewer {
   canCreateAnswer: boolean;
   canAcceptAnswer: boolean;
   myAnswerId?: number;
+  questionReaction: string;
 }
 
 export interface CommunityQnaCommentViewer {
@@ -90,12 +92,14 @@ export interface CommunityQnaComment {
 
 export interface CommunityQnaAnswerStats {
   commentCount: number;
+  likeCount: number;
 }
 
 export interface CommunityQnaAnswerViewer {
   canEdit: boolean;
   canDelete: boolean;
   canComment: boolean;
+  reaction: string;
 }
 
 export interface CommunityQnaAnswerItem {
@@ -159,6 +163,11 @@ export interface CommunityQnaAcceptanceData {
   questionId: number;
   acceptedAnswerId?: number;
   acceptedAt?: string;
+}
+
+export interface CommunityQnaReactionResult {
+  likeCount: number;
+  reaction: string;
 }
 
 export interface CommunityQnaQuestionViewEvent {


### PR DESCRIPTION
## 작업 내용

커뮤니티 게시글 상세 페이지의 헤더, 본문, 반응 영역 레이아웃을 개선합니다.

### 헤더 구조 변경
- 기존 5단 구조 → 제목 중심 2단 구조로 압축
- 배지(IT 지식 등)를 제목 위 왼쪽 정렬로 배치
- 작성자/역할/날짜/조회/댓글을 한 줄 메타 라인으로 통합
- 조회, 댓글은 아이콘(Eye, MessageCircle)으로 변경

### 반응 영역 변경
- 좋아요 아이콘: ThumbsUp → Heart
- 좋아요 + 공유 버튼을 본문 아래, 댓글 위에 인라인 배치
- 공유: `navigator.share` 우선, 미지원 시 클립보드 복사 fallback

### 본문 글자 크기 상향
- 제목: `font-designer-28b` → `font-designer-32b`
- 본문 plain text: `font-designer-16r` → `font-designer-20r`
- 마크다운 p/li/blockquote: `font-designer-14r` → `font-designer-18r`

### 기타
- 댓글 헤더 하단 보더 라인 제거

## 변경 이유

- 제목이 시각 중심이 되도록 정보 위계를 재설계
- 좋아요 버튼을 본문을 읽은 뒤 자연스럽게 반응할 수 있는 위치로 이동
- 본문 가독성 향상을 위한 글자 크기 상향

## 검증 방법

- `yarn lint:fix` ✅
- `yarn prettier:fix` ✅
- `yarn typecheck` ✅
- pre-commit hook build ✅

## 브랜치 정보

- base: `develop`
- head: `fix/community-detail-layout-redesign-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시물·질문 공유 버튼 추가(공유 API 사용/클립보드 복사 및 알림 제공).
  * Q&A 질문·답변 좋아요(하트) 기능 및 좋아요 수 표시, 답변별 좋아요 토글 지원.

* **스타일**
  * 반응 버튼 아이콘을 ThumbsUp에서 하트로 변경.
  * 마크다운 및 게시물 본문 타이포그래피(글자 크기/행간) 조정.
  * 커뮤니티 상세·목록 레이아웃·헤더 타이포그래피 개선.

* **동작 변경**
  * 댓글/답글/편집 UI 리셋 동작 개선(페이지 변경 시 드래프트 초기화 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->