### PR TITLE
스터디 수정 시 썸네일 이미지 유지 및 유효성 검증 로직 수정

### DIFF
--- a/src/components/group-study/forms/group-study-form.tsx
+++ b/src/components/group-study/forms/group-study-form.tsx
@@ -126,6 +126,10 @@ export default function GroupStudyForm({
         return typeof value !== 'string' || value.trim() === '';
       }
       if (field === 'thumbnailExtension') {
+        if (mode === 'edit') {
+          const existingUrl = methods.getValues('thumbnailUrl');
+          return (!value || value === 'DEFAULT') && !existingUrl;
+        }
         return !value || value === 'DEFAULT';
       }
       if (field === 'interviewPost') {
@@ -139,7 +143,14 @@ export default function GroupStudyForm({
 
       return false;
     });
-  }, [currentStepFields, currentStepValues, formState.errors, classification]);
+  }, [
+    currentStepFields,
+    currentStepValues,
+    formState.errors,
+    classification,
+    methods,
+    mode,
+  ]);
 
   return (
     <ModeContext.Provider value={mode}>

--- a/src/components/group-study/modals/group-study-form-modal.tsx
+++ b/src/components/group-study/modals/group-study-form-modal.tsx
@@ -95,9 +95,12 @@ function resolveStudyType(
 function resolveThumbnailExtension(
   imageUrl: string | undefined,
 ): GroupStudyFormValues['thumbnailExtension'] {
-  const ext = imageUrl?.split('.').pop()?.toUpperCase();
+  if (!imageUrl) return 'DEFAULT';
+  const cleanUrl = imageUrl.split('?')[0];
+  const ext = cleanUrl.split('.').pop()?.toUpperCase();
+  const isValid = ext && isOneOf(THUMBNAIL_EXTENSION, ext) && ext !== 'DEFAULT';
 
-  return ext && isOneOf(THUMBNAIL_EXTENSION, ext) ? ext : 'DEFAULT';
+  return isValid ? ext : 'JPG';
 }
 
 function prepareDescription(
@@ -159,6 +162,7 @@ export default function GroupStudyFormModal({
   const [isVerificationModalOpen, setIsVerificationModalOpen] = useState(false);
 
   const originalStartDateRef = useRef<string | undefined>(undefined);
+  const isFormInitializedRef = useRef(false);
 
   const createMethods = useForm<GroupStudyFormValues>({
     resolver: zodResolver(GroupStudyFormSchema),
@@ -224,27 +228,29 @@ export default function GroupStudyFormModal({
 
       return {
         classification: resolvedClassification,
-        type: resolveStudyType(value.basicInfo?.type, resolvedClassification),
+        type:
+          resolveStudyType(value.basicInfo?.type, resolvedClassification) ??
+          'PROJECT',
         thumbnailExtension: resolveThumbnailExtension(thumbnailUrl),
-        thumbnailUrl,
+        thumbnailUrl: thumbnailUrl ?? null,
         studyLeaderParticipation:
           value.basicInfo?.studyLeaderParticipation ?? false,
-        targetRoles: value.basicInfo?.targetRoles,
+        targetRoles: value.basicInfo?.targetRoles ?? [],
         maxMembersCount: value.basicInfo?.maxMembersCount?.toString() ?? '',
-        experienceLevels: value.basicInfo?.experienceLevels,
-        method: value.basicInfo?.method,
-        location: value.basicInfo?.location,
-        regularMeeting: value.basicInfo?.regularMeeting,
-        startDate: value.basicInfo?.startDate,
-        endDate: value.basicInfo?.endDate,
+        experienceLevels: value.basicInfo?.experienceLevels ?? [],
+        method: value.basicInfo?.method ?? 'ONLINE',
+        location: value.basicInfo?.location ?? '',
+        regularMeeting: value.basicInfo?.regularMeeting ?? 'NONE',
+        startDate: value.basicInfo?.startDate ?? '',
+        endDate: value.basicInfo?.endDate ?? '',
         price: value.basicInfo?.price?.toString() ?? '',
-        title: value.detailInfo?.title,
-        description: value.detailInfo?.description,
-        summary: value.detailInfo?.summary,
+        title: value.detailInfo?.title ?? '',
+        description: value.detailInfo?.description ?? '',
+        summary: value.detailInfo?.summary ?? '',
         descriptionPendingImages: [],
         interviewPost: value.interviewPost?.interviewPost
           ?.map((q) => q.question)
-          .filter((q): q is string => Boolean(q)),
+          .filter((q): q is string => Boolean(q)) ?? [''],
       } satisfies GroupStudyFormValues;
     },
     [classification],
@@ -413,9 +419,14 @@ export default function GroupStudyFormModal({
   }, [open, mode]);
 
   useEffect(() => {
-    if (mode === 'edit' && controlledOpen && groupStudyInfo) {
+    if (!controlledOpen) {
+      isFormInitializedRef.current = false;
+      return;
+    }
+    if (mode === 'edit' && groupStudyInfo && !isFormInitializedRef.current) {
       originalStartDateRef.current = groupStudyInfo.basicInfo?.startDate;
       editMethods.reset(refineStudyDetail(groupStudyInfo));
+      isFormInitializedRef.current = true;
     }
   }, [controlledOpen, groupStudyInfo, editMethods, mode, refineStudyDetail]);
 


### PR DESCRIPTION
### 🌱 연관된 이슈

<!-- 관련 이슈를 적어주세요 -->
- 스터디 수정 시 썸네일 이미지가 비어있었음

### ☘️ 작업 내용

<!-- 작업한 내용을 적어주세요 -->
- ref를 이용하여 기존 썸네일 이미지를 스터디 수정 시 로드하도록 수정

### 🍀 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

#### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 그룹 스터디 폼의 썸네일 확장자 처리 로직 개선
  * 편집 모드에서 폼 초기화 및 다음 버튼 활성화 조건 개선
  * 폼 데이터 유효성 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->