### PR TITLE
로딩 상태 스켈레톤 전환 및 queryKey 버그 수정

### DIFF
--- a/src/app/(service)/(my)/loading.tsx
+++ b/src/app/(service)/(my)/loading.tsx
@@ -1,0 +1,7 @@
+export default function MyPageLoading() {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="border-border-brand h-500 w-500 animate-spin rounded-full border-4 border-t-transparent" />
+    </div>
+  );
+}

--- a/src/app/(service)/(my)/my-activity/page.tsx
+++ b/src/app/(service)/(my)/my-activity/page.tsx
@@ -2,12 +2,36 @@
 
 import Image from 'next/image';
 import MyStudyCard from '@/components/common/cards/my-study-card';
+import { Skeleton } from '@/components/common/ui/loading-skeleton';
 import { useStudyDashboardQuery } from '@/hooks/queries/user/use-update-user-profile-mutation';
 
 export default function MyActivity() {
   const { data: dashboard, isLoading, isError } = useStudyDashboardQuery();
 
-  if (isLoading) return <div>로딩 중...</div>;
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-400">
+        {[3, 2].map((count, section) => (
+          <div key={section} className="flex flex-col gap-200">
+            <Skeleton className="h-300 w-[160px]" />
+            <div className="flex gap-200">
+              {Array.from({ length: count }).map((_, i) => (
+                <Skeleton key={i} className="h-[90px] flex-1 rounded-150" />
+              ))}
+            </div>
+          </div>
+        ))}
+        <div className="flex flex-col gap-200">
+          <Skeleton className="h-300 w-[160px]" />
+          <div className="flex gap-200">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-[90px] flex-1 rounded-150" />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
   if (isError || !dashboard) return <div>에러가 발생했습니다.</div>;
 
   return (

--- a/src/app/(service)/(my)/my-study/completed/page.tsx
+++ b/src/app/(service)/(my)/my-study/completed/page.tsx
@@ -4,6 +4,7 @@ import { Plus } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
 import Button from '@/components/common/ui/button';
+import { Skeleton } from '@/components/common/ui/loading-skeleton';
 import Pagination from '@/components/common/ui/pagination';
 import CompletedGroupStudyList from '@/components/home/lists/completed-group-study-list';
 import { useAuthReady } from '@/features/auth/model/use-auth';
@@ -36,7 +37,27 @@ export default function CompletedPage() {
   ) as MemberGroupStudyList[];
 
   if (isLoading) {
-    return null;
+    return (
+      <div className="flex flex-col gap-300">
+        <div className="flex flex-row items-center justify-between">
+          <Skeleton className="h-300 w-[120px]" />
+          <Skeleton className="h-300 w-[130px]" />
+        </div>
+        <div>
+          <Skeleton className="mb-200 h-200 w-[120px]" />
+          <ul className="grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-300">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <li key={i} className="flex flex-col gap-100">
+                <Skeleton className="h-study-card rounded-100" />
+                <Skeleton className="h-150 w-[60px]" />
+                <Skeleton className="h-150 w-full" />
+                <Skeleton className="h-100 w-4/5" />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/app/(service)/(my)/my-study/not-completed/page.tsx
+++ b/src/app/(service)/(my)/my-study/not-completed/page.tsx
@@ -4,6 +4,7 @@ import { Plus } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
 import Button from '@/components/common/ui/button';
+import { Skeleton } from '@/components/common/ui/loading-skeleton';
 import Pagination from '@/components/common/ui/pagination';
 import NotCompletedGroupStudyList from '@/components/home/lists/not-completed-group-study-list';
 import { useAuthReady } from '@/features/auth/model/use-auth';
@@ -36,7 +37,27 @@ export default function NotCompletedPage() {
   ) as MemberGroupStudyList[];
 
   if (isLoading) {
-    return null;
+    return (
+      <div className="flex flex-col gap-300">
+        <div className="flex flex-row items-center justify-between">
+          <Skeleton className="h-300 w-[120px]" />
+          <Skeleton className="h-300 w-[130px]" />
+        </div>
+        <div>
+          <Skeleton className="mb-200 h-200 w-[120px]" />
+          <ul className="grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-300">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <li key={i} className="flex flex-col gap-100">
+                <Skeleton className="h-study-card rounded-100" />
+                <Skeleton className="h-150 w-[60px]" />
+                <Skeleton className="h-150 w-full" />
+                <Skeleton className="h-100 w-4/5" />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/app/(service)/(my)/my-study/page.tsx
+++ b/src/app/(service)/(my)/my-study/page.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useMemo } from 'react';
 import Button from '@/components/common/ui/button';
+import { Skeleton } from '@/components/common/ui/loading-skeleton';
 import CompletedGroupStudyList from '@/components/home/lists/completed-group-study-list';
 import NotCompletedGroupStudyList from '@/components/home/lists/not-completed-group-study-list';
 import { useAuthReady } from '@/features/auth/model/use-auth';
@@ -70,7 +71,31 @@ export default function MyStudy() {
   }, [notCompletedData, completedData]);
 
   if (isLoading) {
-    return null;
+    return (
+      <div className="flex flex-col gap-300">
+        <div className="flex flex-row items-center justify-between">
+          <Skeleton className="h-300 w-[120px]" />
+          <Skeleton className="h-300 w-[130px]" />
+        </div>
+        <div className="flex flex-col gap-600">
+          {[0, 1].map((section) => (
+            <div key={section}>
+              <Skeleton className="mb-200 h-200 w-[100px]" />
+              <ul className="grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-300">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <li key={i} className="flex flex-col gap-100">
+                    <Skeleton className="h-study-card rounded-100" />
+                    <Skeleton className="h-150 w-[60px]" />
+                    <Skeleton className="h-150 w-full" />
+                    <Skeleton className="h-100 w-4/5" />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/app/(service)/group-study/[id]/page.tsx
+++ b/src/app/(service)/group-study/[id]/page.tsx
@@ -107,7 +107,7 @@ export default async function Page({
   const data = queryClient.getQueryData<GroupStudyFullResponseDto>([
     'groupStudyDetail',
     Number(id),
-  ])!;
+  ]);
 
   const memberId = await readAuthenticatedMemberId();
 
@@ -116,7 +116,7 @@ export default async function Page({
   if (!isLeader && memberId) {
     // 내가 리더가 아닐 경우에만 내 신청 상태 정보 미리 가져오기
     await queryClient.prefetchQuery({
-      queryKey: ['groupStudyMyStatus', Number(id)],
+      queryKey: ['groupStudyMemberStatus', Number(id)],
       queryFn: () =>
         getGroupStudyMyStatusInServer({ groupStudyId: Number(id) }),
     });

--- a/src/app/(service)/group-study/page.tsx
+++ b/src/app/(service)/group-study/page.tsx
@@ -11,7 +11,7 @@ export default function GroupStudyPage() {
 
 function GroupStudyListPageSkeleton() {
   return (
-    <div className="mx-auto w-full max-w-[1280px] px-400 py-600">
+    <div className="mx-auto w-full max-w-7xl px-400 py-600">
       <div className="mb-600">
         <div className="bg-background-alternative animate-pulse rounded-200 h-[240px]" />
       </div>

--- a/src/app/(service)/group-study/page.tsx
+++ b/src/app/(service)/group-study/page.tsx
@@ -12,8 +12,18 @@ export default function GroupStudyPage() {
 function GroupStudyListPageSkeleton() {
   return (
     <div className="mx-auto w-full max-w-[1280px] px-400 py-600">
-      <div className="flex h-[400px] items-center justify-center">
-        <span className="text-text-subtle">로딩 중...</span>
+      <div className="mb-600">
+        <div className="bg-background-alternative animate-pulse rounded-200 h-[240px]" />
+      </div>
+      <div className="flex flex-col gap-400">
+        <div className="bg-background-alternative animate-pulse rounded-150 h-[60px]" />
+        <ul className="grid grid-cols-1 gap-300 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <li key={i}>
+              <div className="bg-background-alternative animate-pulse rounded-200 h-[380px]" />
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/src/components/common/ui/loading-skeleton.tsx
+++ b/src/components/common/ui/loading-skeleton.tsx
@@ -1,0 +1,12 @@
+import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'bg-background-alternative animate-pulse rounded-100',
+        className,
+      )}
+    />
+  );
+}

--- a/src/components/group-study/pages/group-study-detail-page.tsx
+++ b/src/components/group-study/pages/group-study-detail-page.tsx
@@ -380,7 +380,7 @@ export default function StudyDetailPage({
       />
       <div
         className={cn(
-          'transition-opacity duration-150',
+          'w-full transition-opacity duration-150',
           isPending && 'opacity-60',
         )}
       >

--- a/src/components/group-study/pages/group-study-detail-page.tsx
+++ b/src/components/group-study/pages/group-study-detail-page.tsx
@@ -3,8 +3,10 @@
 import { sendGTMEvent } from '@next/third-parties/google';
 import dynamic from 'next/dynamic';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import MoreMenu from '@/components/common/ui/dropdown/more-menu';
+import { Skeleton } from '@/components/common/ui/loading-skeleton';
 import StudyActiveTicker from '@/components/common/ui/study-active-ticker';
 import Tabs from '@/components/common/ui/tabs';
 import ChannelSection from '@/components/group-study/discussion/channel/lounge-section';
@@ -85,6 +87,7 @@ export default function StudyDetailPage({
   const searchParams = useSearchParams();
   const setLeaderInfo = useLeaderStore((state) => state.setLeaderInfo);
   const showToast = useToastStore((state) => state.showToast);
+  const [isPending, startTransition] = useTransition();
 
   const tabParam = searchParams.get('tab') ?? undefined;
 
@@ -260,7 +263,15 @@ export default function StudyDetailPage({
   }, [activeTab, isLoading, isMyStatusLoading, pathname, router, tabParam]);
 
   if (isLoading || !studyDetail) {
-    return <div>로딩중...</div>;
+    return (
+      <div className="flex w-full flex-col items-center">
+        <div className="mt-500 w-full max-w-study-content px-400">
+          <Skeleton className="mb-300 h-600 rounded-150" />
+          <Skeleton className="mb-150 h-300 w-3/4" />
+          <Skeleton className="h-200 w-1/2" />
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -354,53 +365,62 @@ export default function StudyDetailPage({
         tabs={availableTabs}
         activeTab={activeTab}
         onChange={(value: StudyTabValue) => {
-          const params = new URLSearchParams(searchParams.toString());
-          params.set('tab', value);
-          router.push(`${pathname}?${params.toString()}`, { scroll: false });
+          startTransition(() => {
+            const params = new URLSearchParams(searchParams.toString());
+            params.set('tab', value);
+            router.push(`${pathname}?${params.toString()}`, { scroll: false });
 
-          sendGTMEvent({
-            event: 'group_study_tab_change',
-            group_study_id: String(groupStudyId),
-            tab: value,
+            sendGTMEvent({
+              event: 'group_study_tab_change',
+              group_study_id: String(groupStudyId),
+              tab: value,
+            });
           });
         }}
       />
-      {activeTab === 'intro' && (
-        <StudyInfoSection
-          study={studyDetail}
-          isLeader={isLeader}
-          isMember={isMember}
-        />
-      )}
-      {activeTab === 'members' && (
-        <GroupStudyMemberList
-          groupStudyId={groupStudyId}
-          leaderId={studyDetail.basicInfo.leader.memberId}
-          myApplicationStatus={myApplicationStatus}
-        />
-      )}
+      <div
+        className={cn(
+          'transition-opacity duration-150',
+          isPending && 'opacity-60',
+        )}
+      >
+        {activeTab === 'intro' && (
+          <StudyInfoSection
+            study={studyDetail}
+            isLeader={isLeader}
+            isMember={isMember}
+          />
+        )}
+        {activeTab === 'members' && (
+          <GroupStudyMemberList
+            groupStudyId={groupStudyId}
+            leaderId={studyDetail.basicInfo.leader.memberId}
+            myApplicationStatus={myApplicationStatus}
+          />
+        )}
 
-      {activeTab === 'mission' && (
-        <MissionSection
-          groupStudyId={groupStudyId}
-          isMember={isMember}
-          isLeader={isLeader}
-        />
-      )}
-      {activeTab === 'lounge' && (
-        <ChannelSection
-          groupStudyId={groupStudyId}
-          memberId={memberId}
-          myApplicationStatus={myApplicationStatus}
-        />
-      )}
-      {activeTab === 'inquiry' && (
-        <InquirySection
-          groupStudyId={groupStudyId}
-          isLeader={isLeader}
-          isAdmin={isAdmin}
-        />
-      )}
+        {activeTab === 'mission' && (
+          <MissionSection
+            groupStudyId={groupStudyId}
+            isMember={isMember}
+            isLeader={isLeader}
+          />
+        )}
+        {activeTab === 'lounge' && (
+          <ChannelSection
+            groupStudyId={groupStudyId}
+            memberId={memberId}
+            myApplicationStatus={myApplicationStatus}
+          />
+        )}
+        {activeTab === 'inquiry' && (
+          <InquirySection
+            groupStudyId={groupStudyId}
+            isLeader={isLeader}
+            isAdmin={isAdmin}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/group-study/pages/group-study-list-page.tsx
+++ b/src/components/group-study/pages/group-study-list-page.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import PageContainer from '@/components/common/layout/page-container';
+import { Skeleton } from '@/components/common/ui/loading-skeleton';
 import StudyListToolbar from '@/components/group-study/pages/study-list-toolbar';
 import MyParticipatingStudiesSection from '@/components/group-study/section/my-participating-studies-section';
 import GroupStudyList from '@/components/home/lists/group-study-list';
@@ -57,8 +58,15 @@ export default function GroupStudyListPage() {
   if (isLoading) {
     return (
       <PageContainer className="py-600">
-        <div className="flex h-[400px] items-center justify-center">
-          <span className="text-text-subtle">로딩 중...</span>
+        <div className="flex flex-col gap-400">
+          <Skeleton className="h-[60px] rounded-150" />
+          <ul className="grid grid-cols-1 gap-300 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <li key={i}>
+                <Skeleton className="h-[380px] rounded-200" />
+              </li>
+            ))}
+          </ul>
         </div>
       </PageContainer>
     );

--- a/src/components/group-study/pages/premium-study-detail-page.tsx
+++ b/src/components/group-study/pages/premium-study-detail-page.tsx
@@ -3,8 +3,10 @@
 import { sendGTMEvent } from '@next/third-parties/google';
 import dynamic from 'next/dynamic';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import MoreMenu from '@/components/common/ui/dropdown/more-menu';
+import { Skeleton } from '@/components/common/ui/loading-skeleton';
 import StudyActiveTicker from '@/components/common/ui/study-active-ticker';
 import Tabs from '@/components/common/ui/tabs';
 import ChannelSection from '@/components/group-study/discussion/channel/lounge-section';
@@ -89,6 +91,7 @@ export default function PremiumStudyDetailPage({
   const searchParams = useSearchParams();
   const setLeaderInfo = useLeaderStore((state) => state.setLeaderInfo);
   const showToast = useToastStore((state) => state.showToast);
+  const [isPending, startTransition] = useTransition();
   const tabParam = searchParams.get('tab') ?? undefined;
   const requestedTab = isStudyTabValue(tabParam) ? tabParam : 'intro';
 
@@ -289,7 +292,15 @@ export default function PremiumStudyDetailPage({
   ]);
 
   if (isLoading || !studyDetail) {
-    return <div>로딩중...</div>;
+    return (
+      <div className="flex w-full flex-col items-center">
+        <div className="mt-500 w-full max-w-study-content px-400">
+          <Skeleton className="mb-300 h-600 rounded-150" />
+          <Skeleton className="mb-150 h-300 w-3/4" />
+          <Skeleton className="h-200 w-1/2" />
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -385,50 +396,59 @@ export default function PremiumStudyDetailPage({
         tabs={availableTabs}
         activeTab={activeTab}
         onChange={(value: StudyTabValue) => {
-          const params = new URLSearchParams(searchParams.toString());
-          params.set('tab', value);
-          router.push(`${pathname}?${params.toString()}`, { scroll: false });
-          sendGTMEvent({
-            event: 'premium_study_tab_change',
-            group_study_id: String(groupStudyId),
-            tab: value,
+          startTransition(() => {
+            const params = new URLSearchParams(searchParams.toString());
+            params.set('tab', value);
+            router.push(`${pathname}?${params.toString()}`, { scroll: false });
+            sendGTMEvent({
+              event: 'premium_study_tab_change',
+              group_study_id: String(groupStudyId),
+              tab: value,
+            });
           });
         }}
       />
-      {activeTab === 'intro' && (
-        <PremiumStudyInfoSection
-          study={studyDetail as GroupStudyFullResponse}
-        />
-      )}
-      {activeTab === 'members' && (
-        <GroupStudyMemberList
-          groupStudyId={groupStudyId}
-          leaderId={studyDetail.basicInfo.leader.memberId}
-          myApplicationStatus={myApplicationStatus}
-        />
-      )}
-      {activeTab === 'mission' && (
-        <MissionSection
-          groupStudyId={groupStudyId}
-          isMember={isMember}
-          isLeader={isLeader}
-        />
-      )}
-      {activeTab === 'lounge' && (
-        <ChannelSection
-          groupStudyId={groupStudyId}
-          memberId={memberId}
-          myApplicationStatus={myApplicationStatus}
-        />
-      )}
-      {activeTab === 'inquiry' && (
-        <InquirySection
-          groupStudyId={groupStudyId}
-          isPremium
-          isLeader={isLeader}
-          isAdmin={isAdmin}
-        />
-      )}
+      <div
+        className={cn(
+          'transition-opacity duration-150',
+          isPending && 'opacity-60',
+        )}
+      >
+        {activeTab === 'intro' && (
+          <PremiumStudyInfoSection
+            study={studyDetail as GroupStudyFullResponse}
+          />
+        )}
+        {activeTab === 'members' && (
+          <GroupStudyMemberList
+            groupStudyId={groupStudyId}
+            leaderId={studyDetail.basicInfo.leader.memberId}
+            myApplicationStatus={myApplicationStatus}
+          />
+        )}
+        {activeTab === 'mission' && (
+          <MissionSection
+            groupStudyId={groupStudyId}
+            isMember={isMember}
+            isLeader={isLeader}
+          />
+        )}
+        {activeTab === 'lounge' && (
+          <ChannelSection
+            groupStudyId={groupStudyId}
+            memberId={memberId}
+            myApplicationStatus={myApplicationStatus}
+          />
+        )}
+        {activeTab === 'inquiry' && (
+          <InquirySection
+            groupStudyId={groupStudyId}
+            isPremium
+            isLeader={isLeader}
+            isAdmin={isAdmin}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/group-study/pages/premium-study-detail-page.tsx
+++ b/src/components/group-study/pages/premium-study-detail-page.tsx
@@ -410,7 +410,7 @@ export default function PremiumStudyDetailPage({
       />
       <div
         className={cn(
-          'transition-opacity duration-150',
+          'w-full transition-opacity duration-150',
           isPending && 'opacity-60',
         )}
       >

--- a/src/components/home/calendar.tsx
+++ b/src/components/home/calendar.tsx
@@ -2,11 +2,8 @@
 
 import { ko } from 'date-fns/locale';
 import React, { useState } from 'react';
-import { HTMLAttributes } from 'react';
-import {
-  type CalendarDay as DayPickerDay,
-  type Modifiers,
-} from 'react-day-picker';
+import type { HTMLAttributes } from 'react';
+import type { CalendarDay as DayPickerDay, Modifiers } from 'react-day-picker';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import { Calendar as ShadcnCalendar } from '@/components/common/ui/(shadcn)/ui/calendar';
 import { Skeleton } from '@/components/common/ui/loading-skeleton';
@@ -43,7 +40,7 @@ export function CalendarDay({
         <div className="absolute inset-0 flex items-center justify-center">
           <div
             className={cn(
-              'flex size-[32px] items-center justify-center rounded-full',
+              'flex size-400 items-center justify-center rounded-full',
               customClass,
             )}
           >

--- a/src/components/home/calendar.tsx
+++ b/src/components/home/calendar.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-day-picker';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import { Calendar as ShadcnCalendar } from '@/components/common/ui/(shadcn)/ui/calendar';
+import { Skeleton } from '@/components/common/ui/loading-skeleton';
 import { useMonthlyStudyCalendarQuery } from '@/hooks/queries/one-to-one/use-schedule-query';
 
 interface CalendarDayProps extends HTMLAttributes<HTMLTableCellElement> {
@@ -77,7 +78,13 @@ const Calendar = (props: React.ComponentProps<typeof ShadcnCalendar>) => {
       .map((entry) => new Date(year, month - 1, entry.day));
   }, [data, year, month]);
 
-  if (isLoading) return <div>로딩 중...</div>;
+  if (isLoading) {
+    return (
+      <div className="rounded-200 border border-border-subtle p-250">
+        <Skeleton className="h-[320px] rounded-150" />
+      </div>
+    );
+  }
 
   const monthlyCount = data?.monthlyCompletedCount;
   const totalCount = data?.totalCompletedCount;

--- a/src/hooks/queries/group-study/use-apply-group-study.tsx
+++ b/src/hooks/queries/group-study/use-apply-group-study.tsx
@@ -12,7 +12,7 @@ export const useApplyGroupStudyMutation = (
     mutationFn: applyGroupStudy,
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['groupStudyMyStatus', groupStudyId],
+        queryKey: ['groupStudyMemberStatus', groupStudyId],
       });
     },
   });


### PR DESCRIPTION
## Summary

- `return null` / `로딩 중...` 텍스트로 처리하던 로딩 상태를 모두 스켈레톤 UI로 교체하여 CLS(Cumulative Layout Shift) 제거
- `group-study/[id]` SSR prefetch의 queryKey가 클라이언트 hook과 불일치하던 버그 수정 — 중복 네트워크 요청 제거
- 스터디 상세 탭 전환에 `useTransition` 적용 — 탭 클릭 시 빈 화면 없이 `opacity-60` 전환으로 체감 반응성 개선
- 재사용 가능한 `Skeleton` 기본 컴포넌트 신규 생성 (`src/components/common/ui/loading-skeleton.tsx`)
- `(my)` 세그먼트에 route-level `loading.tsx` 추가 — 서버 auth check 중 스피너 표시

## Changes

### Bug Fixes

| File | Description |
|------|-------------|
| `src/app/(service)/group-study/[id]/page.tsx` | SSR prefetch queryKey `groupStudyMyStatus` → `groupStudyMemberStatus` 수정 (클라이언트 hook과 일치) |

### Features

| File | Description |
|------|-------------|
| `src/components/common/ui/loading-skeleton.tsx` | `Skeleton` 기본 컴포넌트 신규 생성 (`bg-background-alternative animate-pulse`) |
| `src/app/(service)/(my)/loading.tsx` | `(my)` 세그먼트 route-level 로딩 신규 추가 |
| `src/app/(service)/(my)/my-study/page.tsx` | `return null` → 스터디 카드 그리드 구조 스켈레톤으로 교체 |
| `src/app/(service)/(my)/my-study/not-completed/page.tsx` | `return null` → 스켈레톤으로 교체 |
| `src/app/(service)/(my)/my-study/completed/page.tsx` | `return null` → 스켈레톤으로 교체 |
| `src/app/(service)/(my)/my-activity/page.tsx` | `로딩 중...` → 활동 카드 구조 스켈레톤으로 교체 |
| `src/components/home/calendar.tsx` | `로딩 중...` → 캘린더 영역 스켈레톤으로 교체 |
| `src/components/group-study/pages/group-study-list-page.tsx` | `로딩 중...` → 카드 그리드 스켈레톤으로 교체 |
| `src/app/(service)/group-study/page.tsx` | Suspense fallback `로딩 중...` → 배너+카드 그리드 스켈레톤으로 교체 |
| `src/components/group-study/pages/group-study-detail-page.tsx` | `로딩중...` → 헤더 스켈레톤, 탭 전환에 `useTransition` 적용 |
| `src/components/group-study/pages/premium-study-detail-page.tsx` | `로딩중...` → 헤더 스켈레톤, 탭 전환에 `useTransition` 적용 |

## Problem & Solution

### Problem 1 — CLS (Cumulative Layout Shift)
`return null`은 로딩 완료 후 레이아웃이 갑자기 나타나는 점프 현상(CLS)을 유발 CLS는 Core Web Vitals 지표로 Google 검색 랭킹에도 영향을 미침. `my-study`, `my-study/not-completed`, `my-study/completed` 세 페이지가 해당

**해결**: 실제 레이아웃 구조와 동일한 형태의 스켈레톤으로 교체. 로딩 중에도 레이아웃 공간 유지

### Problem 2 — SSR 데이터 무효화 (중복 요청)
`group-study/[id]/page.tsx`에서 SSR prefetch 시 `['groupStudyMyStatus', id]` key를 사용했으나, 실제 클라이언트 hook `useGetGroupStudyMyStatus`는 `['groupStudyMemberStatus', id]`를 사용함. key 불일치로 `HydrationBoundary`가 전달한 SSR 데이터가 클라이언트에서 사용되지 않고, 동일 API를 한 번 더 호출하는 문제

**해결**: prefetch queryKey를 hook의 실제 key와 일치하도록 수정. SSR 데이터가 클라이언트에서 즉시 재사용

### Problem 3 — 탭 전환 빈 화면
스터디 상세 페이지에서 탭 클릭 시 `router.push`가 즉시 실행되어 현재 탭 콘텐츠가 즉시 언마운트되고 새 탭 콘텐츠가 로드될 때까지 빈 화면이 노출

**해결**: `useTransition`으로 URL 업데이트를 non-urgent로 표시. 전환 중 이전 콘텐츠가 `opacity-60`으로 유지

## Test plan

- [ ] `/my-study` 진입 시 `return null` 대신 카드 그리드 형태의 스켈레톤이 표시되는지 확인
- [ ] `/my-study/not-completed`, `/my-study/completed` 동일하게 스켈레톤 표시 확인
- [ ] `/my-activity` 진입 시 `로딩 중...` 대신 카드 구조 스켈레톤 표시 확인
- [ ] `/group-study` 목록 페이지 로딩 시 스켈레톤 카드 그리드 표시 확인
- [ ] `/group-study/[id]` Network 탭에서 `groupStudyMemberStatus` 요청이 1회만 발생하는지 확인 (SSR prefetch 재사용)
- [ ] 스터디 상세 탭 클릭 시 콘텐츠 영역이 `opacity-60`으로 흐려졌다가 전환되는지 확인
- [ ] 프리미엄 스터디 상세 (`/premium-study/[id]`) 동일 탭 전환 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 앱 전체의 로딩 상태가 개선되었습니다. 단순한 텍스트 메시지 대신 실제 콘텐츠 레이아웃을 반영한 스켈레톤 로딩 화면이 표시되어 더 부드러운 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->