### PR TITLE
chore: Claude Code Action 워크플로우 추가

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,55 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    # synchronize 제거: 매 푸시마다 자동 리뷰가 돌면 Max 쿼터 소비가 커서 PR open/reopen/ready 시점만 동작하도록 축소.
+    types: [opened, reopened, ready_for_review]
+    # 프론트엔드 소스/설정 변경에만 자동 리뷰가 돌도록 paths 필터 적용 (쿼터 절약).
+    paths:
+      - "src/**/*.ts"
+      - "src/**/*.tsx"
+      - "src/**/*.js"
+      - "src/**/*.jsx"
+      - "src/**/*.css"
+      - "src/**/*.scss"
+      - "package.json"
+      - "next.config.*"
+      - "tailwind.config.*"
+      - "tsconfig.json"
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write  # 자동 리뷰가 PR에 인라인 코멘트와 요약 코멘트를 작성할 수 있도록 write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+
+      # 자동 리뷰 완료 시 프론트엔드 Slack 채널에 알림. 기존 PR open 알림과는 별도 메시지로 구분.
+      - name: Notify Slack on review complete
+        if: always()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_FRONT_CHANNEL_ID }}
+            text: "Claude 자동 리뷰 완료 (${{ steps.claude-review.outcome }})\n- PR: <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>\n- 작성자: ${{ github.event.pull_request.user.login }}"
+            unfurl_links: false
+            unfurl_media: false

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,57 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # Claude가 PR 브랜치에 커밋 푸시할 수 있도록 write
+      pull-requests: write  # Claude가 PR 코멘트/리뷰를 작성할 수 있도록 write
+      issues: write         # Claude가 이슈 코멘트를 작성할 수 있도록 write
+      id-token: write
+      actions: read         # Claude가 PR의 CI 결과를 읽을 수 있도록 필요
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # 프론트엔드 작업에 필요한 패키지 매니저 명령어 허용
+          claude_args: '--allowed-tools "Bash(npm *),Bash(yarn *),Bash(pnpm *),Bash(npx *)"'
+
+      # Claude 응답 완료 시 프론트엔드 Slack 채널에 알림. 성공/실패 모두 통지하여 쿼터 소진 등 에러 상황도 추적 가능하게 함.
+      - name: Notify Slack on Claude response
+        if: always()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_FRONT_CHANNEL_ID }}
+            text: "Claude가 응답했습니다 (${{ steps.claude.outcome }})\n- 위치: <${{ github.event.issue.pull_request.html_url || github.event.issue.html_url || github.event.pull_request.html_url }}|보러 가기>\n- 호출자: ${{ github.event.comment.user.login || github.event.review.user.login || github.event.issue.user.login }}"
+            unfurl_links: false
+            unfurl_media: false


### PR DESCRIPTION
## Summary
- `@claude` 멘션 시 PR/이슈에서 코드 수정·커밋 푸시·코멘트가 가능한 `claude.yml` 추가
- PR open/reopen/ready_for_review 시점에 프론트엔드 변경분(ts/tsx/js/jsx/css/scss + 주요 설정파일)에 한해 자동 리뷰가 도는 `claude-code-review.yml` 추가
- 두 워크플로우 모두 실행 결과를 `SLACK_FRONT_CHANNEL_ID` 채널로 알림 (성공/실패 모두)
- mvp 레포의 동일 워크플로우(`anthropics/claude-code-action@v1`)를 프론트엔드 환경에 맞춰 이식

## 사용 시크릿
- `CLAUDE_CODE_OAUTH_TOKEN` (신규 추가)
- `SLACK_BOT_TOKEN` (기존)
- `SLACK_FRONT_CHANNEL_ID` (기존)

## Test plan
- [ ] 머지 후 develop 대상으로 테스트 PR을 열어 `claude-code-review` 자동 실행 확인
- [ ] 해당 PR에 `@claude PR 설명 한 줄로 정리해줘` 코멘트로 멘션 호출 확인
- [ ] 두 케이스 모두 프론트엔드 Slack 채널에 알림 도착 확인
- [ ] 비-프론트엔드 파일만 변경된 PR에서는 자동 리뷰가 실행되지 않는지 확인 (paths 필터)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프론트엔드 코드 변경 시 자동으로 AI 기반 코드 리뷰를 실행하는 워크플로우 추가
  * 코드 리뷰 완료 후 Slack으로 결과를 통지하는 기능 추가
  * 특정 키워드 언급 시 온디맨드 코드 리뷰를 실행할 수 있는 워크플로우 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->