### PR TITLE
fix : 이미지 업로드 파일 선택 시 Windows에서 썸네일 누락 수정

### DIFF
--- a/src/components/common/ui/editor/image-utils.ts
+++ b/src/components/common/ui/editor/image-utils.ts
@@ -297,7 +297,13 @@ export const getImageFileNormalizationErrorMessage = (
  * toImageInputAccept(['jpg', 'png', 'webp']) // '.jpg,.png,.webp'
  */
 export const toImageInputAccept = (extensions: readonly string[]) => {
-  return extensions.map((extension) => `.${extension}`).join(',');
+  const mimeTypes = Object.entries(IMAGE_EXTENSION_BY_MIME)
+    .filter(([, ext]) => extensions.includes(ext))
+    .map(([mime]) => mime);
+
+  const extensionParts = extensions.map((extension) => `.${extension}`);
+
+  return [...mimeTypes, ...extensionParts].join(',');
 };
 
 /**


### PR DESCRIPTION
## 작업 내용

이미지 업로드 파일 선택 다이얼로그에서 Windows Chrome 환경에서 많은 이미지 썸네일이 누락되는 문제를 수정합니다.

## 변경 이유

`<input type="file">` 의 `accept` 속성에 확장자(`.jpg,.png,...`)만 지정되어 있었습니다.
Windows Chrome은 확장자만 있으면 "사용자 저장 파일" 커스텀 필터를 생성하는데, 이 경우 Windows Shell의 이미지 썸네일 생성이 정상 동작하지 않는 경우가 있습니다.

MIME 타입(`image/jpeg`, `image/png` 등)을 확장자와 함께 지정하면 Chrome이 OS 수준의 네이티브 이미지 필터를 사용하게 되어 썸네일이 정상 표시됩니다.

## 변경 사항

- `toImageInputAccept()` 함수가 기존 `IMAGE_EXTENSION_BY_MIME` 맵을 활용하여 MIME 타입을 자동으로 추출하고 확장자 앞에 병기하도록 수정
- 기존: `.jpg,.jpeg,.png,.webp,.gif,.heic,.heif`
- 변경: `image/jpeg,image/png,image/gif,image/webp,image/heic,image/heif,.jpg,.jpeg,.png,.webp,.gif,.heic,.heif`

## 검증 방법

- [x] `yarn lint:fix` 통과
- [x] `yarn prettier:fix` 통과
- [x] `yarn typecheck` 통과
- [x] `yarn build` 통과 (pre-push hook)
- [ ] Windows Chrome에서 커뮤니티 글 작성 → 이미지 업로드 파일 선택 시 썸네일 정상 표시 확인

## 브랜치 정보

- **base**: `develop`
- **head**: `fix/image-upload-accept-mime-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  * 이미지 파일 입력 처리 개선으로 더 광범위한 파일 형식 호환성 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->