### PR TITLE
[design-system] feat : Button + TextField/TextArea Figma DS 2.0 정렬

### DIFF
--- a/.claude/commands/design-to-dev.md
+++ b/.claude/commands/design-to-dev.md
@@ -1,136 +1,170 @@
-# /design-to-dev — Figma to Component Pipeline
+# /design-to-dev-en — Turn a Figma Design Into Component Code
 
-Converts a Figma URL into committed component code + Storybook stories + visual comparison report.
+Takes a Figma URL and produces component code + Storybook stories + a visual comparison report, then commits everything.
 
-## Input
+## Usage
 
 ```
-/design-to-dev <figma-url> [component-name]
+/design-to-dev-en <figma-url> [component-name]
 ```
 
 Example:
 ```
-/design-to-dev https://figma.com/design/xxx?node-id=123 StudyCard
+/design-to-dev-en https://figma.com/design/xxx?node-id=123 StudyCard
 ```
 
-## Execution Order
+---
 
-### Step 1 — Parallel preparation
+### Step 0 — Figure out what kind of frame this is (before writing any code)
 
-Run all three simultaneously:
+Look at the Figma frame and decide which type it is. The type determines which stories you need to build.
 
-**A. Figma analysis** (Figma MCP)
+| Type | What it looks like | Stories needed |
+|------|--------------------|----------------|
+| **A — Single component** | One component, different states (hover, disabled, etc.) | Default + each state + Mobile |
+| **B — Variant grid** | A table of size × state × type combinations | VisualMatrix + Interactive |
+| **C — Composite screen** | Multiple different components placed together | Composite story |
 
-**A.0 — Frame enumeration FIRST (REQUIRED for variant frames)**
+If you can't tell, call `get_screenshot(frame-node-id)` to look at the frame visually before deciding.
+
+---
+
+### Step 1 — Preparation (run A, B, C at the same time)
+
+#### A. Read the Figma design
+
+**A.0 — List all child nodes first (required)**
+
+If you only look at the root node, you'll miss hidden states like Disabled or Pressed.
+
 ```
 get_metadata(node-id)
-  → enumerate ALL child symbols/nodes inside the frame
-  → never assume the root node alone defines the component
-  → for design-system files: a single Button frame can contain 96+ variants
-    (sizes × colors × states × icon arrangements)
-  → record every child node-id; later Steps must cover every cell of the matrix
+  → list every child node inside the frame
+  → a single Button frame can have 96+ variants inside
+  → write down every child node-id and name
 ```
 
-If `get_design_context` is called without first enumerating children, hidden
-variants (e.g. Disabled, Pressed, edge-case sizes) will be silently skipped.
-This has caused real mismatches (e.g. Primary-Disabled text color drifting from
-Secondary-Disabled because only one was sampled).
+**A.0.0 — Check Code Connect mapping first (required)**
 
-**A.0.1 — Coordinates ≠ Visual structure (REQUIRED interpretation step)**
+Before writing any code, check whether the Figma node is already mapped to a codebase component.
 
-`get_metadata` returns absolute (x, y) for every symbol, but the X/Y *grouping
-intent* is NOT directly inferable from coordinate clusters. A 96-variant frame
-could be either:
-
-  (a) outer = Size (4 columns), inner = Interaction (4 sub-cols), then Type rows
-  (b) outer = Type (2 big blocks vertically), inner = Size × State combined row
-
-Both produce similar coordinate clusters but **render in completely different
-shapes**. Coordinate-based assumption alone failed in real session: Button
-frame `164:1175` was structured as (b), not (a).
-
-Mitigation:
-  1. After A.0 enumeration, ALSO call `get_screenshot(frame-node-id)` BEFORE
-     building any layout. Visually inspect: are there 2 horizontal mega-bands
-     or 4 vertical mega-columns?
-  2. Do NOT start writing render code until you have looked at the screenshot.
-  3. If structure is ambiguous, build a 1-row prototype, screenshot it, and
-     ask the user to confirm orientation BEFORE expanding to all 96 cells.
-
-**A.0.2 — Symbol name ≠ Visual asset (REQUIRED for icon symbols)**
-
-Symbol names like `Icon_left=true, Icon_right=false` only declare position
-flags — they do NOT identify which icon graphic is rendered inside. Real case:
-metadata showed `Icon_left=true` and the implementer assumed a `<Plus />` icon,
-but Figma actually rendered the same `<ArrowRight />` in both positions
-(generic placeholder pattern).
-
-Mitigation:
-  - For any icon-bearing variant, call `get_design_context(child-node-id)` on
-    at least one Primary+icon and one Secondary+icon cell to inspect the actual
-    SVG / instance reference.
-  - When the icon is a placeholder (same icon in left & right slots), use the
-    same component for both positions in code.
-  - Never infer icon identity from the variant prop name.
-
-**A.1 — Per-node design context**
 ```
-get_design_context(node-id)            # the parent frame (overview + screenshot)
-get_design_context(child-node-id) × N  # MUST sample every (size × color × state) cell
-                                       # at minimum: one of each Interaction state
-                                       # AND one of each Type per state (Primary vs Secondary
-                                       # may use DIFFERENT tokens in the same state)
+get_code_connect_map(node-id)
+  → mapping exists → import the mapped component, skip code generation
+  → no mapping → continue with the normal workflow (A.0.1 onward)
+```
+
+After Step 5 commit, optionally register the new component to Code Connect:
+```
+get_code_connect_suggestions(node-id) → send_code_connect_mappings(...)
+```
+(Optional — prevents duplicate generation on the next run against the same design.)
+
+**A.0.1 — Don't guess the layout from coordinates alone (required)**
+
+Figma gives you absolute (x, y) positions, but those numbers don't tell you whether the grid reads left-to-right or top-to-bottom. The same coordinate spread could mean:
+- (a) Size changes across columns, state changes within sub-columns
+- (b) Type makes the big blocks, size × state fills each block
+
+These look similar in raw numbers but are completely different visually.
+
+What to do:
+1. After A.0, call `get_screenshot(frame-node-id)` before writing anything
+2. Look at the screenshot — how many big columns? How many big rows?
+3. **Do not write render code until you've seen the screenshot**
+4. If still unclear, build a one-row prototype → take screenshot → ask the user to confirm → then expand
+
+**A.0.2 — A symbol's name doesn't tell you which icon it is (required)**
+
+`Icon_left=true` just means "icon on the left" — it doesn't say which icon. You can't guess the icon from the prop name.
+
+- For any icon-bearing variant, call `get_design_context(child-node-id)` to see the actual SVG
+- If both left and right slots use the same icon (placeholder pattern), use the same component for both in code
+
+**A.0.3 — Draw an ASCII grid of the frame layout (required)**
+
+After looking at the screenshot, write out the frame structure as a grid. This becomes the reference for Step 3.1 coordinates.
+
+```
+Example:
+         │ Default │ Hover │ Pressed │ Disabled │
+─────────┼─────────┼───────┼─────────┼──────────┤
+L/none   │   ██    │  ██   │   ██    │    ██    │  ← Primary block
+L/right  │   ██    │  ██   │   ██    │    ██    │
+L/left   │   ██    │  ██   │   ██    │    ██    │
+─────────┼─────────┼───────┼─────────┼──────────┤
+L/none   │   ░░    │  ░░   │   ░░    │    ░░    │  ← Secondary block
+...
+```
+
+Label each direction clearly:
+- **Row axis**: what changes going down (icon position, variant type, etc.)
+- **Col axis**: what changes going right (state, size, etc.)
+- **Block axis**: what creates the major sections (type, color, etc.)
+
+**A.1 — Read the design details for each node**
+
+```
+get_design_context(node-id)            # overview of the parent frame + screenshot
+get_design_context(child-node-id) × N  # sample every (size × color × state) cell
+                                       # Primary and Secondary can use different tokens
+                                       # even in the same state
   → layout: auto-layout vs absolute, padding, gap, alignment
-  → transforms: rotation (exact degree e.g. -9.38°), scale, mirror
+  → transforms: rotation (exact degrees), scale, mirror
   → typography: family, weight, size, line-height, letter-spacing
-  → effects: drop-shadow, backdrop-blur, blend-mode, opacity
+  → effects: drop shadow, blur, blend mode, opacity
   → hierarchy: parent→child, z-order, masks
 
-get_variable_defs(node-id) × N         # call PER variant — token sets differ
-                                       # (e.g. Primary-Disabled may bind a unique
-                                       # `color/text/disabled` not used elsewhere)
+get_variable_defs(node-id) × N         # call per variant — token sets differ
   → extract design tokens
   → map each to global.css @theme inline variables
-
-get_screenshot()
-  → save as reference image for Step 4 comparison
 ```
 
-**A.2 — Large response handling**
+**A.2 — When the response is too large**
+
+If `get_design_context` returns more than 50 KB, MCP gives you a file path instead.
+Use `grep + sort + uniq -c` on that file to find which tokens appear most often — no need to read the whole thing.
+
+**A.3 — Identify the layout type**
+
+This decides how to structure the story container:
+- **Auto-layout frame** → use `flex`/`gap` in the story wrapper
+- **Absolute frame** → use `position: relative` container + `position: absolute` per child
+- **Variant grid (Type B)** → always absolute (column widths and row heights vary per cell, flex won't work)
+- **Form field** (TextField, TextArea, etc.) → flag for Step 4.3 audit
+
+#### B. Token audit
+
 ```
-If get_design_context output > 50KB, MCP returns persisted-output path.
-Use grep + sort + uniq -c on the persisted file to extract token usage
-frequency (e.g. how many variants use gap-50 vs gap-75) — this reveals
-matrix coverage without re-reading the whole blob.
+Build a mapping table: Figma token → project token
+
+✅ Found    → use the project token (p-200, rounded-150, etc.)
+⚠️ Close    → use the nearest token, note the difference in the report
+❌ No match → STOP: never use arbitrary values (p-[3px]). Report to user before continuing.
 ```
 
-**B. Token audit**
-```
-Build mapping table: Figma token → project custom token
+#### C. Backend sync (only for components that show API data)
 
-✅ Mapped  → use project token (p-200, rounded-150, etc.)
-⚠️ Close   → use nearest token, note deviation in report
-❌ No match → BLOCK: report to user before proceeding
-             Never use arbitrary values (p-[3px], w-[320px])
-```
+Skip this for pure design system components like Button, TextField, and Icon.
 
-**C. Backend sync**
-```
+```bash
 cd ../study-platform-mvp && git pull origin dev
 
-If component renders backend data:
-  → identify related DTO in src/types/api/ or src/api/openapi/
-  → extract optional fields list → mark as ? in component props
+# If the component renders backend data:
+#   → find the related DTO in src/types/api/ or src/api/openapi/
+#   → note which fields are optional → mark those with ? in component props
 ```
 
-### Step 2 — Component generation
+---
+
+### Step 2 — Write the component code
 
 ```typescript
-// Rules enforced:
+// Rules:
 // - Custom tokens only (p-200, gap-150, rounded-200)
-// - cn() for all className composition
-// - TypeScript props interface required
-// - Optional backend fields marked with ?
+// - Use cn() for every className
+// - TypeScript props interface is required
+// - Optional backend fields use ?
 // - No hardcoded colors or hex values
 
 export function ComponentName({ prop1, prop2 }: ComponentNameProps) {
@@ -142,222 +176,269 @@ export function ComponentName({ prop1, prop2 }: ComponentNameProps) {
 }
 ```
 
-After writing component:
+After writing, all three of these must pass before moving on:
+
 ```bash
 yarn lint:fix && yarn prettier:fix && yarn typecheck
 ```
-All three must pass before continuing.
 
-### Step 3 — Storybook story generation
+---
 
-Generate alongside component (same PR):
+### Step 3 — Write Storybook stories
 
+Story files live **next to the component** (co-located):
+```
+src/components/.../ComponentName.stories.tsx
+```
+
+**Type A (single component):**
 ```typescript
-// ComponentName.stories.tsx
-export default {
-  title: 'Components/ComponentName',
-  component: ComponentName,
-} satisfies Meta<typeof ComponentName>;
-
-// Required stories:
 export const Default: Story = { args: { ... } };
-export const [StateVariant]: Story = { ... }; // hover, disabled, loading, error
+export const Disabled: Story = { args: { disabled: true } };
+export const Error: Story = { args: { error: true } };
 export const Mobile: Story = {
   parameters: { viewport: { defaultViewport: 'mobile1' } },
 };
 ```
 
-#### Step 3.5 — Spec-matrix story (REQUIRED for design-system frames)
+**Type B (variant grid):** VisualMatrix (Step 3.1) + Interactive (Step 3.2) — both are required.
 
-When the source frame contains a variant matrix (e.g. Button = Size × Type ×
-State × Icon = 96 cells), add a `FigmaFullSpec` story that reproduces the
-Figma layout **pixel-faithfully** for visual regression and design review.
+**Type C (composite):** One `Composite` story that places all components together with the same layout and spacing as the Figma frame — not in isolation.
 
-Rules:
+#### Step 3.1 — VisualMatrix story (required for Type B)
 
-1. **Use absolute positioning, NOT flex/gap.** Variant matrices have variable
-   column widths (e.g. Large 145px, XSmall 112px) and variable row heights
-   (28~48px) that flex containers cannot reproduce without per-cell hacks.
+This story reproduces the Figma variant grid pixel-for-pixel, for visual regression and design review.
 
-2. **Normalize Figma absolute coords to (0,0) origin and store as a
-   single source-of-truth table:**
+**Rules:**
+
+1. **Use absolute positioning, not flex/gap.** Each cell has its own width and height, so flex containers can't reproduce the layout without per-cell hacks.
+
+2. **Normalize Figma coordinates to (0, 0).** Subtract the frame's top-left x/y from every child's position. Store this as a single reference table, derived from the ASCII grid (A.0.3).
+
+3. **Generic coordinate table pattern** — name the axes based on your A.0.3 grid, then rename them to match your component:
 
 ```typescript
-// Pattern from real Button (node 164:1175) implementation
-const SIZE_BASE_X: Record<ButtonSize, number> = {
-  large: 0, medium: 604, small: 1176, xsmall: 1664,  // from Figma x - 147
+// Axis keys come from the A.0.3 grid — rename for each component
+const COL_BASE_X: Record<SizeKey, number> = {
+  // normalized x per size column (Figma x - frame.x)
 };
-const STATE_DX: Record<ButtonSize, Record<ButtonState, number>> = {
-  large:  { default: 0, hover: 145, pressed: 290, disabled: 435 },
-  medium: { default: 0, hover: 137, pressed: 274, disabled: 411 },
-  small:  { default: 0, hover: 116, pressed: 232, disabled: 348 },
-  xsmall: { default: 0, hover: 112, pressed: 224, disabled: 336 },
+const STATE_DX: Record<SizeKey, Record<StateKey, number>> = {
+  // x offset per interaction state within each size column
 };
-const ICON_DY: Record<IconArrangement, number> = { none: 0, right: 78, left: 156 };
-const TYPE_BASE_Y: Record<ButtonType, number> = { primary: 0, secondary: 354 };
+const ROW_DY: Record<RowKey, number> = {
+  // y offset per row type (icon arrangement, variant, etc.)
+};
+const BLOCK_BASE_Y: Record<BlockKey, number> = {
+  // y starting point per major block (type, color, etc.)
+};
 
-const cells = SIZE_ORDER.flatMap((size) =>
-  STATE_ORDER.flatMap((state) =>
-    TYPE_ORDER.flatMap((type) =>
-      ICON_ORDER.map((icon) => ({
-        ...keys,
-        x: SIZE_BASE_X[size] + STATE_DX[size][state],
-        y: TYPE_BASE_Y[type] + ICON_DY[icon],
+const cells = BLOCK_KEYS.flatMap((block) =>
+  ROW_KEYS.flatMap((row) =>
+    COL_KEYS.flatMap((col) =>
+      STATE_KEYS.map((state) => ({
+        block, row, col, state,
+        x: COL_BASE_X[col] + STATE_DX[col][state],
+        y: BLOCK_BASE_Y[block] + ROW_DY[row],
       })),
     ),
   ),
 );
 ```
 
-3. **Wrap in `overflow: auto` container** when normalized width exceeds
-   viewport (Button matrix = 2072px). Faithful matching > viewport fit.
-
-4. **Statically simulate hover/pressed states** — CSS `:hover` cannot show all
-   4 interaction states simultaneously. Use `!important` overrides on cva-
-   generated bg classes:
+4. **Match the story container size to the Figma frame:**
 
 ```typescript
-const STATE_OVERRIDE: Record<ButtonType, Record<ButtonState, string>> = {
-  primary: {
-    default: '',
-    hover:    '!bg-fill-brand-default-hover',
-    pressed:  '!bg-fill-brand-default-pressed',
-    disabled: '',  // use disabled prop instead
-  },
-  // ...
+parameters: {
+  layout: 'fullscreen',
+},
+render: () => (
+  // width/height from Figma frame metadata; overflow: auto when wider than viewport
+  <div style={{ width: FRAME_WIDTH, height: FRAME_HEIGHT, position: 'relative', overflow: 'auto' }}>
+    {cells.map((cell) => (
+      <div key={`${cell.block}-${cell.row}-${cell.col}-${cell.state}`}
+           style={{ position: 'absolute', left: cell.x, top: cell.y }}>
+        <Component {...deriveProps(cell)} className={STATE_OVERRIDE[cell.block][cell.state]} />
+      </div>
+    ))}
+  </div>
+),
+```
+
+5. **Simulate interaction states statically** — CSS `:hover` can only show one element's hover state at a time. Use `!important` overrides on cva-generated classes to show all states at once:
+
+```typescript
+// Static overrides so all states appear simultaneously.
+// Real interaction behavior is verified in the Interactive story (Step 3.2).
+const STATE_OVERRIDE: Record<BlockKey, Record<StateKey, string>> = {
+  primary:   { default: '', hover: '!bg-fill-brand-default-hover', pressed: '!bg-fill-brand-default-pressed', disabled: '' },
+  secondary: { default: '', hover: '!bg-...', pressed: '!bg-...', disabled: '' },
 };
 ```
 
-5. **Disable matrix-axis controls** in story `argTypes` so users don't get
-   confused why color/size dropdowns appear inert (they're locked by render
-   loop):
+6. **Disable the grid axis controls** so reviewers don't see confusing dropdowns that don't do anything:
 
 ```typescript
 argTypes: {
-  color:        { table: { disable: true } },
-  size:         { table: { disable: true } },
-  iconPosition: { table: { disable: true } },
-  icon:         { table: { disable: true } },
-  disabled:     { table: { disable: true } },
-}
+  size:     { table: { disable: true } },
+  state:    { table: { disable: true } },
+  disabled: { table: { disable: true } },
+  // ... other grid axes
+},
 ```
 
-### Step 4 — Figma ↔ Storybook visual comparison
+#### Step 3.2 — Interactive story (required alongside VisualMatrix)
 
-```
-1. Start Storybook (yarn storybook → port 6006)
-2. Capture each story via Chrome DevTools MCP (take_screenshot fullPage)
-3. Re-fetch Figma reference via mcp__claude_ai_Figma__get_screenshot
-   (do not reuse a stale screenshot from Step 1 — short-lived URLs may expire)
-4. Read BOTH images in the SAME response (parallel Read calls) so the model
-   sees them side-by-side, not from memory.
+The `!important` overrides in VisualMatrix bypass the real CSS interaction chain (`hover:`, `focus-within:`, `active:`). Interactive verifies the real chain works correctly — no overrides, just actual interactive instances.
 
-Compare in two modes:
-  Visual (multimodal): block structure, column count, row count, color,
-                       spacing, typography, radius, shadows, icon identity
-  Numeric (text):      transforms — rotation °, scale, mirror
-                       coordinate sampling — getBoundingClientRect on key cells
-                       to confirm absolute positions match Figma metadata
-
-Output report:
-  ✅ Match    — list matched properties
-  ⚠️ Deviation — acceptable (sub-pixel rounding, +1px from border, etc.)
-                 with explanation
-  ❌ Mismatch  — fix → re-capture → re-compare
-
-Only proceed after all ❌ items resolved.
+```typescript
+export const Interactive: Story = {
+  render: () => (
+    <div className="flex gap-200 p-200">
+      <Component />           {/* default — hover/press manually in Storybook */}
+      <Component disabled />  {/* disabled */}
+    </div>
+  ),
+};
 ```
 
-#### Step 4.0 — NEVER self-approve a matrix on first pass (REQUIRED)
+---
 
-DOM assertions like "96 buttons rendered, all bg colors correct" prove the
-**cells exist** but NOT that the **layout matches Figma**. Real session: a
-build with all 96 buttons + correct colors + correct sizes was reported as
-"Figma 1:1 match" — but the outer block grouping was completely wrong (4
-size-columns vs Figma's 2 type-rows). The user had to point this out.
+### Step 4 — Compare Figma to Storybook visually
 
-Required protocol for ANY matrix/spec story:
+**Before starting: make sure Storybook is running at `http://localhost:6006`. If not, start it with `yarn storybook`.**
 
-1. **Always do an explicit screenshot diff** — even when DOM checks pass.
-2. **Read both images in one response** so the LLM sees them side-by-side,
-   not from prior-message memory.
-3. **State the layout structure aloud** before claiming match:
-   - "Figma: 2 horizontal mega-blocks (Primary top, Secondary bottom),
-     each block has 3 icon-rows × 16-cell rows."
-   - "My render: 2 horizontal mega-blocks (...), each block has ..."
-   - If the two descriptions differ → it is NOT a match. Fix first.
-4. **Defer to user confirmation** when the structure is non-trivial. Phrase
-   completion as "structure appears to match — please confirm against the
-   Figma file" rather than "1:1 match achieved".
+#### Step 4.1 — Comparison protocol
 
-#### Step 4.5 — Token cross-check matrix (REQUIRED)
+```
+A. Build the story URL
+   Story ID: kebab-case(meta.title) + '--' + kebab-case(export-name)
+   Example: title='Common/UI/TextField', export='VisualMatrix'
+     → id = 'common-ui-textfield--visual-matrix'
+   URL: http://localhost:6006/iframe.html?id=<story-id>&viewMode=story
 
-Pixel-level visual diff misses token-level drift (e.g. `#d1d2d4` vs `#d5d7da` —
-3 RGB units, invisible in screenshots but wrong token binding).
+B. If the URL doesn't work, find the story ID
+   Go to: http://localhost:6006/index.json
+   Run: Object.keys(json.entries).filter(k => k.includes('<keyword>'))
 
-Build an explicit table where rows = (size × color × state × icon) cells from
-Step A.0 enumeration, and columns = each design property:
+C. Take a Storybook screenshot
+   navigate_page(url) → take_screenshot(fullPage: true)
 
-| Variant | Figma value | Project token | Resolved px/hex | Match |
-|---|---|---|---|---|
-| L Primary Default bg | #f63d68 | `bg-fill-brand-default-default` | rose-500 → #f63d68 | ✓ |
-| L Secondary Disabled text | #d5d7da | `text-text-disabled` | gray-300 → #d5d7da | ✓ |
-| L Primary Disabled text | #d1d2d4 | `text-text-disabled` | gray-300 → #d5d7da | ❌ |
+D. Re-fetch the Figma reference (never reuse the Step 1 screenshot — it expires after ~7 days)
+   get_screenshot(nodeId, fileKey, enableBase64Response: true)
+
+E. Read both images in ONE response — never compare from memory.
+
+F. Say the layout out loud before claiming a match:
+   "Figma: <N> blocks, <R> rows × <C> cols per block"
+   "Storybook: <same format>"
+   If the descriptions don't match → it's not a match. Fix first.
+
+G. Compare:
+   - Visual: block/row/col structure, colors, spacing, typography, border-radius
+   - Numeric: use getBoundingClientRect on key cells to check pixel values
+
+H. Report:
+   ✅ Match — list what matched
+   ⚠️ Deviation — explain it (sub-pixel rounding, +1px border, etc.)
+   ❌ Mismatch — BLOCKER: fix → re-capture both → re-compare
+```
+
+**Re-comparison loop:** After fixing any ❌, re-capture both screenshots in one response and re-run the report. Only move to Step 5 when there are zero ❌ items. Never report a fix as done without screenshot evidence.
+
+**Never self-approve on the first pass.** DOM checks prove that cells exist — not that the layout matches Figma. Always do an explicit screenshot comparison.
+
+#### Step 4.2 — Token cross-check (required)
+
+Screenshots miss token-level drift. For example, `#d1d2d4` vs `#d5d7da` is only 3 RGB units apart — invisible in a screenshot but the wrong token binding.
+
+| Variant | Figma value | Project token | Resolved hex | Match |
+|---------|-------------|---------------|--------------|-------|
+| L Primary Default bg | #f63d68 | `bg-fill-brand-default-default` | #f63d68 | ✓ |
+| L Secondary Disabled text | #d5d7da | `text-text-disabled` | #d5d7da | ✓ |
 | M/L gap | 6px | `gap-75` | spacing-75 → 6px | ✓ |
-| XS/S gap | 4px | `gap-50` | spacing-50 → 4px | ✓ |
 
-Verification commands (project side):
 ```bash
-# Resolve project token to CSS value
+# Verify a project token resolves to the expected value
 grep -E "^\s*--color-text-disabled|^\s*--spacing-75" src/app/global.css
-
-# Extract Figma-side raw hex from variable defs (per node)
-get_variable_defs(node-id)
 ```
 
-Failure modes this catches but visual diff misses:
-- Two states map to the same project token but Figma uses two distinct tokens
-  (e.g. Primary-Disabled vs Secondary-Disabled text)
-- Project token name matches Figma name but resolves to different value
-- Spacing scale offsets (4 vs 6 px) inside <10px range
-- Hover/Pressed bound to wrong color step (rose-600 vs rose-700)
+Each ❌ row is a blocker — fix the token or get explicit user approval before Step 5.
 
-Each ❌ row is a blocker — either fix the token binding or document the
-deviation with explicit user approval before Step 5.
+What this catches that screenshots miss:
+- Two states use the same project token but Figma uses two different ones
+- Spacing values that are off by a few pixels (4 vs 6px)
+- Hover/Pressed wired to the wrong color step (rose-600 vs rose-700)
 
-### Step 5 — Commit to feature branch
+#### Step 4.3 — Form field traps (required for input/textarea/select)
+
+When A.3 flagged a form field, check each of these explicitly:
+
+**1. Don't confuse container height with input box height.**
+
+A Figma symbol height (e.g. TextArea L = 125px) almost always includes the helper-text row and gap. The actual input box is shorter:
 
 ```
+input_box_height = symbol_height − helper_height − container_gap
+```
+
+For single-line inputs, the heights are reliable (48/40px in DS 2.0) — verify they're in the spacing scale before using arbitrary `[Npx]`. For textareas, skip `min-h` entirely and use the `rows` attribute instead.
+
+**2. Trailing icon padding is asymmetric.**
+
+When there's an icon on the right, Figma usually reduces right padding by ~4px (12→8). Compare at least one cell without an icon and one with. If `pl` ≠ `pr`, encode it as a cva variant:
+
+```typescript
+hasTrailingIcon: { true: 'pr-100', false: 'pr-150' }
+```
+
+**3. Helper text token inconsistency.**
+
+Sample the helper text color in all states (default, focused, disabled, error, success). If 4 out of 5 use Subtlest but 1 uses Default, treat it as a Figma bug — implement Subtlest and note the outlier in the report.
+
+**4. Static grid overrides aren't real interactions.**
+
+The `!bg-...` overrides in VisualMatrix bypass the real `hover:`/`focus-within:`/`active:` chain. The Interactive story (Step 3.2) is required to verify that real interactions work.
+
+**5. Don't copy Figma typos into code.**
+
+Variable definitions sometimes contain typos (`Disableed`, `Hoverr`). Map them to correctly spelled project tokens — always.
+
+---
+
+### Step 5 — Commit to the feature branch
+
+```bash
 git add src/components/... src/stories/...
-commit message: "feat : <ComponentName> 컴포넌트 구현"
+# commit message: "feat : <ComponentName> 컴포넌트 구현"
 ```
 
-Include in commit:
+Include in the commit:
 - Component file
-- Storybook story file
-- Token mapping deviations (if any) noted in commit body
+- Storybook story file (VisualMatrix + Interactive for Type B)
+- Any token mapping deviations noted in the commit body
+
+---
 
 ## Output
 
 ```
 ✓ Token audit — 12 tokens mapped, 0 blocked
-✓ Component — src/components/common/ui/StudyCard.tsx
-✓ Story — src/stories/StudyCard.stories.tsx
+✓ Component — src/components/common/ui/Button/Button.tsx
+✓ Story — src/components/common/ui/Button/Button.stories.tsx
 ✓ Visual comparison — 8 ✅ match, 1 ⚠️ deviation (rounded 8.03° → 8°)
-✓ Committed: feat : StudyCard 컴포넌트 구현
+✓ Committed: feat : Button 컴포넌트 구현
 ```
 
-## Blockers (stop and report to user)
+## Stop and report to user when
 
-- Token audit: Figma token has no matching project token
-- Typecheck fails after generation
-- Visual comparison: ❌ mismatch that cannot be resolved with available tokens
-- Backend DTO not found for a component that renders API data
+- Token audit finds a Figma token with no matching project token
+- Typecheck fails after writing the component
+- Visual comparison has a ❌ mismatch that can't be fixed with available tokens
+- Component renders API data but no backend DTO exists
 
-## Notes
+## Things to keep in mind
 
-- Transform values (rotation, scale) must be compared numerically, not visually.
-  `-9.38°` and `-9°` are different — use exact Figma value.
-- `get_screenshot` is for reference only. Never implement from screenshot alone.
-- Component and story always committed together — never separately.
-- This command does NOT create a PR. Run `/pr` after feature dev is complete (Phase 2).
+- Rotation and scale values must match numerically. `-9.38°` and `-9°` are different — use the exact Figma value.
+- `get_screenshot` is for reference only. Never implement from a screenshot alone.
+- Component and story are always committed together — never separately.
+- This command does not create a PR. Run `/pr` after feature development is complete.

--- a/.claude/commands/design-to-dev.md
+++ b/.claude/commands/design-to-dev.md
@@ -1,16 +1,16 @@
-# /design-to-dev-en — Turn a Figma Design Into Component Code
+# /design-to-dev — Turn a Figma Design Into Component Code
 
 Takes a Figma URL and produces component code + Storybook stories + a visual comparison report, then commits everything.
 
 ## Usage
 
 ```
-/design-to-dev-en <figma-url> [component-name]
+/design-to-dev <figma-url> [component-name]
 ```
 
 Example:
 ```
-/design-to-dev-en https://figma.com/design/xxx?node-id=123 StudyCard
+/design-to-dev https://figma.com/design/xxx?node-id=123 StudyCard
 ```
 
 ---
@@ -80,27 +80,6 @@ What to do:
 
 - For any icon-bearing variant, call `get_design_context(child-node-id)` to see the actual SVG
 - If both left and right slots use the same icon (placeholder pattern), use the same component for both in code
-
-**A.0.3 — Draw an ASCII grid of the frame layout (required)**
-
-After looking at the screenshot, write out the frame structure as a grid. This becomes the reference for Step 3.1 coordinates.
-
-```
-Example:
-         │ Default │ Hover │ Pressed │ Disabled │
-─────────┼─────────┼───────┼─────────┼──────────┤
-L/none   │   ██    │  ██   │   ██    │    ██    │  ← Primary block
-L/right  │   ██    │  ██   │   ██    │    ██    │
-L/left   │   ██    │  ██   │   ██    │    ██    │
-─────────┼─────────┼───────┼─────────┼──────────┤
-L/none   │   ░░    │  ░░   │   ░░    │    ░░    │  ← Secondary block
-...
-```
-
-Label each direction clearly:
-- **Row axis**: what changes going down (icon position, variant type, etc.)
-- **Col axis**: what changes going right (state, size, etc.)
-- **Block axis**: what creates the major sections (type, color, etc.)
 
 **A.1 — Read the design details for each node**
 
@@ -213,12 +192,12 @@ This story reproduces the Figma variant grid pixel-for-pixel, for visual regress
 
 1. **Use absolute positioning, not flex/gap.** Each cell has its own width and height, so flex containers can't reproduce the layout without per-cell hacks.
 
-2. **Normalize Figma coordinates to (0, 0).** Subtract the frame's top-left x/y from every child's position. Store this as a single reference table, derived from the ASCII grid (A.0.3).
+2. **Normalize Figma coordinates to (0, 0).** Subtract the frame's top-left x/y from every child's position. Store this as a single reference table.
 
-3. **Generic coordinate table pattern** — name the axes based on your A.0.3 grid, then rename them to match your component:
+3. **Generic coordinate table pattern** — name the axes by what changes along each direction in the frame (row/col/block), then rename them to match your component:
 
 ```typescript
-// Axis keys come from the A.0.3 grid — rename for each component
+// Axis keys: rename for each component based on what varies per direction
 const COL_BASE_X: Record<SizeKey, number> = {
   // normalized x per size column (Figma x - frame.x)
 };

--- a/.claude/commands/design-to-dev.md
+++ b/.claude/commands/design-to-dev.md
@@ -20,20 +20,88 @@ Example:
 Run all three simultaneously:
 
 **A. Figma analysis** (Figma MCP)
+
+**A.0 — Frame enumeration FIRST (REQUIRED for variant frames)**
 ```
-get_design_context(node-id)
+get_metadata(node-id)
+  → enumerate ALL child symbols/nodes inside the frame
+  → never assume the root node alone defines the component
+  → for design-system files: a single Button frame can contain 96+ variants
+    (sizes × colors × states × icon arrangements)
+  → record every child node-id; later Steps must cover every cell of the matrix
+```
+
+If `get_design_context` is called without first enumerating children, hidden
+variants (e.g. Disabled, Pressed, edge-case sizes) will be silently skipped.
+This has caused real mismatches (e.g. Primary-Disabled text color drifting from
+Secondary-Disabled because only one was sampled).
+
+**A.0.1 — Coordinates ≠ Visual structure (REQUIRED interpretation step)**
+
+`get_metadata` returns absolute (x, y) for every symbol, but the X/Y *grouping
+intent* is NOT directly inferable from coordinate clusters. A 96-variant frame
+could be either:
+
+  (a) outer = Size (4 columns), inner = Interaction (4 sub-cols), then Type rows
+  (b) outer = Type (2 big blocks vertically), inner = Size × State combined row
+
+Both produce similar coordinate clusters but **render in completely different
+shapes**. Coordinate-based assumption alone failed in real session: Button
+frame `164:1175` was structured as (b), not (a).
+
+Mitigation:
+  1. After A.0 enumeration, ALSO call `get_screenshot(frame-node-id)` BEFORE
+     building any layout. Visually inspect: are there 2 horizontal mega-bands
+     or 4 vertical mega-columns?
+  2. Do NOT start writing render code until you have looked at the screenshot.
+  3. If structure is ambiguous, build a 1-row prototype, screenshot it, and
+     ask the user to confirm orientation BEFORE expanding to all 96 cells.
+
+**A.0.2 — Symbol name ≠ Visual asset (REQUIRED for icon symbols)**
+
+Symbol names like `Icon_left=true, Icon_right=false` only declare position
+flags — they do NOT identify which icon graphic is rendered inside. Real case:
+metadata showed `Icon_left=true` and the implementer assumed a `<Plus />` icon,
+but Figma actually rendered the same `<ArrowRight />` in both positions
+(generic placeholder pattern).
+
+Mitigation:
+  - For any icon-bearing variant, call `get_design_context(child-node-id)` on
+    at least one Primary+icon and one Secondary+icon cell to inspect the actual
+    SVG / instance reference.
+  - When the icon is a placeholder (same icon in left & right slots), use the
+    same component for both positions in code.
+  - Never infer icon identity from the variant prop name.
+
+**A.1 — Per-node design context**
+```
+get_design_context(node-id)            # the parent frame (overview + screenshot)
+get_design_context(child-node-id) × N  # MUST sample every (size × color × state) cell
+                                       # at minimum: one of each Interaction state
+                                       # AND one of each Type per state (Primary vs Secondary
+                                       # may use DIFFERENT tokens in the same state)
   → layout: auto-layout vs absolute, padding, gap, alignment
   → transforms: rotation (exact degree e.g. -9.38°), scale, mirror
   → typography: family, weight, size, line-height, letter-spacing
   → effects: drop-shadow, backdrop-blur, blend-mode, opacity
   → hierarchy: parent→child, z-order, masks
 
-get_variable_defs()
+get_variable_defs(node-id) × N         # call PER variant — token sets differ
+                                       # (e.g. Primary-Disabled may bind a unique
+                                       # `color/text/disabled` not used elsewhere)
   → extract design tokens
   → map each to global.css @theme inline variables
 
 get_screenshot()
   → save as reference image for Step 4 comparison
+```
+
+**A.2 — Large response handling**
+```
+If get_design_context output > 50KB, MCP returns persisted-output path.
+Use grep + sort + uniq -c on the persisted file to extract token usage
+frequency (e.g. how many variants use gap-50 vs gap-75) — this reveals
+matrix coverage without re-reading the whole blob.
 ```
 
 **B. Token audit**
@@ -99,25 +167,163 @@ export const Mobile: Story = {
 };
 ```
 
+#### Step 3.5 — Spec-matrix story (REQUIRED for design-system frames)
+
+When the source frame contains a variant matrix (e.g. Button = Size × Type ×
+State × Icon = 96 cells), add a `FigmaFullSpec` story that reproduces the
+Figma layout **pixel-faithfully** for visual regression and design review.
+
+Rules:
+
+1. **Use absolute positioning, NOT flex/gap.** Variant matrices have variable
+   column widths (e.g. Large 145px, XSmall 112px) and variable row heights
+   (28~48px) that flex containers cannot reproduce without per-cell hacks.
+
+2. **Normalize Figma absolute coords to (0,0) origin and store as a
+   single source-of-truth table:**
+
+```typescript
+// Pattern from real Button (node 164:1175) implementation
+const SIZE_BASE_X: Record<ButtonSize, number> = {
+  large: 0, medium: 604, small: 1176, xsmall: 1664,  // from Figma x - 147
+};
+const STATE_DX: Record<ButtonSize, Record<ButtonState, number>> = {
+  large:  { default: 0, hover: 145, pressed: 290, disabled: 435 },
+  medium: { default: 0, hover: 137, pressed: 274, disabled: 411 },
+  small:  { default: 0, hover: 116, pressed: 232, disabled: 348 },
+  xsmall: { default: 0, hover: 112, pressed: 224, disabled: 336 },
+};
+const ICON_DY: Record<IconArrangement, number> = { none: 0, right: 78, left: 156 };
+const TYPE_BASE_Y: Record<ButtonType, number> = { primary: 0, secondary: 354 };
+
+const cells = SIZE_ORDER.flatMap((size) =>
+  STATE_ORDER.flatMap((state) =>
+    TYPE_ORDER.flatMap((type) =>
+      ICON_ORDER.map((icon) => ({
+        ...keys,
+        x: SIZE_BASE_X[size] + STATE_DX[size][state],
+        y: TYPE_BASE_Y[type] + ICON_DY[icon],
+      })),
+    ),
+  ),
+);
+```
+
+3. **Wrap in `overflow: auto` container** when normalized width exceeds
+   viewport (Button matrix = 2072px). Faithful matching > viewport fit.
+
+4. **Statically simulate hover/pressed states** — CSS `:hover` cannot show all
+   4 interaction states simultaneously. Use `!important` overrides on cva-
+   generated bg classes:
+
+```typescript
+const STATE_OVERRIDE: Record<ButtonType, Record<ButtonState, string>> = {
+  primary: {
+    default: '',
+    hover:    '!bg-fill-brand-default-hover',
+    pressed:  '!bg-fill-brand-default-pressed',
+    disabled: '',  // use disabled prop instead
+  },
+  // ...
+};
+```
+
+5. **Disable matrix-axis controls** in story `argTypes` so users don't get
+   confused why color/size dropdowns appear inert (they're locked by render
+   loop):
+
+```typescript
+argTypes: {
+  color:        { table: { disable: true } },
+  size:         { table: { disable: true } },
+  iconPosition: { table: { disable: true } },
+  icon:         { table: { disable: true } },
+  disabled:     { table: { disable: true } },
+}
+```
+
 ### Step 4 — Figma ↔ Storybook visual comparison
 
 ```
 1. Start Storybook (yarn storybook → port 6006)
-2. Capture each story via Claude Preview MCP (preview_screenshot)
-3. Load Figma reference image from Step 1
+2. Capture each story via Chrome DevTools MCP (take_screenshot fullPage)
+3. Re-fetch Figma reference via mcp__claude_ai_Figma__get_screenshot
+   (do not reuse a stale screenshot from Step 1 — short-lived URLs may expire)
+4. Read BOTH images in the SAME response (parallel Read calls) so the model
+   sees them side-by-side, not from memory.
 
 Compare in two modes:
-  Visual (multimodal): color, spacing, typography, radius, shadows
+  Visual (multimodal): block structure, column count, row count, color,
+                       spacing, typography, radius, shadows, icon identity
   Numeric (text):      transforms — rotation °, scale, mirror
-                       (screenshots cannot reliably show transform values)
+                       coordinate sampling — getBoundingClientRect on key cells
+                       to confirm absolute positions match Figma metadata
 
 Output report:
   ✅ Match    — list matched properties
-  ⚠️ Deviation — acceptable (sub-pixel rounding, etc.) with explanation
+  ⚠️ Deviation — acceptable (sub-pixel rounding, +1px from border, etc.)
+                 with explanation
   ❌ Mismatch  — fix → re-capture → re-compare
 
 Only proceed after all ❌ items resolved.
 ```
+
+#### Step 4.0 — NEVER self-approve a matrix on first pass (REQUIRED)
+
+DOM assertions like "96 buttons rendered, all bg colors correct" prove the
+**cells exist** but NOT that the **layout matches Figma**. Real session: a
+build with all 96 buttons + correct colors + correct sizes was reported as
+"Figma 1:1 match" — but the outer block grouping was completely wrong (4
+size-columns vs Figma's 2 type-rows). The user had to point this out.
+
+Required protocol for ANY matrix/spec story:
+
+1. **Always do an explicit screenshot diff** — even when DOM checks pass.
+2. **Read both images in one response** so the LLM sees them side-by-side,
+   not from prior-message memory.
+3. **State the layout structure aloud** before claiming match:
+   - "Figma: 2 horizontal mega-blocks (Primary top, Secondary bottom),
+     each block has 3 icon-rows × 16-cell rows."
+   - "My render: 2 horizontal mega-blocks (...), each block has ..."
+   - If the two descriptions differ → it is NOT a match. Fix first.
+4. **Defer to user confirmation** when the structure is non-trivial. Phrase
+   completion as "structure appears to match — please confirm against the
+   Figma file" rather than "1:1 match achieved".
+
+#### Step 4.5 — Token cross-check matrix (REQUIRED)
+
+Pixel-level visual diff misses token-level drift (e.g. `#d1d2d4` vs `#d5d7da` —
+3 RGB units, invisible in screenshots but wrong token binding).
+
+Build an explicit table where rows = (size × color × state × icon) cells from
+Step A.0 enumeration, and columns = each design property:
+
+| Variant | Figma value | Project token | Resolved px/hex | Match |
+|---|---|---|---|---|
+| L Primary Default bg | #f63d68 | `bg-fill-brand-default-default` | rose-500 → #f63d68 | ✓ |
+| L Secondary Disabled text | #d5d7da | `text-text-disabled` | gray-300 → #d5d7da | ✓ |
+| L Primary Disabled text | #d1d2d4 | `text-text-disabled` | gray-300 → #d5d7da | ❌ |
+| M/L gap | 6px | `gap-75` | spacing-75 → 6px | ✓ |
+| XS/S gap | 4px | `gap-50` | spacing-50 → 4px | ✓ |
+
+Verification commands (project side):
+```bash
+# Resolve project token to CSS value
+grep -E "^\s*--color-text-disabled|^\s*--spacing-75" src/app/global.css
+
+# Extract Figma-side raw hex from variable defs (per node)
+get_variable_defs(node-id)
+```
+
+Failure modes this catches but visual diff misses:
+- Two states map to the same project token but Figma uses two distinct tokens
+  (e.g. Primary-Disabled vs Secondary-Disabled text)
+- Project token name matches Figma name but resolves to different value
+- Spacing scale offsets (4 vs 6 px) inside <10px range
+- Hover/Pressed bound to wrong color step (rose-600 vs rose-700)
+
+Each ❌ row is a blocker — either fix the token binding or document the
+deviation with explicit user approval before Step 5.
 
 ### Step 5 — Commit to feature branch
 

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -77,6 +77,7 @@ https://velog.io/@oneook/tailwindcss-4.0-%EB%AC%B4%EC%97%87%EC%9D%B4-%EB%8B%AC%E
   --color-gray-50: #fafafa;
   --color-gray-100: #f5f5f5;
   --color-gray-200: #e9eaeb;
+  --color-gray-275: #d1d2d4;
   --color-gray-300: #d5d7da;
   --color-gray-400: #a4a7ae;
   --color-gray-500: #717680;
@@ -201,6 +202,7 @@ https://velog.io/@oneook/tailwindcss-4.0-%EB%AC%B4%EC%97%87%EC%9D%B4-%EB%8B%AC%E
   --color-text-brand: var(--color-rose-500);
   --color-text-default: var(--color-gray-800);
   --color-text-disabled: var(--color-gray-300);
+  --color-text-disabled-strong: var(--color-gray-275);
   --color-text-error: var(--color-red-500);
   --color-text-strong: var(--color-gray-900);
   --color-text-subtlest: var(--color-gray-400);

--- a/src/components/common/ui/button/button.stories.tsx
+++ b/src/components/common/ui/button/button.stories.tsx
@@ -4,8 +4,10 @@ import { ArrowRight, Plus } from 'lucide-react';
 import Button from '.';
 
 const meta: Meta<typeof Button> = {
+  title: 'Common/UI/Button',
   component: Button,
   tags: ['autodocs'],
+  render: (args) => <Button {...args} />,
   argTypes: {
     color: {
       control: { type: 'select' },
@@ -90,7 +92,7 @@ export const WithLeftIcon: Story = {
     children: '아이콘 (왼쪽)',
     color: 'primary',
     size: 'medium',
-    icon: <Plus size={16} />,
+    icon: <Plus />,
     iconPosition: 'left',
   },
 };
@@ -100,7 +102,7 @@ export const WithRightIcon: Story = {
     children: '아이콘 (오른쪽)',
     color: 'primary',
     size: 'medium',
-    icon: <ArrowRight size={16} />,
+    icon: <ArrowRight />,
     iconPosition: 'right',
   },
 };
@@ -111,6 +113,204 @@ export const Disabled: Story = {
     color: 'primary',
     size: 'medium',
     disabled: true,
+  },
+};
+
+type ButtonSize = 'large' | 'medium' | 'small' | 'xsmall';
+type ButtonType = 'primary' | 'secondary';
+type ButtonState = 'default' | 'hover' | 'pressed' | 'disabled';
+type IconArrangement = 'none' | 'right' | 'left';
+
+const SIZE_ORDER: ButtonSize[] = ['large', 'medium', 'small', 'xsmall'];
+const STATE_ORDER: ButtonState[] = ['default', 'hover', 'pressed', 'disabled'];
+const TYPE_ORDER: ButtonType[] = ['primary', 'secondary'];
+const ICON_ORDER: IconArrangement[] = ['none', 'right', 'left'];
+
+const STATE_LABEL: Record<ButtonState, string> = {
+  default: 'Default',
+  hover: 'Hover',
+  pressed: 'Pressed',
+  disabled: 'Disabled',
+};
+
+const SIZE_TO_PROP: Record<
+  ButtonSize,
+  'large' | 'medium' | 'small' | 'xsmall'
+> = {
+  large: 'large',
+  medium: 'medium',
+  small: 'small',
+  xsmall: 'xsmall',
+};
+
+const STATE_OVERRIDE: Record<ButtonType, Record<ButtonState, string>> = {
+  primary: {
+    default: '',
+    hover: '!bg-fill-brand-default-hover',
+    pressed: '!bg-fill-brand-default-pressed',
+    disabled: '',
+  },
+  secondary: {
+    default: '',
+    hover: '!bg-fill-neutral-default-hover',
+    pressed: '!bg-fill-neutral-default-pressed',
+    disabled: '',
+  },
+};
+
+function FigmaCell({
+  size,
+  type,
+  state,
+  icon,
+  label,
+}: {
+  size: ButtonSize;
+  type: ButtonType;
+  state: ButtonState;
+  icon: IconArrangement;
+  label: string;
+}) {
+  const isDisabled = state === 'disabled';
+  const overrideClass = STATE_OVERRIDE[type][state];
+  const iconNode =
+    icon === 'left' || icon === 'right' ? <ArrowRight /> : undefined;
+  const iconPosition = icon === 'right' ? 'right' : 'left';
+
+  return (
+    <Button
+      color={type}
+      size={SIZE_TO_PROP[size]}
+      disabled={isDisabled}
+      className={overrideClass}
+      icon={iconNode}
+      iconPosition={iconPosition}
+    >
+      {label}
+    </Button>
+  );
+}
+
+export const FigmaFullSpec: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Figma DS 2.0 (node 164:1175) 전체 96 variant 배치를 그대로 재현. 4 Size × 4 Interaction × 2 Type × 3 Icon. Hover/Pressed는 `!bg-*` 강제 override로 정적 시각화. children만 Controls로 조정 가능.',
+      },
+    },
+  },
+  argTypes: {
+    color: { table: { disable: true } },
+    size: { table: { disable: true } },
+    iconPosition: { table: { disable: true } },
+    icon: { table: { disable: true } },
+    disabled: { table: { disable: true } },
+    loading: { table: { disable: true } },
+    loadingText: { table: { disable: true } },
+    spinner: { table: { disable: true } },
+    asChild: { table: { disable: true } },
+  },
+  args: {
+    children: 'Label',
+  },
+  render: (args) => {
+    const label = typeof args.children === 'string' ? args.children : 'Label';
+
+    const SIZE_BASE_X: Record<ButtonSize, number> = {
+      large: 0,
+      medium: 604,
+      small: 1176,
+      xsmall: 1664,
+    };
+    const STATE_DX: Record<ButtonSize, Record<ButtonState, number>> = {
+      large: { default: 0, hover: 145, pressed: 290, disabled: 435 },
+      medium: { default: 0, hover: 137, pressed: 274, disabled: 411 },
+      small: { default: 0, hover: 116, pressed: 232, disabled: 348 },
+      xsmall: { default: 0, hover: 112, pressed: 224, disabled: 336 },
+    };
+    const ICON_DY: Record<IconArrangement, number> = {
+      none: 0,
+      right: 78,
+      left: 156,
+    };
+    const TYPE_BASE_Y: Record<ButtonType, number> = {
+      primary: 0,
+      secondary: 354,
+    };
+
+    const cells = SIZE_ORDER.flatMap((size) =>
+      STATE_ORDER.flatMap((state) =>
+        TYPE_ORDER.flatMap((type) =>
+          ICON_ORDER.map((icon) => ({
+            size,
+            state,
+            type,
+            icon,
+            x: SIZE_BASE_X[size] + STATE_DX[size][state],
+            y: TYPE_BASE_Y[type] + ICON_DY[icon],
+          })),
+        ),
+      ),
+    );
+
+    const columnLabels = SIZE_ORDER.flatMap((size) =>
+      STATE_ORDER.map((state) => ({
+        key: `${size}-${state}`,
+        text: STATE_LABEL[state],
+        x: SIZE_BASE_X[size] + STATE_DX[size][state],
+      })),
+    );
+
+    const LABEL_ROW_HEIGHT = 28;
+
+    return (
+      <div style={{ overflow: 'auto', padding: 48, background: '#ffffff' }}>
+        <div
+          style={{
+            position: 'relative',
+            width: 2072,
+            height: 558 + LABEL_ROW_HEIGHT,
+          }}
+        >
+          {columnLabels.map(({ key, text, x }) => (
+            <span
+              key={`label-${key}`}
+              style={{
+                position: 'absolute',
+                left: x,
+                top: 0,
+                fontSize: 11,
+                fontWeight: 600,
+                color: '#6b7280',
+                textTransform: 'uppercase',
+                letterSpacing: 0.5,
+              }}
+            >
+              {text}
+            </span>
+          ))}
+          {cells.map(({ size, state, type, icon, x, y }) => (
+            <div
+              key={`${size}-${state}-${type}-${icon}`}
+              style={{
+                position: 'absolute',
+                left: x,
+                top: y + LABEL_ROW_HEIGHT,
+              }}
+            >
+              <FigmaCell
+                size={size}
+                type={type}
+                state={state}
+                icon={icon}
+                label={label}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
   },
 };
 

--- a/src/components/common/ui/button/index.tsx
+++ b/src/components/common/ui/button/index.tsx
@@ -11,16 +11,16 @@ const ICON_SIZE_MAP = {
 } as const;
 
 const buttonVariants = cva(
-  'flex items-center justify-center cursor-pointer py-0 disabled:bg-background-disabled',
+  'flex items-center justify-center cursor-pointer py-0 disabled:bg-background-disabled disabled:cursor-not-allowed',
   {
     variants: {
       color: {
         primary:
-          'bg-fill-brand-default-default text-text-inverse hover:bg-fill-brand-default-hover active:bg-fill-brand-default-pressed disabled:text-text-disabled-strong disabled:cursor-not-allowed',
+          'bg-fill-brand-default-default text-text-inverse hover:bg-fill-brand-default-hover active:bg-fill-brand-default-pressed disabled:text-text-disabled-strong',
         secondary:
-          'bg-fill-neutral-default-default text-text-default hover:bg-fill-neutral-default-hover active:bg-fill-neutral-default-pressed disabled:text-text-disabled disabled:cursor-not-allowed',
+          'bg-fill-neutral-default-default text-text-default hover:bg-fill-neutral-default-hover active:bg-fill-neutral-default-pressed disabled:text-text-disabled',
         outlined:
-          'bg-fill-background-surface-default text-text-default border border-border-default border-[1px] hover:bg-fill-neutral-subtle-hover active:bg-fill-neutral-subtle-pressed disabled:text-text-disabled disabled:border-border-disabled disabled:cursor-not-allowed',
+          'bg-fill-background-surface-default text-text-default border border-border-default border-[1px] hover:bg-fill-neutral-subtle-hover active:bg-fill-neutral-subtle-pressed disabled:text-text-disabled disabled:border-border-disabled',
       },
       size: {
         xsmall: 'px-100 font-designer-13b rounded-75 h-350',
@@ -95,7 +95,6 @@ function Button({
   );
 
   return asChild ? (
-    // asChild 모드 → Slot은 children 하나만 받아야 함
     <Comp
       data-slot="button"
       className={cn(buttonVariants({ color, size }), className)}
@@ -106,7 +105,6 @@ function Button({
       {children}
     </Comp>
   ) : (
-    // 기본 모드 → 내부 UI 구성 가능
     <button
       data-slot="button"
       className={cn(buttonVariants({ color, size }), className)}

--- a/src/components/common/ui/button/index.tsx
+++ b/src/components/common/ui/button/index.tsx
@@ -1,18 +1,26 @@
 import { Slot } from '@radix-ui/react-slot';
 import { cva, VariantProps } from 'class-variance-authority';
+import { cloneElement, isValidElement } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 
+const ICON_SIZE_MAP = {
+  xsmall: 18,
+  small: 20,
+  medium: 24,
+  large: 24,
+} as const;
+
 const buttonVariants = cva(
-  'flex items-center justify-center cursor-pointer py-0 disabled:bg-background-disabled disabled:text-text-disabled',
+  'flex items-center justify-center cursor-pointer py-0 disabled:bg-background-disabled',
   {
     variants: {
       color: {
         primary:
-          'bg-fill-brand-default-default text-text-inverse hover:bg-fill-brand-default-hover active:bg-fill-brand-default-pressed',
+          'bg-fill-brand-default-default text-text-inverse hover:bg-fill-brand-default-hover active:bg-fill-brand-default-pressed disabled:text-text-disabled-strong disabled:cursor-not-allowed',
         secondary:
-          'bg-fill-neutral-default-default text-text-default hover:bg-fill-neutral-default-hover active:bg-fill-neutral-default-pressed',
+          'bg-fill-neutral-default-default text-text-default hover:bg-fill-neutral-default-hover active:bg-fill-neutral-default-pressed disabled:text-text-disabled disabled:cursor-not-allowed',
         outlined:
-          'bg-fill-background-surface-default text-text-default border border-border-default border-[1px] hover:bg-fill-neutral-subtle-hover active:bg-fill-neutral-subtle-pressed',
+          'bg-fill-background-surface-default text-text-default border border-border-default border-[1px] hover:bg-fill-neutral-subtle-hover active:bg-fill-neutral-subtle-pressed disabled:text-text-disabled disabled:border-border-disabled disabled:cursor-not-allowed',
       },
       size: {
         xsmall: 'px-100 font-designer-13b rounded-75 h-350',
@@ -27,6 +35,18 @@ const buttonVariants = cva(
     },
   },
 );
+
+const buttonContentGapVariants = cva('flex items-center', {
+  variants: {
+    size: {
+      xsmall: 'gap-50',
+      small: 'gap-50',
+      medium: 'gap-75',
+      large: 'gap-75',
+    },
+  },
+  defaultVariants: { size: 'medium' },
+});
 
 function Button({
   color,
@@ -52,20 +72,24 @@ function Button({
   }) {
   const Comp = asChild ? Slot : 'button';
   const isDisabled = disabled || loading;
+  const iconSize = ICON_SIZE_MAP[size ?? 'medium'];
+  const sizedIcon = isValidElement<{ size?: number }>(icon)
+    ? cloneElement(icon, { size: icon.props.size ?? iconSize })
+    : icon;
   const loadingIndicator = spinner ?? (
     <span className="h-14 w-14 animate-spin rounded-full border-2 border-current border-t-transparent" />
   );
   const contentText = loading ? (loadingText ?? children) : children;
 
   const content = (
-    <span className="flex items-center gap-50">
+    <span className={buttonContentGapVariants({ size })}>
       {loading && <span className="flex items-center">{loadingIndicator}</span>}
-      {icon && iconPosition === 'left' && (
-        <span className="flex items-center">{icon}</span>
+      {sizedIcon && iconPosition === 'left' && (
+        <span className="flex items-center">{sizedIcon}</span>
       )}
       {contentText}
-      {icon && iconPosition === 'right' && (
-        <span className="flex items-center">{icon}</span>
+      {sizedIcon && iconPosition === 'right' && (
+        <span className="flex items-center">{sizedIcon}</span>
       )}
     </span>
   );

--- a/src/components/common/ui/text-field/index.tsx
+++ b/src/components/common/ui/text-field/index.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { cva } from 'class-variance-authority';
+import { forwardRef, useState } from 'react';
+import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+
+type FieldState = 'default' | 'error' | 'success' | 'disabled';
+
+const containerVariants = 'flex w-full flex-col gap-75';
+
+const STATE_VARIANTS: Record<FieldState, string> = {
+  default:
+    'border-border-default hover:bg-fill-neutral-subtle-hover active:bg-fill-neutral-subtle-pressed focus-within:border-border-strong focus-within:bg-fill-neutral-subtle-default',
+  error: 'border-border-error',
+  success: 'border-border-success',
+  disabled: 'border-border-disabled bg-background-disabled cursor-not-allowed',
+};
+
+const inputBoxVariants = cva(
+  'flex w-full items-center border bg-fill-neutral-subtle-default rounded-100 pl-150 transition-colors',
+  {
+    variants: {
+      size: {
+        L: 'h-600',
+        M: 'h-500',
+      },
+      state: STATE_VARIANTS,
+      hasTrailingIcon: {
+        true: 'pr-100',
+        false: 'pr-150',
+      },
+    },
+    defaultVariants: { size: 'L', state: 'default', hasTrailingIcon: false },
+  },
+);
+
+const textareaBoxVariants = cva(
+  'flex w-full flex-col items-start border bg-fill-neutral-subtle-default rounded-100 p-150 transition-colors',
+  {
+    variants: {
+      state: STATE_VARIANTS,
+    },
+    defaultVariants: { state: 'default' },
+  },
+);
+
+const fieldElementVariants = cva(
+  'min-w-0 flex-1 bg-transparent text-text-default outline-none placeholder:text-text-subtlest disabled:cursor-not-allowed disabled:text-text-disabled disabled:placeholder:text-text-disabled',
+  {
+    variants: {
+      size: {
+        L: 'font-designer-16m',
+        M: 'font-designer-14m',
+      },
+    },
+    defaultVariants: { size: 'L' },
+  },
+);
+
+const helperVariants = cva('font-designer-13r', {
+  variants: {
+    state: {
+      default: 'text-text-subtlest',
+      error: 'text-text-error',
+      success: 'text-text-success',
+      disabled: 'text-text-subtlest',
+    },
+  },
+  defaultVariants: { state: 'default' },
+});
+
+function deriveState({
+  disabled,
+  error,
+  success,
+}: {
+  disabled?: boolean;
+  error?: boolean;
+  success?: boolean;
+}): FieldState {
+  if (disabled) return 'disabled';
+  if (error) return 'error';
+  if (success) return 'success';
+  return 'default';
+}
+
+interface CommonProps {
+  size?: 'L' | 'M';
+  helperText?: string;
+  error?: boolean;
+  success?: boolean;
+  className?: string;
+  containerClassName?: string;
+}
+
+type TextFieldProps = CommonProps & {
+  showClear?: boolean;
+  trailingIcon?: React.ReactNode;
+  onClear?: () => void;
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>;
+
+const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
+  function TextField(
+    {
+      size = 'L',
+      helperText,
+      error,
+      success,
+      disabled,
+      showClear,
+      trailingIcon,
+      onClear,
+      className,
+      containerClassName,
+      ...inputProps
+    },
+    ref,
+  ) {
+    const state = deriveState({ disabled, error, success });
+    const hasTrailingIcon = (showClear && !disabled) || !!trailingIcon;
+    return (
+      <div className={cn(containerVariants, containerClassName)}>
+        <div
+          className={cn(
+            inputBoxVariants({ size, state, hasTrailingIcon }),
+            className,
+          )}
+        >
+          <input
+            ref={ref}
+            data-slot="text-field"
+            disabled={disabled}
+            aria-invalid={error || undefined}
+            className={fieldElementVariants({ size })}
+            {...inputProps}
+          />
+          {showClear && !disabled ? (
+            <button
+              type="button"
+              onClick={onClear}
+              aria-label="입력 지우기"
+              className="ml-50 size-5 shrink-0 text-gray-400"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <path
+                  d="M10 0C4.47 0 0 4.47 0 10C0 15.53 4.47 20 10 20C15.53 20 20 15.53 20 10C20 4.47 15.53 0 10 0ZM15 13.59L13.59 15L10 11.41L6.41 15L5 13.59L8.59 10L5 6.41L6.41 5L10 8.59L13.59 5L15 6.41L11.41 10L15 13.59Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          ) : trailingIcon ? (
+            <span className="text-icon-subtlest ml-50 flex size-5 items-center justify-center">
+              {trailingIcon}
+            </span>
+          ) : null}
+        </div>
+        {helperText && (
+          <p className={helperVariants({ state })}>{helperText}</p>
+        )}
+      </div>
+    );
+  },
+);
+
+type TextAreaProps = CommonProps & {
+  showCounter?: boolean;
+} & Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'size'>;
+
+const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  function TextArea(
+    {
+      size = 'L',
+      helperText,
+      error,
+      success,
+      disabled,
+      showCounter,
+      maxLength,
+      value,
+      defaultValue,
+      onChange,
+      className,
+      containerClassName,
+      rows = 3,
+      ...textareaProps
+    },
+    ref,
+  ) {
+    const state = deriveState({ disabled, error, success });
+    const showHelperRow =
+      !!helperText || (showCounter && maxLength !== undefined);
+    const isControlled = value !== undefined;
+    const [internalValue, setInternalValue] = useState(
+      String(defaultValue ?? ''),
+    );
+    const textValue = isControlled ? String(value) : internalValue;
+
+    return (
+      <div className={cn(containerVariants, containerClassName)}>
+        <div className={cn(textareaBoxVariants({ state }), className)}>
+          <textarea
+            ref={ref}
+            data-slot="text-field"
+            disabled={disabled}
+            maxLength={maxLength}
+            rows={rows}
+            value={value}
+            defaultValue={defaultValue}
+            aria-invalid={error || undefined}
+            onChange={(event) => {
+              if (!isControlled) setInternalValue(event.target.value);
+              onChange?.(event);
+            }}
+            className={cn(fieldElementVariants({ size }), 'w-full resize-none')}
+            {...textareaProps}
+          />
+        </div>
+        {showHelperRow && (
+          <div className="flex items-start justify-between gap-150">
+            {helperText ? (
+              <p className={cn(helperVariants({ state }), 'flex-1 min-w-0')}>
+                {helperText}
+              </p>
+            ) : (
+              <span className="flex-1" />
+            )}
+            {showCounter && maxLength !== undefined && (
+              <p
+                className={cn(
+                  'font-designer-13r shrink-0',
+                  state === 'disabled'
+                    ? 'text-text-disabled'
+                    : 'text-text-subtlest',
+                )}
+              >
+                {textValue.length}/{maxLength}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+export { TextField, TextArea };
+export type { TextFieldProps, TextAreaProps };

--- a/src/components/common/ui/text-field/text-field.stories.tsx
+++ b/src/components/common/ui/text-field/text-field.stories.tsx
@@ -1,0 +1,308 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Search } from 'lucide-react';
+import { TextArea, TextField } from '.';
+
+const meta: Meta<typeof TextField> = {
+  title: 'Common/UI/TextField',
+  component: TextField,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: { type: 'select' }, options: ['L', 'M'] },
+    error: { control: 'boolean' },
+    success: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    showClear: { control: 'boolean' },
+  },
+  args: {
+    placeholder: '입력하세요',
+    helperText: '가이드 메세지',
+  },
+  render: (args) => <TextField {...args} />,
+};
+
+export default meta;
+type Story = StoryObj<typeof TextField>;
+
+export const Default: Story = {
+  args: { size: 'L', placeholder: '입력하세요', helperText: '가이드 메세지' },
+};
+
+export const Focused: Story = {
+  args: {
+    size: 'L',
+    defaultValue: '입력하세요',
+    helperText: '가이드 메세지',
+    showClear: true,
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    size: 'L',
+    placeholder: '입력하세요',
+    helperText: '가이드 메세지',
+    error: true,
+  },
+};
+
+export const Success: Story = {
+  args: {
+    size: 'L',
+    placeholder: '입력하세요',
+    helperText: '가이드 메세지',
+    success: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    size: 'L',
+    placeholder: '입력하세요',
+    helperText: '가이드 메세지',
+    disabled: true,
+  },
+};
+
+export const SizeMedium: Story = {
+  args: { size: 'M', placeholder: '입력하세요', helperText: '가이드 메세지' },
+};
+
+export const WithSearchIcon: Story = {
+  args: {
+    size: 'M',
+    placeholder: '입력하세요',
+    helperText: '가이드 메세지',
+    trailingIcon: <Search size={20} />,
+  },
+};
+
+export const TextAreaDefault: StoryObj<typeof TextArea> = {
+  render: (args) => <TextArea {...args} />,
+  args: {
+    size: 'L',
+    placeholder: '입력하세요',
+    helperText: '가이드 메세지',
+    showCounter: true,
+    maxLength: 1000,
+  },
+};
+
+export const TextAreaError: StoryObj<typeof TextArea> = {
+  render: (args) => <TextArea {...args} />,
+  args: {
+    size: 'L',
+    placeholder: '입력하세요',
+    helperText: '가이드 메세지',
+    showCounter: true,
+    maxLength: 1000,
+    error: true,
+  },
+};
+
+export const LiveStates: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '런타임 :hover / :focus-within / :active 검증용. FigmaFullSpec 매트릭스는 정적 override라 실제 인터랙션 동작을 보장하지 않으므로, 이 스토리에서 마우스/포커스를 직접 적용해 확인.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex max-w-md flex-col gap-300 p-300">
+      <TextField placeholder="hover/focus 직접 적용" helperText="default" />
+      <TextField placeholder="error" helperText="가이드 메세지" error />
+      <TextField placeholder="success" helperText="가이드 메세지" success />
+      <TextField placeholder="disabled" helperText="가이드 메세지" disabled />
+      <TextField
+        defaultValue="trailing icon shrinks pr"
+        helperText="cancel 아이콘 → pr-100 적용"
+        showClear
+      />
+      <TextArea
+        placeholder="textarea 자연 높이 (rows=3)"
+        helperText="가이드 메세지"
+        showCounter
+        maxLength={1000}
+      />
+    </div>
+  ),
+};
+
+type FieldType = 'default' | 'textarea';
+type FieldSize = 'L' | 'M';
+type Interaction =
+  | 'default'
+  | 'hover'
+  | 'pressed'
+  | 'disabled'
+  | 'error'
+  | 'success';
+interface FocusPlaceholder {
+  focused: boolean;
+  placeholder: boolean;
+  label: string;
+}
+
+const INTERACTIONS: Interaction[] = [
+  'default',
+  'hover',
+  'pressed',
+  'disabled',
+  'error',
+  'success',
+];
+
+const ROW_VARIANTS: FocusPlaceholder[] = [
+  { focused: false, placeholder: true, label: 'Empty (placeholder)' },
+  { focused: true, placeholder: false, label: 'Focused + value' },
+  { focused: false, placeholder: false, label: 'Filled' },
+];
+
+const TYPE_SIZES: { type: FieldType; size: FieldSize; title: string }[] = [
+  { type: 'default', size: 'L', title: 'Type=Default · Size=L' },
+  { type: 'default', size: 'M', title: 'Type=Default · Size=M' },
+  { type: 'textarea', size: 'L', title: 'Type=Text Area · Size=L' },
+  { type: 'textarea', size: 'M', title: 'Type=Text Area · Size=M' },
+];
+
+// Static visual overrides for the FigmaFullSpec matrix only.
+// Runtime hover/pressed are driven by `hover:` / `active:` variants in
+// `inputBoxVariants`; this matrix forces the visual so reviewers can see
+// every state side-by-side without simulating pointer events.
+// Use the LiveStates story (or interactive Default story) to verify the
+// real `:hover` / `:focus-within` chain.
+const BG_OVERRIDE: Record<Interaction, string> = {
+  default: '',
+  hover: '!bg-fill-neutral-subtle-hover',
+  pressed: '!bg-fill-neutral-subtle-pressed',
+  disabled: '',
+  error: '',
+  success: '',
+};
+
+function MatrixCell({
+  type,
+  size,
+  interaction,
+  focused,
+  placeholder,
+}: {
+  type: FieldType;
+  size: FieldSize;
+  interaction: Interaction;
+  focused: boolean;
+  placeholder: boolean;
+}) {
+  const isError = interaction === 'error';
+  const isSuccess = interaction === 'success';
+  const isDisabled = interaction === 'disabled';
+  const valueText = placeholder ? undefined : '입력하세요';
+  const placeholderText = placeholder ? '입력하세요' : undefined;
+  const focusBorderOverride =
+    focused &&
+    interaction !== 'disabled' &&
+    interaction !== 'error' &&
+    interaction !== 'success'
+      ? '!border-border-strong'
+      : '';
+  const overrideClass =
+    `${BG_OVERRIDE[interaction]} ${focusBorderOverride}`.trim();
+
+  if (type === 'default') {
+    const showSearch =
+      size === 'M' &&
+      placeholder &&
+      !focused &&
+      (interaction === 'default' ||
+        interaction === 'hover' ||
+        interaction === 'pressed');
+    const showCancelIcon = focused && !placeholder;
+    const trailingIconNode =
+      !showCancelIcon && showSearch ? <Search size={20} /> : undefined;
+    return (
+      <TextField
+        size={size}
+        defaultValue={valueText}
+        placeholder={placeholderText}
+        disabled={isDisabled}
+        error={isError}
+        success={isSuccess}
+        helperText="가이드 메세지"
+        showClear={showCancelIcon}
+        trailingIcon={trailingIconNode}
+        className={overrideClass || undefined}
+      />
+    );
+  }
+  return (
+    <TextArea
+      size={size}
+      defaultValue={valueText}
+      placeholder={placeholderText}
+      disabled={isDisabled}
+      error={isError}
+      success={isSuccess}
+      helperText="가이드 메세지"
+      showCounter
+      maxLength={1000}
+      className={overrideClass || undefined}
+    />
+  );
+}
+
+export const FigmaFullSpec: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Figma DS 2.0 (node 181:2263) 전체 72 variant 배치를 그대로 재현. 4 (Type × Size) 섹션 × 6 Interaction × 3 (Focused, Placeholder) 행. Hover/Pressed는 `!bg-*` override로 정적 시각화. Focused 행은 `!border-border-strong` override + cancel 아이콘.',
+      },
+    },
+  },
+  argTypes: {
+    size: { table: { disable: true } },
+    error: { table: { disable: true } },
+    success: { table: { disable: true } },
+    disabled: { table: { disable: true } },
+    showClear: { table: { disable: true } },
+    helperText: { table: { disable: true } },
+    placeholder: { table: { disable: true } },
+  },
+  render: () => (
+    <div className="bg-fill-neutral-subtle-default flex flex-col gap-300 p-300">
+      {TYPE_SIZES.map(({ type, size, title }) => (
+        <section key={`${type}-${size}`} className="flex flex-col gap-150">
+          <h3 className="font-designer-16b text-text-default">{title}</h3>
+          <div
+            className="grid gap-100"
+            style={{
+              gridTemplateColumns: `repeat(${INTERACTIONS.length}, minmax(200px, 1fr))`,
+            }}
+          >
+            {INTERACTIONS.map((interaction) => (
+              <span
+                key={`hdr-${type}-${size}-${interaction}`}
+                className="font-designer-13b text-text-subtlest uppercase"
+              >
+                {interaction}
+              </span>
+            ))}
+            {ROW_VARIANTS.flatMap(({ focused, placeholder }) =>
+              INTERACTIONS.map((interaction) => (
+                <MatrixCell
+                  key={`${type}-${size}-${interaction}-${focused}-${placeholder}`}
+                  type={type}
+                  size={size}
+                  interaction={interaction}
+                  focused={focused}
+                  placeholder={placeholder}
+                />
+              )),
+            )}
+          </div>
+        </section>
+      ))}
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

- **Button**: Figma DS 2.0 스펙 정렬 + Storybook stories 보강 (8c20237, 17d1c66)
- **TextField/TextArea**: cva 기반 신규 컴포넌트, 공유 STATE_VARIANTS, 카운터 동기화, FigmaFullSpec(72셀) + LiveStates 듀얼 스토리 (cfd71bf)
- **design-to-dev 플레이북**: Button/TextField 구현 중 실제로 밟았던 함정들을 체계적인 규칙으로 codify

---

## `.claude/commands/design-to-dev.md` 변경 상세 (157줄 → 423줄)

이 플레이북은 Figma 디자인을 컴포넌트 코드로 변환하는 AI 에이전트 실행 지침서입니다. Button/TextField 구현 과정에서 발견된 실수 패턴들을 재발 방지 규칙으로 추가했습니다.

### Step 0 추가 — 코드 작성 전 프레임 타입 분류

Figma 프레임을 3가지 타입으로 분류하는 단계를 최앞단에 추가했습니다:

| 타입 | 형태 | 필요한 스토리 |
|------|------|--------------|
| **A — 단일 컴포넌트** | 상태(hover/disabled 등) 변형 | Default + 각 상태 + Mobile |
| **B — 변형 매트릭스** | size × state × type 조합 표 | VisualMatrix + Interactive |
| **C — 합성 화면** | 여러 컴포넌트 배치 | Composite |

타입을 잘못 판단하면 Step 3 스토리 구조 전체가 틀려집니다. Button이 Type B임을 인식하지 못한 채 구현하면 96개 변형 중 일부만 커버하는 스토리가 나옵니다.

---

### Step 1 A. — 필수 pre-flight 추가

**A.0 — 자식 노드 전체 목록 확보 (신규 필수)**

루트 노드만 보면 Disabled·Pressed 같은 숨겨진 상태를 놓칩니다. `get_metadata(node-id)`로 모든 자식 노드 id·이름 목록을 먼저 확보합니다. Button 프레임 하나에 96개 이상의 변형이 있을 수 있습니다.

**A.0.0 — Code Connect 매핑 확인 (신규)**

코드 작성 전 `get_code_connect_map(node-id)`으로 이미 코드베이스에 매핑된 노드인지 확인합니다. 매핑 존재 시 코드 생성 스킵, 매핑된 컴포넌트를 임포트합니다. Step 5 커밋 후 신규 컴포넌트를 Code Connect에 등록(선택)합니다.

**A.0.1 — 좌표만으로 레이아웃 추측 금지 (신규)**

같은 (x, y) 좌표 분포가 완전히 다른 그리드 구조를 뜻할 수 있습니다:
- (a) 열 = Size, 열 내부 = State
- (b) 블록 = Type, 블록 내부 = Size × State

두 경우 모두 raw 좌표가 비슷하게 보입니다. A.0 완료 후 `get_screenshot(frame-node-id)`으로 육안 확인 필수. **스크린샷 확인 전 렌더 코드 작성 금지.**

**A.0.2 — 심볼 이름 ≠ 아이콘 식별 (신규)**

`Icon_left=true`는 "왼쪽에 아이콘 있음"을 뜻할 뿐, 어떤 아이콘인지 알 수 없습니다. 아이콘이 있는 변형은 `get_design_context(child-node-id)`로 실제 SVG를 확인해야 합니다.

**A.1~A.3 보강**

- **A.1**: `get_design_context`를 루트뿐 아니라 모든 (size × color × state) 조합 샘플링으로 확장. Primary와 Secondary가 같은 state에서 다른 토큰을 쓸 수 있습니다.
- **A.2**: `get_design_context` 응답 50KB 초과 시 MCP가 파일 경로 반환 — `grep + sort + uniq -c`로 주요 토큰 추출.
- **A.3**: 레이아웃 타입 식별 추가. Form field 감지 시 Step 4.3 감사 대상으로 플래그.

---

### Step 3 — 타입별 스토리 분기 + VisualMatrix/Interactive 명세

**이전**: 단일 패턴 (Default + StateVariant + Mobile)

**이후**: 타입 분기 + Type B 전용 규칙 6개:

1. **절대 위치 사용** — 셀마다 다른 width/height를 flex/gap으로 재현 불가
2. **Figma 좌표 (0,0) 정규화** — 프레임 top-left x/y를 모든 자식 좌표에서 차감해 단일 참조 테이블로 저장 - 오프셋 벗어나는 문제 방지
3. **좌표 테이블 패턴** — 방향별로 변하는 축을 `COL_BASE_X`, `STATE_DX`, `ROW_DY`, `BLOCK_BASE_Y` 4개 테이블로 모델링
4. **컨테이너 크기** — Figma 프레임 메타데이터 width/height 그대로 적용 (`overflow: auto`)
5. **상태 정적 시뮬레이션** — CSS `:hover`는 한 번에 하나만 활성화되므로 `!important` 오버라이드로 hover/pressed/default 동시 표시
6. **축 컨트롤 비활성화** — `argTypes`에서 `table: { disable: true }` (VisualMatrix에서 size/state 드롭다운 작동 안 함)

**Step 3.2 Interactive (신규)**: VisualMatrix의 `!important` 오버라이드는 실제 `hover:` / `focus-within:` / `active:` CSS 체인을 우회합니다. Interactive 스토리는 오버라이드 없이 실제 인터랙션 체인이 동작하는지 검증합니다.

---

### Step 4 — 시각 비교 프로토콜 완전 재작성

**Step 4.1 — 비교 프로토콜 (8단계)**:
- Story URL 구성 규칙 (kebab-case 변환 공식)
- URL 실패 시 `index.json`에서 story ID 탐색
- Storybook 스크린샷 (`fullPage: true`)
- Figma 참조 **재취득** — Step 1 스크린샷은 ~7일 후 만료되므로 재사용 금지
- 두 이미지를 **동일 응답에서** 읽기 (기억에서 비교 금지)
- 레이아웃 소리내어 확인: `"Figma: N블록, R행 × C열"` → `"Storybook: 동일"` — 불일치 시 수정 먼저
- 시각 비교 + `getBoundingClientRect` 수치 비교
- **첫 패스 자체 승인 금지** — DOM 확인은 셀 존재를 증명할 뿐, 레이아웃 일치를 증명하지 않음

**Step 4.2 — 토큰 교차 확인 (신규)**:

스크린샷은 `#d1d2d4` vs `#d5d7da` (RGB 3단위 차이)를 잡아낼 수 없습니다. 모든 변형에 대해 Figma 값 → 프로젝트 토큰 → resolved hex 매핑 표 작성 후 `global.css`에서 `grep`으로 실제 값 검증. ❌ 행은 블로커.

**Step 4.3 — Form field 함정 (신규, 5가지)**:

1. **컨테이너 높이 ≠ 입력 박스 높이** — Figma 심볼 높이(예: TextArea L = 125px)는 helper-text 행과 gap 포함. `input_box_height = symbol_height − helper_height − container_gap`. Textarea는 `min-h` 대신 `rows` 속성 사용.
2. **trailing 아이콘 패딩 비대칭** — 오른쪽 아이콘 있을 때 오른쪽 패딩 ~4px 감소(12→8). cva variant으로 인코딩: `hasTrailingIcon: { true: 'pr-100', false: 'pr-150' }`
3. **helper text 토큰 불일치** — 5개 상태 중 4개가 Subtlest, 1개가 Default라면 Figma 버그로 처리. Subtlest로 구현하고 리포트에 기록.
4. **정적 그리드 오버라이드 ≠ 실제 인터랙션** — VisualMatrix `!bg-...`는 실제 CSS 체인 우회. Interactive 스토리 필수.
5. **Figma 오탈자 코드에 복사 금지** — `Disableed`, `Hoverr` 같은 변수명은 올바른 프로젝트 토큰에 매핑.

---

## Test plan

- [ ] Storybook `Common/UI/Button` 모든 variant 시각 확인
- [ ] Storybook `Common/UI/TextField` → FigmaFullSpec 매트릭스 vs Figma 비교
- [ ] LiveStates에서 hover/focus-within/active 실제 인터랙션 동작 확인
- [ ] TextArea uncontrolled 모드: defaultValue만 줬을 때 카운터가 입력에 따라 갱신되는지 확인
- [ ] `yarn typecheck` / `yarn lint:fix` / `yarn prettier:fix` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)