### PR TITLE
MENTOR_STUDY 참여 여부 필터링 버그 수정

### DIFF
--- a/src/components/group-study/pages/premium-study-list-page.tsx
+++ b/src/components/group-study/pages/premium-study-list-page.tsx
@@ -90,7 +90,7 @@ export default function PremiumStudyListPage() {
       </div>
 
       {/* 내가 참여중인 스터디 섹션 */}
-      <MyParticipatingStudiesSection classification="PREMIUM_STUDY" />
+      <MyParticipatingStudiesSection classification="MENTOR_STUDY" />
 
       <StudyListToolbar
         title="멘토스터디 둘러보기"

--- a/src/components/group-study/section/my-participating-studies-section.tsx
+++ b/src/components/group-study/section/my-participating-studies-section.tsx
@@ -11,12 +11,12 @@ import { useMemberStudyListV2Query } from '@/hooks/queries/user/use-member-study
 import { hashValue } from '@/utils/hash';
 
 interface MyParticipatingStudiesSectionProps {
-  classification: 'GROUP_STUDY' | 'PREMIUM_STUDY';
+  classification: 'GROUP_STUDY' | 'MENTOR_STUDY';
 }
 
 const CLASSIFICATION_TO_STUDY_TYPE = {
   GROUP_STUDY: 'GROUP_STUDY',
-  PREMIUM_STUDY: 'MENTOR_STUDY',
+  MENTOR_STUDY: 'MENTOR_STUDY',
 } as const;
 
 export default function MyParticipatingStudiesSection({
@@ -44,7 +44,7 @@ export default function MyParticipatingStudiesSection({
   const { data: myStudiesData } = useMemberStudyListV2Query({
     memberId: memberId ?? 0,
     studyType:
-      classification === 'PREMIUM_STUDY' ? 'MENTOR_STUDY' : classification,
+      classification === 'MENTOR_STUDY' ? 'MENTOR_STUDY' : classification,
     studyStatus: 'NOT_COMPLETED', // 진행 중과 모집 중 모두 포함
     page: 1,
     pageSize: 100, // 충분히 많이 가져오기

--- a/src/components/group-study/section/my-participating-studies-section.tsx
+++ b/src/components/group-study/section/my-participating-studies-section.tsx
@@ -58,16 +58,15 @@ export default function MyParticipatingStudiesSection({
     recruiting: undefined, // 모든 상태 포함 (진행 중, 모집 중 모두)
   });
 
-  // 내가 참여중인 스터디 ID Set 생성 (IN_PROGRESS, RECRUITING)
+  // 내가 참여중인 스터디 ID Set 생성 (NOT_COMPLETED — status 필터는 API 쿼리에서 처리)
+  // MENTOR_STUDY는 백엔드 V2 API에서 status를 null로 반환하므로 프론트엔드에서 status를 재필터링하지 않음
   const participatingStudyIds = useMemo(() => {
     if (!myStudiesData?.content) return new Set<number>();
 
     const studyType = CLASSIFICATION_TO_STUDY_TYPE[classification];
 
     const filtered = myStudiesData.content.filter(
-      (study) =>
-        (study.status === 'IN_PROGRESS' || study.status === 'RECRUITING') &&
-        study.type === studyType,
+      (study) => study.type === studyType,
     );
 
     return new Set(filtered.map((study) => study.studyId));


### PR DESCRIPTION
## Summary

- 내 스터디 섹션에서 참여 중인 스터디 ID Set 생성 시 프론트엔드에서 `status`를 재필터링하던 로직 제거
- 백엔드 V2 API는 MENTOR_STUDY의 `status`를 `null`로 반환하므로, `IN_PROGRESS || RECRUITING` 조건이 항상 `false`가 되어 참여 중인 MENTOR_STUDY가 목록에서 제외되는 버그 수정
- `status` 필터링은 API 쿼리 파라미터(`NOT_COMPLETED`)에서 이미 처리되므로 프론트엔드 재필터링이 불필요함

## Changes

### Bug Fixes

| File | Description |
|------|-------------|
| `src/components/group-study/section/my-participating-studies-section.tsx` | `participatingStudyIds` 생성 시 `status` 조건 제거, `type` 필터만 유지 |

## Test plan

- [ ] MENTOR_STUDY(프리미엄 스터디) 참여 중인 유저로 로그인 후 홈 화면에서 내 스터디 섹션에 MENTOR_STUDY가 정상 노출되는지 확인
- [ ] 일반 GROUP_STUDY 참여 중인 유저로 로그인 후 내 스터디 섹션에 정상 노출되는지 확인
- [ ] 두 타입 스터디 모두 참여 중인 경우 각각의 탭에서 올바르게 필터링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 참여 중인 스터디 섹션이 멘토 스터디(MENTOR_STUDY) 분류를 지원하도록 업데이트되었습니다.
  * 클라이언트 측 상태 필터를 제거하고 서버(API)의 상태 기반 필터링으로 통일되어 목록 정확도가 향상되었습니다(백엔드에서 일부 멘토 스터디의 상태가 null일 수 있음).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->