### PR TITLE
fix : 커뮤니티 댓글 입력칸 여러 줄 입력 시 auto-resize 적용

### DIFF
--- a/src/features/community/ui/community-comment-form.tsx
+++ b/src/features/community/ui/community-comment-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import Avatar from '@/components/common/ui/avatar';
 import Button from '@/components/common/ui/button';
@@ -46,6 +46,10 @@ export default function CommunityCommentForm({
     textarea.style.height = `${textarea.scrollHeight}px`;
   }, []);
 
+  useEffect(() => {
+    adjustTextareaHeight();
+  }, [value, adjustTextareaHeight]);
+
   const handleCancel = () => {
     onCancel?.();
     setIsExpanded(false);
@@ -69,10 +73,7 @@ export default function CommunityCommentForm({
             rows={isCompact ? 2 : 1}
             autoFocus={autoFocus}
             disabled={disabled}
-            onChange={(event) => {
-              onChange(event.target.value);
-              adjustTextareaHeight();
-            }}
+            onChange={(event) => onChange(event.target.value)}
             onFocus={() => setIsExpanded(true)}
             onBlur={() => {
               if (!isCompact && value.trim().length === 0) {

--- a/src/features/community/ui/community-comment-form.tsx
+++ b/src/features/community/ui/community-comment-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import Avatar from '@/components/common/ui/avatar';
 import Button from '@/components/common/ui/button';
@@ -31,8 +31,20 @@ export default function CommunityCommentForm({
   isCompact = false,
 }: CommunityCommentFormProps) {
   const [isExpanded, setIsExpanded] = useState(autoFocus || isCompact);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isSubmitDisabled = disabled || value.trim().length === 0;
   const shouldShowActions = isCompact || isExpanded || value.trim().length > 0;
+
+  const adjustTextareaHeight = useCallback(() => {
+    const textarea = textareaRef.current;
+
+    if (!textarea) {
+      return;
+    }
+
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, []);
 
   const handleCancel = () => {
     onCancel?.();
@@ -51,12 +63,16 @@ export default function CommunityCommentForm({
 
         <div className="min-w-0 flex-1">
           <textarea
+            ref={textareaRef}
             value={value}
             placeholder={placeholder}
             rows={isCompact ? 2 : 1}
             autoFocus={autoFocus}
             disabled={disabled}
-            onChange={(event) => onChange(event.target.value)}
+            onChange={(event) => {
+              onChange(event.target.value);
+              adjustTextareaHeight();
+            }}
             onFocus={() => setIsExpanded(true)}
             onBlur={() => {
               if (!isCompact && value.trim().length === 0) {
@@ -64,7 +80,7 @@ export default function CommunityCommentForm({
               }
             }}
             className={cn(
-              'w-full resize-none bg-transparent py-100 font-designer-15r leading-250 text-text-default placeholder:text-text-subtlest focus:outline-none',
+              'w-full resize-none overflow-hidden bg-transparent py-100 font-designer-15r leading-250 text-text-default placeholder:text-text-subtlest focus:outline-none',
               disabled && 'cursor-not-allowed text-text-disabled',
             )}
           />


### PR DESCRIPTION
## Summary
- 커뮤니티 댓글 입력 textarea가 2~3줄 이상 입력해도 높이가 고정되어 불편했던 문제 수정
- scrollHeight 기반 auto-resize를 적용하여 입력 내용에 맞게 높이 자동 확장
- 커뮤니티 일반 댓글, QnA 질문 댓글, QnA 답변 댓글 모두 동일 적용 (공통 컴포넌트 1곳 수정)

## 변경 이유
- `<textarea>`에 `rows` 고정값 + `resize-none`만 적용되어 있어 여러 줄 입력 시 스크롤만 생기고 칸이 늘어나지 않았음
- 사용자가 자신의 입력 내용을 한눈에 확인할 수 없어 불편

## 변경 파일
- `src/features/community/ui/community-comment-form.tsx` — auto-resize 로직 추가

## 검증 방법
- [ ] 커뮤니티 일반 게시글 댓글에서 2~3줄 이상 입력 시 칸 높이 자동 확장 확인
- [ ] QnA 질문 댓글에서 동일 확인
- [ ] QnA 답변 댓글에서 동일 확인
- [ ] 대댓글(답글) 입력에서 동일 확인
- [ ] 내용 삭제 시 높이가 다시 줄어드는지 확인

## 브랜치 정보
- **base**: `develop`
- **head**: `fix/community-comment-textarea-auto-resize-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 입력 필드가 입력 내용에 따라 자동으로 높이가 조정됩니다. 스크롤 없이 더 편리한 입력 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->