### PR TITLE
클래스 API smoke 페이지 추가

### DIFF
--- a/src/app/(landing)/class-test/page.tsx
+++ b/src/app/(landing)/class-test/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import ClassDomainTestPage from '@/features/class-domain-test/ui/class-domain-test-page';
+
+export const metadata: Metadata = {
+  title: 'Class API Test - ZERO-ONE',
+  description: 'Class domain API smoke test page',
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function Page() {
+  return <ClassDomainTestPage />;
+}

--- a/src/features/auth/server/middleware/route-policy.ts
+++ b/src/features/auth/server/middleware/route-policy.ts
@@ -110,6 +110,11 @@ const ROUTE_POLICIES: readonly RoutePolicy[] = [
     path: '/inquiry',
     match: ROUTE_MATCH_TYPES.PREFIX,
   },
+  {
+    kind: ROUTE_POLICY_KINDS.PUBLIC_SESSION,
+    path: '/class-test',
+    match: ROUTE_MATCH_TYPES.PREFIX,
+  },
 ] as const;
 
 const matchesRoutePolicy = (pathname: string, policy: RoutePolicy): boolean => {

--- a/src/features/class-domain-test/api/class-domain-test-api.ts
+++ b/src/features/class-domain-test/api/class-domain-test-api.ts
@@ -1,0 +1,160 @@
+import { isAxiosError } from 'axios';
+import { axiosInstance } from '@/api/client/axios';
+
+// Backend class API uses JSON null for intentionally empty DTO fields.
+// eslint-disable-next-line @rushstack/no-new-null
+type ApiNullable<T> = T | null;
+
+interface BaseResponse<T> {
+  statusCode: number;
+  timestamp?: string;
+  content: T;
+  message?: string;
+}
+
+export type ClassCourseStatus = 'OPEN' | 'COMING_SOON';
+export type ClassViewerStatus =
+  | 'ANONYMOUS'
+  | 'LOGIN_ONLY'
+  | 'FREE_ENROLLED'
+  | 'PAID';
+
+export interface ClassCourseSummary {
+  courseId: number;
+  slug: string;
+  title: string;
+  thumbnailUrl: ApiNullable<string>;
+  status: ClassCourseStatus;
+}
+
+export interface ClassPageResponse<T> {
+  content: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+}
+
+export interface ClassPlanItem {
+  code: string;
+  label: string;
+  valueAmount: number;
+}
+
+export interface ClassPlan {
+  planCode: string;
+  name: string;
+  subtitle: ApiNullable<string>;
+  items: ClassPlanItem[];
+  listTotalAmount: number;
+  earlyBirdPrice: ApiNullable<number>;
+  regularPriceAfterEb: ApiNullable<number>;
+  discountRate: ApiNullable<number>;
+}
+
+export interface ClassCourseDetail {
+  courseId: number;
+  slug: string;
+  viewerStatus: ClassViewerStatus;
+  title: string;
+  description: ApiNullable<string>;
+  thumbnailUrl: ApiNullable<string>;
+  plans?: ClassPlan[];
+  earlyBirdEndsAt?: ApiNullable<string>;
+  freeEnrollmentAvailable?: ApiNullable<boolean>;
+  freeEnrolled?: ApiNullable<boolean>;
+  freeLessonCount?: ApiNullable<number>;
+  isEnrolled?: ApiNullable<boolean>;
+  journeyMapEnabled?: ApiNullable<boolean>;
+  fullAccess?: ApiNullable<boolean>;
+  purchaseAvailable?: ApiNullable<boolean>;
+}
+
+export interface ClassCurriculumLesson {
+  lessonId: number;
+  order: number;
+  title: string;
+  isFree: boolean;
+  locked: boolean;
+  estimatedMinutes: number;
+}
+
+export interface ClassCurriculumChapter {
+  chapterId: number;
+  order: number;
+  chapterNumber: number;
+  title: string;
+  estimatedMinutes: number;
+  lessons: ClassCurriculumLesson[];
+}
+
+export interface ClassCurriculum {
+  courseId: number;
+  durationDays: number;
+  totalChapters: number;
+  totalLessons: number;
+  chapters: ClassCurriculumChapter[];
+}
+
+export interface ClassApiError {
+  status?: number;
+  message: string;
+}
+
+export const getClassCourses = async () => {
+  const { data } = await axiosInstance.get<
+    BaseResponse<ClassPageResponse<ClassCourseSummary>>
+  >('/courses', {
+    params: {
+      status: 'OPEN',
+      page: 0,
+      size: 20,
+    },
+  });
+
+  return data.content;
+};
+
+export const getClassCourseDetail = async (slug: string) => {
+  const { data } = await axiosInstance.get<BaseResponse<ClassCourseDetail>>(
+    `/courses/${slug}`,
+  );
+
+  return data.content;
+};
+
+export const getClassCurriculum = async (slug: string) => {
+  const { data } = await axiosInstance.get<BaseResponse<ClassCurriculum>>(
+    `/courses/${slug}/curriculum`,
+  );
+
+  return data.content;
+};
+
+export const toClassApiError = (error: unknown): ClassApiError => {
+  if (isAxiosError(error)) {
+    const responseData = error.response?.data as
+      | { message?: string; errorCode?: string }
+      | undefined;
+    return {
+      status: error.response?.status,
+      message:
+        responseData?.message ??
+        responseData?.errorCode ??
+        error.message ??
+        'API 요청에 실패했습니다.',
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+    };
+  }
+
+  return {
+    message: '알 수 없는 오류가 발생했습니다.',
+  };
+};

--- a/src/features/class-domain-test/api/class-domain-test-api.ts
+++ b/src/features/class-domain-test/api/class-domain-test-api.ts
@@ -103,6 +103,12 @@ export interface ClassApiError {
   message: string;
 }
 
+export interface ClassAdminCreateResult {
+  slug: string;
+  courseId: number;
+  lessonIds: number[];
+}
+
 export const getClassCourses = async () => {
   const { data } = await axiosInstance.get<
     BaseResponse<ClassPageResponse<ClassCourseSummary>>
@@ -131,6 +137,88 @@ export const getClassCurriculum = async (slug: string) => {
   );
 
   return data.content;
+};
+
+export const loginClassAdminTestMember = async () => {
+  const { data } = await axiosInstance.post<
+    BaseResponse<{ accessToken: string }>
+  >('/growth/test/login', {
+    memberId: 1,
+  });
+
+  return data.content.accessToken;
+};
+
+export const createClassAdminSample = async (
+  accessToken: string,
+): Promise<ClassAdminCreateResult> => {
+  const slug = `class-test-${Date.now()}`;
+  const authorization = {
+    Authorization: `Bearer ${accessToken}`,
+  };
+  const { data: courseData } = await axiosInstance.post<
+    BaseResponse<{ courseId: number }>
+  >(
+    '/admin/courses',
+    {
+      slug,
+      title: `브라우저 테스트 클래스 ${new Date().toLocaleTimeString()}`,
+      description: 'class-test 페이지에서 운영자 API로 생성한 임시 클래스',
+      thumbnailUrl: 'https://cdn.example.com/class-test.png',
+      status: 'OPEN',
+      durationDays: 5,
+      earlyBirdEndsAt: '2026-06-30T23:59:00+09:00',
+    },
+    { headers: authorization },
+  );
+  const courseId = courseData.content.courseId;
+  const { data: freeLessonData } = await axiosInstance.post<
+    BaseResponse<{ lessonId: number }>
+  >(
+    `/admin/courses/${courseId}/lessons`,
+    {
+      chapterNumber: 1,
+      lessonNumber: 1,
+      title: '무료 첫 레슨',
+      content: '운영자가 브라우저에서 입력한 무료 레슨 본문',
+      estimatedMinutes: 25,
+      isFree: true,
+      isPublished: true,
+    },
+    { headers: authorization },
+  );
+  const { data: paidLessonData } = await axiosInstance.post<
+    BaseResponse<{ lessonId: number }>
+  >(
+    `/admin/courses/${courseId}/lessons`,
+    {
+      chapterNumber: 1,
+      lessonNumber: 2,
+      title: '유료 둘째 레슨',
+      content: '운영자가 브라우저에서 입력한 유료 레슨 본문',
+      estimatedMinutes: 35,
+      isFree: false,
+      isPublished: true,
+    },
+    { headers: authorization },
+  );
+
+  await axiosInstance.put(
+    `/admin/courses/${courseId}/completion-message`,
+    {
+      message: '완주를 축하합니다. 다음 도전을 시작하세요.',
+    },
+    { headers: authorization },
+  );
+
+  return {
+    slug,
+    courseId,
+    lessonIds: [
+      freeLessonData.content.lessonId,
+      paidLessonData.content.lessonId,
+    ],
+  };
 };
 
 export const toClassApiError = (error: unknown): ClassApiError => {

--- a/src/features/class-domain-test/ui/class-domain-test-page.tsx
+++ b/src/features/class-domain-test/ui/class-domain-test-page.tsx
@@ -3,15 +3,18 @@
 import { useCallback, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import {
-  getClassCourseDetail,
-  getClassCourses,
-  getClassCurriculum,
-  toClassApiError,
+  type ClassAdminCreateResult,
   type ClassApiError,
   type ClassCourseDetail,
   type ClassCourseSummary,
   type ClassCurriculum,
   type ClassPageResponse,
+  createClassAdminSample,
+  getClassCourseDetail,
+  getClassCourses,
+  getClassCurriculum,
+  loginClassAdminTestMember,
+  toClassApiError,
 } from '@/features/class-domain-test/api/class-domain-test-api';
 
 type SmokeState = 'idle' | 'loading' | 'success' | 'error';
@@ -29,6 +32,9 @@ export default function ClassDomainTestPage() {
   const [courses, setCourses] =
     useState<ClassPageResponse<ClassCourseSummary>>();
   const [selectedSlug, setSelectedSlug] = useState('');
+  const [adminToken, setAdminToken] = useState('');
+  const [adminCreateResult, setAdminCreateResult] =
+    useState<ClassAdminCreateResult>();
   const [detail, setDetail] = useState<ClassCourseDetail>();
   const [curriculum, setCurriculum] = useState<ClassCurriculum>();
   const [coursesResult, setCoursesResult] =
@@ -36,6 +42,8 @@ export default function ClassDomainTestPage() {
   const [detailResult, setDetailResult] =
     useState<SmokeResult>(initialSmokeResult);
   const [curriculumResult, setCurriculumResult] =
+    useState<SmokeResult>(initialSmokeResult);
+  const [adminResult, setAdminResult] =
     useState<SmokeResult>(initialSmokeResult);
 
   const loadCourses = useCallback(async () => {
@@ -141,6 +149,40 @@ export default function ClassDomainTestPage() {
     }
   }, []);
 
+  const loginAdmin = useCallback(async () => {
+    setAdminResult({ state: 'loading', error: undefined });
+
+    try {
+      const accessToken = await loginClassAdminTestMember();
+      setAdminToken(accessToken);
+      setAdminResult({ state: 'success', error: undefined });
+    } catch (error) {
+      setAdminResult({ state: 'error', error: toClassApiError(error) });
+    }
+  }, []);
+
+  const createAdminSample = useCallback(async () => {
+    if (!adminToken) {
+      setAdminResult({
+        state: 'error',
+        error: { message: '먼저 운영자 테스트 로그인을 실행하세요.' },
+      });
+      return;
+    }
+
+    setAdminResult({ state: 'loading', error: undefined });
+
+    try {
+      const result = await createClassAdminSample(adminToken);
+      setAdminCreateResult(result);
+      setSelectedSlug(result.slug);
+      setAdminResult({ state: 'success', error: undefined });
+      await loadCourses();
+    } catch (error) {
+      setAdminResult({ state: 'error', error: toClassApiError(error) });
+    }
+  }, [adminToken, loadCourses]);
+
   return (
     <main className="bg-background-alternative min-h-screen w-full px-300 py-400">
       <section className="mx-auto flex w-full max-w-screen-xl flex-col gap-250">
@@ -180,6 +222,41 @@ export default function ClassDomainTestPage() {
             </SmokeButton>
           </div>
         </header>
+
+        <SmokeCard title="L-admin 운영자 생성 smoke" result={adminResult}>
+          <div className="flex flex-wrap gap-100">
+            <SmokeButton
+              onClick={loginAdmin}
+              isLoading={adminResult.state === 'loading'}
+            >
+              운영자 테스트 로그인
+            </SmokeButton>
+            <SmokeButton
+              onClick={createAdminSample}
+              isLoading={adminResult.state === 'loading'}
+            >
+              코스+레슨 생성
+            </SmokeButton>
+          </div>
+          <p className="font-designer-13r text-text-subtlest">
+            accessToken은 화면에 노출하지 않고 브라우저 state에만 보관합니다.
+          </p>
+          {adminCreateResult && (
+            <div className="grid gap-100 md:grid-cols-3">
+              <Metric label="courseId" value={adminCreateResult.courseId} />
+              <Metric
+                label="lessons"
+                value={adminCreateResult.lessonIds.length}
+              />
+              <div className="rounded-150 bg-background-alternative p-150">
+                <p className="font-designer-12r text-text-subtlest">slug</p>
+                <p className="font-designer-13b break-all text-text-default">
+                  {adminCreateResult.slug}
+                </p>
+              </div>
+            </div>
+          )}
+        </SmokeCard>
 
         <section className="grid gap-200 lg:grid-cols-3">
           <SmokeCard title="A-01 GET /courses" result={coursesResult}>

--- a/src/features/class-domain-test/ui/class-domain-test-page.tsx
+++ b/src/features/class-domain-test/ui/class-domain-test-page.tsx
@@ -1,0 +1,399 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import {
+  getClassCourseDetail,
+  getClassCourses,
+  getClassCurriculum,
+  toClassApiError,
+  type ClassApiError,
+  type ClassCourseDetail,
+  type ClassCourseSummary,
+  type ClassCurriculum,
+  type ClassPageResponse,
+} from '@/features/class-domain-test/api/class-domain-test-api';
+
+type SmokeState = 'idle' | 'loading' | 'success' | 'error';
+
+interface SmokeResult {
+  state: SmokeState;
+  error?: ClassApiError;
+}
+
+const initialSmokeResult: SmokeResult = {
+  state: 'idle',
+};
+
+export default function ClassDomainTestPage() {
+  const [courses, setCourses] =
+    useState<ClassPageResponse<ClassCourseSummary>>();
+  const [selectedSlug, setSelectedSlug] = useState('');
+  const [detail, setDetail] = useState<ClassCourseDetail>();
+  const [curriculum, setCurriculum] = useState<ClassCurriculum>();
+  const [coursesResult, setCoursesResult] =
+    useState<SmokeResult>(initialSmokeResult);
+  const [detailResult, setDetailResult] =
+    useState<SmokeResult>(initialSmokeResult);
+  const [curriculumResult, setCurriculumResult] =
+    useState<SmokeResult>(initialSmokeResult);
+
+  const loadCourses = useCallback(async () => {
+    setCoursesResult({ state: 'loading', error: undefined });
+    setDetail(undefined);
+    setCurriculum(undefined);
+
+    try {
+      const nextCourses = await getClassCourses();
+      const firstSlug = nextCourses.content.at(0)?.slug ?? '';
+      setCourses(nextCourses);
+      setSelectedSlug((currentSlug) => currentSlug || firstSlug);
+      setCoursesResult({ state: 'success', error: undefined });
+    } catch (error) {
+      setCoursesResult({ state: 'error', error: toClassApiError(error) });
+    }
+  }, []);
+
+  const loadDetail = useCallback(async () => {
+    if (!selectedSlug) {
+      setDetailResult({
+        state: 'error',
+        error: { message: '먼저 slug를 선택하거나 입력하세요.' },
+      });
+      return;
+    }
+
+    setDetailResult({ state: 'loading', error: undefined });
+
+    try {
+      const nextDetail = await getClassCourseDetail(selectedSlug);
+      setDetail(nextDetail);
+      setDetailResult({ state: 'success', error: undefined });
+    } catch (error) {
+      setDetailResult({ state: 'error', error: toClassApiError(error) });
+    }
+  }, [selectedSlug]);
+
+  const loadCurriculum = useCallback(async () => {
+    if (!selectedSlug) {
+      setCurriculumResult({
+        state: 'error',
+        error: { message: '먼저 slug를 선택하거나 입력하세요.' },
+      });
+      return;
+    }
+
+    setCurriculumResult({ state: 'loading', error: undefined });
+
+    try {
+      const nextCurriculum = await getClassCurriculum(selectedSlug);
+      setCurriculum(nextCurriculum);
+      setCurriculumResult({ state: 'success', error: undefined });
+    } catch (error) {
+      setCurriculumResult({ state: 'error', error: toClassApiError(error) });
+    }
+  }, [selectedSlug]);
+
+  const runSmoke = useCallback(async () => {
+    setCoursesResult({ state: 'loading', error: undefined });
+    setDetailResult(initialSmokeResult);
+    setCurriculumResult(initialSmokeResult);
+    setDetail(undefined);
+    setCurriculum(undefined);
+
+    try {
+      const nextCourses = await getClassCourses();
+      const firstSlug = nextCourses.content.at(0)?.slug ?? '';
+      setCourses(nextCourses);
+      setSelectedSlug(firstSlug);
+      setCoursesResult({ state: 'success', error: undefined });
+
+      if (!firstSlug) {
+        setDetailResult({
+          state: 'error',
+          error: {
+            message: '조회된 OPEN 코스가 없어 상세 smoke를 건너뜁니다.',
+          },
+        });
+        return;
+      }
+
+      setDetailResult({ state: 'loading', error: undefined });
+      try {
+        const nextDetail = await getClassCourseDetail(firstSlug);
+        setDetail(nextDetail);
+        setDetailResult({ state: 'success', error: undefined });
+      } catch (error) {
+        setDetailResult({ state: 'error', error: toClassApiError(error) });
+        return;
+      }
+
+      setCurriculumResult({ state: 'loading', error: undefined });
+      try {
+        const nextCurriculum = await getClassCurriculum(firstSlug);
+        setCurriculum(nextCurriculum);
+        setCurriculumResult({ state: 'success', error: undefined });
+      } catch (error) {
+        setCurriculumResult({ state: 'error', error: toClassApiError(error) });
+      }
+    } catch (error) {
+      setCoursesResult({ state: 'error', error: toClassApiError(error) });
+    }
+  }, []);
+
+  return (
+    <main className="bg-background-alternative min-h-screen w-full px-300 py-400">
+      <section className="mx-auto flex w-full max-w-screen-xl flex-col gap-250">
+        <header className="rounded-250 border border-border-default bg-background-default p-300 shadow-2">
+          <p className="font-designer-14b text-text-brand">E2E TEST HARNESS</p>
+          <h1 className="font-designer-28b text-text-default">
+            Class domain API smoke page
+          </h1>
+          <p className="font-designer-15r mt-100 text-text-subtle">
+            디자인 완성도보다 실제 backend class API 호출 확인에 집중하는 임시
+            페이지입니다.
+          </p>
+          <div className="mt-250 flex flex-wrap gap-100">
+            <SmokeButton
+              onClick={runSmoke}
+              isLoading={coursesResult.state === 'loading'}
+            >
+              전체 smoke 실행
+            </SmokeButton>
+            <SmokeButton
+              onClick={loadCourses}
+              isLoading={coursesResult.state === 'loading'}
+            >
+              A-01 목록
+            </SmokeButton>
+            <SmokeButton
+              onClick={loadDetail}
+              isLoading={detailResult.state === 'loading'}
+            >
+              A-02 상세
+            </SmokeButton>
+            <SmokeButton
+              onClick={loadCurriculum}
+              isLoading={curriculumResult.state === 'loading'}
+            >
+              A-04 커리큘럼
+            </SmokeButton>
+          </div>
+        </header>
+
+        <section className="grid gap-200 lg:grid-cols-3">
+          <SmokeCard title="A-01 GET /courses" result={coursesResult}>
+            <label className="flex flex-col gap-75">
+              <span className="font-designer-13b text-text-subtle">
+                선택 slug
+              </span>
+              <input
+                value={selectedSlug}
+                onChange={(event) => setSelectedSlug(event.target.value)}
+                className="rounded-150 border border-border-default bg-background-default px-150 py-100 font-designer-14r text-text-default"
+                placeholder="vibe-coding-intro"
+              />
+            </label>
+            <div className="flex flex-col gap-100">
+              {courses?.content.map((course) => (
+                <button
+                  key={course.courseId}
+                  type="button"
+                  onClick={() => setSelectedSlug(course.slug)}
+                  className={cn(
+                    'rounded-150 border px-150 py-125 text-left',
+                    selectedSlug === course.slug
+                      ? 'border-border-brand bg-background-accent-rose-subtle'
+                      : 'border-border-default bg-background-default',
+                  )}
+                >
+                  <span className="font-designer-15b text-text-default">
+                    {course.title}
+                  </span>
+                  <span className="font-designer-13r block text-text-subtle">
+                    {course.slug} · {course.status}
+                  </span>
+                </button>
+              ))}
+              {courses && courses.content.length === 0 && (
+                <p className="font-designer-14r text-text-subtle">
+                  OPEN 코스가 없습니다.
+                </p>
+              )}
+            </div>
+            {courses && (
+              <p className="font-designer-13r text-text-subtlest">
+                page {courses.page} / total {courses.totalElements} / hasNext{' '}
+                {String(courses.hasNext)}
+              </p>
+            )}
+          </SmokeCard>
+
+          <SmokeCard title="A-02 GET /courses/{slug}" result={detailResult}>
+            {detail ? (
+              <div className="flex flex-col gap-100">
+                <h2 className="font-designer-22b text-text-default">
+                  {detail.title}
+                </h2>
+                <p className="font-designer-14r text-text-subtle">
+                  {detail.description}
+                </p>
+                <KeyValue label="viewerStatus" value={detail.viewerStatus} />
+                <KeyValue label="courseId" value={String(detail.courseId)} />
+                <KeyValue
+                  label="freeEnrollmentAvailable"
+                  value={String(detail.freeEnrollmentAvailable)}
+                />
+                <KeyValue
+                  label="purchaseAvailable"
+                  value={String(detail.purchaseAvailable)}
+                />
+                <KeyValue
+                  label="plans"
+                  value={String(detail.plans?.length ?? 0)}
+                />
+              </div>
+            ) : (
+              <EmptyMessage text="상세 응답이 아직 없습니다." />
+            )}
+          </SmokeCard>
+
+          <SmokeCard
+            title="A-04 GET /courses/{slug}/curriculum"
+            result={curriculumResult}
+          >
+            {curriculum ? (
+              <div className="flex flex-col gap-150">
+                <div className="grid grid-cols-3 gap-100">
+                  <Metric label="chapters" value={curriculum.totalChapters} />
+                  <Metric label="lessons" value={curriculum.totalLessons} />
+                  <Metric label="days" value={curriculum.durationDays} />
+                </div>
+                <div className="flex flex-col gap-100">
+                  {curriculum.chapters.map((chapter) => (
+                    <article
+                      key={chapter.chapterId}
+                      className="rounded-150 border border-border-default bg-background-default p-150"
+                    >
+                      <h3 className="font-designer-15b text-text-default">
+                        CH {chapter.chapterNumber}. {chapter.title}
+                      </h3>
+                      <p className="font-designer-13r text-text-subtlest">
+                        {chapter.lessons.length} lessons ·{' '}
+                        {chapter.estimatedMinutes} min
+                      </p>
+                      <ul className="mt-100 flex flex-col gap-75">
+                        {chapter.lessons.map((lesson) => (
+                          <li
+                            key={lesson.lessonId}
+                            className="font-designer-13r flex items-center justify-between text-text-subtle"
+                          >
+                            <span>
+                              L{lesson.order}. {lesson.title}
+                            </span>
+                            <span>{lesson.locked ? 'LOCKED' : 'OPEN'}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <EmptyMessage text="커리큘럼 응답이 아직 없습니다." />
+            )}
+          </SmokeCard>
+        </section>
+      </section>
+    </main>
+  );
+}
+
+function SmokeButton({
+  children,
+  isLoading,
+  onClick,
+}: {
+  children: React.ReactNode;
+  isLoading: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isLoading}
+      className="rounded-150 bg-background-brand-default px-200 py-125 font-designer-14b text-text-inverse disabled:opacity-50"
+    >
+      {isLoading ? '요청 중...' : children}
+    </button>
+  );
+}
+
+function SmokeCard({
+  children,
+  result,
+  title,
+}: {
+  children: React.ReactNode;
+  result: SmokeResult;
+  title: string;
+}) {
+  return (
+    <article className="rounded-250 border border-border-default bg-background-default p-250 shadow-1">
+      <div className="mb-200 flex items-center justify-between gap-150">
+        <h2 className="font-designer-18b text-text-default">{title}</h2>
+        <StatusBadge state={result.state} />
+      </div>
+      {result.error && (
+        <div className="mb-150 rounded-150 border border-border-error bg-background-accent-red-subtle p-150">
+          <p className="font-designer-13b text-text-error">
+            {result.error.status ? `${result.error.status} · ` : ''}
+            {result.error.message}
+          </p>
+        </div>
+      )}
+      <div className="flex flex-col gap-150">{children}</div>
+    </article>
+  );
+}
+
+function StatusBadge({ state }: { state: SmokeState }) {
+  return (
+    <span
+      className={cn(
+        'rounded-500 px-125 py-50 font-designer-12b',
+        state === 'success' &&
+          'bg-background-accent-green-subtle text-text-success',
+        state === 'error' && 'bg-background-accent-red-subtle text-text-error',
+        state === 'loading' &&
+          'bg-background-accent-yellow-subtle text-text-warning',
+        state === 'idle' && 'bg-background-alternative text-text-subtle',
+      )}
+    >
+      {state.toUpperCase()}
+    </span>
+  );
+}
+
+function KeyValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-150 border-b border-border-subtle py-75">
+      <span className="font-designer-13r text-text-subtlest">{label}</span>
+      <span className="font-designer-13b text-text-default">{value}</span>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-150 bg-background-alternative p-150 text-center">
+      <p className="font-designer-20b text-text-default">{value}</p>
+      <p className="font-designer-12r text-text-subtlest">{label}</p>
+    </div>
+  );
+}
+
+function EmptyMessage({ text }: { text: string }) {
+  return <p className="font-designer-14r text-text-subtle">{text}</p>;
+}

--- a/src/features/class-domain-test/ui/class-domain-test-page.tsx
+++ b/src/features/class-domain-test/ui/class-domain-test-page.tsx
@@ -24,9 +24,38 @@ interface SmokeResult {
   error?: ClassApiError;
 }
 
+interface ScenarioStep {
+  title: string;
+  description: string;
+  state: SmokeState;
+}
+
 const initialSmokeResult: SmokeResult = {
   state: 'idle',
 };
+
+const initialScenarioSteps: ScenarioStep[] = [
+  {
+    title: '운영자 권한 준비',
+    description: '로컬 test login으로 관리자 토큰을 받습니다.',
+    state: 'idle',
+  },
+  {
+    title: '테스트 클래스 생성',
+    description: '운영자 API로 공개 클래스와 레슨 2개를 만듭니다.',
+    state: 'idle',
+  },
+  {
+    title: '사용자 공개 목록 확인',
+    description: '방금 만든 클래스가 공개 목록에 나오는지 확인합니다.',
+    state: 'idle',
+  },
+  {
+    title: '상세/커리큘럼 확인',
+    description: '상세 정보와 무료/유료 레슨 잠금 상태를 확인합니다.',
+    state: 'idle',
+  },
+];
 
 const viewerStatusLabel: Record<ClassCourseDetail['viewerStatus'], string> = {
   ANONYMOUS: '비로그인 사용자로 상세를 조회했습니다.',
@@ -56,6 +85,10 @@ export default function ClassDomainTestPage() {
     useState<ClassAdminCreateResult>();
   const [detail, setDetail] = useState<ClassCourseDetail>();
   const [curriculum, setCurriculum] = useState<ClassCurriculum>();
+  const [scenarioResult, setScenarioResult] =
+    useState<SmokeResult>(initialSmokeResult);
+  const [scenarioSteps, setScenarioSteps] =
+    useState<ScenarioStep[]>(initialScenarioSteps);
   const [coursesResult, setCoursesResult] =
     useState<SmokeResult>(initialSmokeResult);
   const [detailResult, setDetailResult] =
@@ -65,10 +98,27 @@ export default function ClassDomainTestPage() {
   const [adminResult, setAdminResult] =
     useState<SmokeResult>(initialSmokeResult);
 
-  const loadCourses = useCallback(async () => {
-    setCoursesResult({ state: 'loading', error: undefined });
+  const updateScenarioStep = useCallback(
+    (stepIndex: number, state: SmokeState) => {
+      setScenarioSteps((currentSteps) =>
+        currentSteps.map((step, index) =>
+          index === stepIndex ? { ...step, state } : step,
+        ),
+      );
+    },
+    [],
+  );
+
+  const resetReadResults = useCallback(() => {
     setDetail(undefined);
     setCurriculum(undefined);
+    setDetailResult(initialSmokeResult);
+    setCurriculumResult(initialSmokeResult);
+  }, []);
+
+  const loadCourses = useCallback(async () => {
+    setCoursesResult({ state: 'loading', error: undefined });
+    resetReadResults();
 
     try {
       const nextCourses = await getClassCourses();
@@ -79,7 +129,7 @@ export default function ClassDomainTestPage() {
     } catch (error) {
       setCoursesResult({ state: 'error', error: toClassApiError(error) });
     }
-  }, []);
+  }, [resetReadResults]);
 
   const loadDetail = useCallback(async () => {
     if (!selectedSlug) {
@@ -121,12 +171,9 @@ export default function ClassDomainTestPage() {
     }
   }, [selectedSlug]);
 
-  const runSmoke = useCallback(async () => {
+  const runPublicReadSmoke = useCallback(async () => {
     setCoursesResult({ state: 'loading', error: undefined });
-    setDetailResult(initialSmokeResult);
-    setCurriculumResult(initialSmokeResult);
-    setDetail(undefined);
-    setCurriculum(undefined);
+    resetReadResults();
 
     try {
       const nextCourses = await getClassCourses();
@@ -139,34 +186,37 @@ export default function ClassDomainTestPage() {
         setDetailResult({
           state: 'error',
           error: {
-            message: '조회된 OPEN 코스가 없어 상세 smoke를 건너뜁니다.',
+            message: '조회된 OPEN 코스가 없어 상세 조회를 건너뜁니다.',
           },
         });
         return;
       }
 
       setDetailResult({ state: 'loading', error: undefined });
-      try {
-        const nextDetail = await getClassCourseDetail(firstSlug);
-        setDetail(nextDetail);
-        setDetailResult({ state: 'success', error: undefined });
-      } catch (error) {
-        setDetailResult({ state: 'error', error: toClassApiError(error) });
-        return;
-      }
-
       setCurriculumResult({ state: 'loading', error: undefined });
-      try {
-        const nextCurriculum = await getClassCurriculum(firstSlug);
-        setCurriculum(nextCurriculum);
-        setCurriculumResult({ state: 'success', error: undefined });
-      } catch (error) {
-        setCurriculumResult({ state: 'error', error: toClassApiError(error) });
-      }
+      const [nextDetail, nextCurriculum] = await Promise.all([
+        getClassCourseDetail(firstSlug),
+        getClassCurriculum(firstSlug),
+      ]);
+      setDetail(nextDetail);
+      setCurriculum(nextCurriculum);
+      setDetailResult({ state: 'success', error: undefined });
+      setCurriculumResult({ state: 'success', error: undefined });
     } catch (error) {
-      setCoursesResult({ state: 'error', error: toClassApiError(error) });
+      const apiError = toClassApiError(error);
+      setCoursesResult({ state: 'error', error: apiError });
+      setDetailResult((current) =>
+        current.state === 'loading'
+          ? { state: 'error', error: apiError }
+          : current,
+      );
+      setCurriculumResult((current) =>
+        current.state === 'loading'
+          ? { state: 'error', error: apiError }
+          : current,
+      );
     }
-  }, []);
+  }, [resetReadResults]);
 
   const loginAdmin = useCallback(async () => {
     setAdminResult({ state: 'loading', error: undefined });
@@ -202,267 +252,399 @@ export default function ClassDomainTestPage() {
     }
   }, [adminToken, loadCourses]);
 
+  const runLocalScenario = useCallback(async () => {
+    setScenarioResult({ state: 'loading', error: undefined });
+    setScenarioSteps(initialScenarioSteps);
+    setAdminResult(initialSmokeResult);
+    setCoursesResult(initialSmokeResult);
+    resetReadResults();
+
+    try {
+      updateScenarioStep(0, 'loading');
+      setAdminResult({ state: 'loading', error: undefined });
+      const accessToken = await loginClassAdminTestMember();
+      setAdminToken(accessToken);
+      updateScenarioStep(0, 'success');
+
+      updateScenarioStep(1, 'loading');
+      const created = await createClassAdminSample(accessToken);
+      setAdminCreateResult(created);
+      setSelectedSlug(created.slug);
+      setAdminResult({ state: 'success', error: undefined });
+      updateScenarioStep(1, 'success');
+
+      updateScenarioStep(2, 'loading');
+      setCoursesResult({ state: 'loading', error: undefined });
+      const nextCourses = await getClassCourses();
+      setCourses(nextCourses);
+      setCoursesResult({ state: 'success', error: undefined });
+      updateScenarioStep(2, 'success');
+
+      updateScenarioStep(3, 'loading');
+      setDetailResult({ state: 'loading', error: undefined });
+      setCurriculumResult({ state: 'loading', error: undefined });
+      const [nextDetail, nextCurriculum] = await Promise.all([
+        getClassCourseDetail(created.slug),
+        getClassCurriculum(created.slug),
+      ]);
+      setDetail(nextDetail);
+      setCurriculum(nextCurriculum);
+      setDetailResult({ state: 'success', error: undefined });
+      setCurriculumResult({ state: 'success', error: undefined });
+      updateScenarioStep(3, 'success');
+      setScenarioResult({ state: 'success', error: undefined });
+    } catch (error) {
+      const apiError = toClassApiError(error);
+      setScenarioResult({ state: 'error', error: apiError });
+      setAdminResult((current) =>
+        current.state === 'loading'
+          ? { state: 'error', error: apiError }
+          : current,
+      );
+      setCoursesResult((current) =>
+        current.state === 'loading'
+          ? { state: 'error', error: apiError }
+          : current,
+      );
+      setDetailResult((current) =>
+        current.state === 'loading'
+          ? { state: 'error', error: apiError }
+          : current,
+      );
+      setCurriculumResult((current) =>
+        current.state === 'loading'
+          ? { state: 'error', error: apiError }
+          : current,
+      );
+      setScenarioSteps((currentSteps) =>
+        currentSteps.map((step) =>
+          step.state === 'loading' ? { ...step, state: 'error' } : step,
+        ),
+      );
+    }
+  }, [resetReadResults, updateScenarioStep]);
+
   return (
     <main className="bg-background-alternative min-h-screen w-full px-300 py-400">
       <section className="mx-auto flex w-full max-w-screen-xl flex-col gap-250">
         <header className="rounded-250 border border-border-default bg-background-default p-300 shadow-2">
           <p className="font-designer-14b text-text-brand">LOCAL CLASS TEST</p>
           <h1 className="font-designer-28b text-text-default">
-            클래스 생성 → 공개 조회 확인
+            클래스 기능이 연결됐는지 확인하기
           </h1>
           <p className="font-designer-15r mt-100 text-text-subtle">
-            버튼을 순서대로 누르면서 운영자 API로 만든 클래스가 사용자 공개
-            API에서 바로 보이는지 확인하는 로컬 테스트 화면입니다.
+            이 화면은 실제 운영자 화면이 아닙니다. 로컬 테스트용으로 클래스와
+            레슨을 하나 만들고, 그 클래스가 사용자 공개 API에서 보이는지
+            확인합니다. 처음 보는 사람은 아래 큰 버튼 하나만 누르면 됩니다.
           </p>
-          <div className="mt-200 grid gap-100 md:grid-cols-3">
-            <GuideStep
-              step="1"
-              title="운영자 로그인"
-              description="로컬 test login으로 admin token을 준비합니다."
-            />
-            <GuideStep
-              step="2"
-              title="코스+레슨 생성"
-              description="admin API로 공개 코스와 레슨 2개를 만듭니다."
-            />
-            <GuideStep
-              step="3"
-              title="목록/상세/커리큘럼 확인"
-              description="public API가 방금 만든 데이터를 반환하면 통과입니다."
-            />
-          </div>
-          <div className="mt-250 flex flex-wrap gap-100">
-            <SmokeButton
-              onClick={runSmoke}
-              isLoading={coursesResult.state === 'loading'}
-            >
-              전체 smoke 실행
-            </SmokeButton>
-            <SmokeButton
-              onClick={loadCourses}
-              isLoading={coursesResult.state === 'loading'}
-            >
-              A-01 목록
-            </SmokeButton>
-            <SmokeButton
-              onClick={loadDetail}
-              isLoading={detailResult.state === 'loading'}
-            >
-              A-02 상세
-            </SmokeButton>
-            <SmokeButton
-              onClick={loadCurriculum}
-              isLoading={curriculumResult.state === 'loading'}
-            >
-              A-04 커리큘럼
-            </SmokeButton>
-          </div>
         </header>
 
-        <SmokeCard
-          title="1. 운영자 데이터 만들기"
-          endpoint="POST /growth/test/login → POST /admin/courses → POST /admin/courses/{courseId}/lessons"
-          result={adminResult}
-          verifies="관리자가 브라우저에서 테스트용 공개 클래스와 무료/유료 레슨을 만들 수 있는지 확인합니다."
-        >
-          <div className="flex flex-wrap gap-100">
+        <section className="rounded-250 border-2 border-border-brand bg-background-default p-300 shadow-2">
+          <div className="flex flex-col gap-150 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <p className="font-designer-14b text-text-brand">
+                가장 쉬운 사용법
+              </p>
+              <h2 className="font-designer-24b mt-50 text-text-default">
+                1번 버튼만 누르세요
+              </h2>
+              <p className="font-designer-14r mt-75 text-text-subtle">
+                자동으로 관리자 로그인, 클래스 생성, 공개 목록 조회,
+                상세/커리큘럼 조회를 순서대로 실행합니다. 네 단계가 모두 초록색
+                성공이면 테스트 통과입니다.
+              </p>
+            </div>
             <SmokeButton
-              onClick={loginAdmin}
-              isLoading={adminResult.state === 'loading'}
+              variant="primary"
+              onClick={runLocalScenario}
+              isLoading={scenarioResult.state === 'loading'}
             >
-              1) 운영자 테스트 로그인
-            </SmokeButton>
-            <SmokeButton
-              onClick={createAdminSample}
-              isLoading={adminResult.state === 'loading'}
-            >
-              2) 코스+레슨 생성
+              1번: 자동 테스트 시작
             </SmokeButton>
           </div>
-          <p className="font-designer-13r text-text-subtle">
-            성공하면 새 slug가 자동 선택되고, 아래 목록/상세/커리큘럼에서 같은
-            클래스가 조회됩니다. accessToken은 화면에 노출하지 않습니다.
-          </p>
-          {adminCreateResult && (
-            <div className="grid gap-100 md:grid-cols-3">
-              <Metric
-                label="생성된 courseId"
-                value={adminCreateResult.courseId}
+          {scenarioResult.error && (
+            <ErrorMessage error={scenarioResult.error} className="mt-150" />
+          )}
+          <div className="mt-200 grid gap-100 md:grid-cols-4">
+            {scenarioSteps.map((step, index) => (
+              <ScenarioStepCard
+                key={step.title}
+                step={index + 1}
+                title={step.title}
+                description={step.description}
+                state={step.state}
               />
-              <Metric
-                label="생성된 레슨 수"
-                value={adminCreateResult.lessonIds.length}
-              />
-              <div className="rounded-150 bg-background-alternative p-150">
-                <p className="font-designer-12r text-text-subtlest">slug</p>
-                <p className="font-designer-13b break-all text-text-default">
-                  {adminCreateResult.slug}
-                </p>
-              </div>
+            ))}
+          </div>
+          {scenarioResult.state === 'success' && adminCreateResult && (
+            <div className="mt-200 rounded-150 bg-background-accent-green-subtle p-150">
+              <p className="font-designer-15b text-text-success">
+                테스트 완료: 방금 만든 클래스가 공개 API에서 조회됩니다.
+              </p>
+              <p className="font-designer-13r mt-50 break-all text-text-subtle">
+                생성된 slug: {adminCreateResult.slug}
+              </p>
             </div>
           )}
-        </SmokeCard>
+        </section>
 
-        <section className="grid gap-200 lg:grid-cols-3">
+        <section className="flex flex-col gap-150">
+          <div>
+            <p className="font-designer-14b text-text-brand">세부 결과</p>
+            <h2 className="font-designer-22b text-text-default">
+              자동 테스트가 실제로 확인한 내용
+            </h2>
+          </div>
           <SmokeCard
-            title="2. 공개 목록에서 보이는지 확인"
-            endpoint="GET /api/v1/courses?status=OPEN&page=0&size=20"
-            result={coursesResult}
-            verifies="방금 만든 OPEN 클래스가 사용자 공개 목록에 노출되는지 확인합니다."
+            title="운영자 데이터 만들기"
+            endpoint="POST /growth/test/login → POST /admin/courses → POST /admin/courses/{courseId}/lessons"
+            result={adminResult}
+            verifies="관리자 권한으로 테스트용 공개 클래스와 무료/유료 레슨을 만들 수 있는지 확인합니다."
           >
-            <label className="flex flex-col gap-75">
-              <span className="font-designer-13b text-text-subtle">
-                테스트할 클래스 slug
-              </span>
-              <input
-                value={selectedSlug}
-                onChange={(event) => setSelectedSlug(event.target.value)}
-                className="rounded-150 border border-border-default bg-background-default px-150 py-100 font-designer-14r text-text-default"
-                placeholder="먼저 A-01 목록 또는 코스+레슨 생성을 실행하세요"
-              />
-            </label>
-            <div className="flex flex-col gap-100">
-              {courses?.content.map((course) => (
-                <button
-                  key={course.courseId}
-                  type="button"
-                  onClick={() => setSelectedSlug(course.slug)}
-                  className={cn(
-                    'rounded-150 border px-150 py-125 text-left',
-                    selectedSlug === course.slug
-                      ? 'border-border-brand bg-background-accent-rose-subtle'
-                      : 'border-border-default bg-background-default',
-                  )}
+            <div className="flex flex-wrap gap-100">
+              <SmokeButton
+                onClick={loginAdmin}
+                isLoading={adminResult.state === 'loading'}
+              >
+                수동: 운영자 로그인
+              </SmokeButton>
+              <SmokeButton
+                onClick={createAdminSample}
+                isLoading={adminResult.state === 'loading'}
+              >
+                수동: 코스+레슨 생성
+              </SmokeButton>
+            </div>
+            <p className="font-designer-13r text-text-subtle">
+              자동 테스트가 실패했을 때만 개별 버튼으로 어느 단계가 문제인지
+              확인하세요. accessToken은 화면에 노출하지 않습니다.
+            </p>
+            {adminCreateResult && (
+              <div className="grid gap-100 md:grid-cols-3">
+                <Metric
+                  label="생성된 courseId"
+                  value={adminCreateResult.courseId}
+                />
+                <Metric
+                  label="생성된 레슨 수"
+                  value={adminCreateResult.lessonIds.length}
+                />
+                <div className="rounded-150 bg-background-alternative p-150">
+                  <p className="font-designer-12r text-text-subtlest">slug</p>
+                  <p className="font-designer-13b break-all text-text-default">
+                    {adminCreateResult.slug}
+                  </p>
+                </div>
+              </div>
+            )}
+          </SmokeCard>
+
+          <section className="grid gap-200 lg:grid-cols-3">
+            <SmokeCard
+              title="공개 목록 확인"
+              endpoint="GET /api/v1/courses?status=OPEN&page=0&size=20"
+              result={coursesResult}
+              verifies="방금 만든 OPEN 클래스가 사용자 공개 목록에 노출되는지 확인합니다."
+            >
+              <div className="flex flex-wrap gap-100">
+                <SmokeButton
+                  onClick={runPublicReadSmoke}
+                  isLoading={coursesResult.state === 'loading'}
                 >
-                  <span className="font-designer-15b text-text-default">
-                    {course.title}
-                  </span>
-                  <span className="font-designer-13r block text-text-subtle">
-                    {course.slug} · {course.status}
-                  </span>
-                </button>
-              ))}
-              {courses && courses.content.length === 0 && (
-                <p className="font-designer-14r text-text-subtle">
-                  OPEN 코스가 없습니다.
+                  수동: 공개 조회 전체 실행
+                </SmokeButton>
+                <SmokeButton
+                  onClick={loadCourses}
+                  isLoading={coursesResult.state === 'loading'}
+                >
+                  수동: 목록만 조회
+                </SmokeButton>
+              </div>
+              <label className="flex flex-col gap-75">
+                <span className="font-designer-13b text-text-subtle">
+                  테스트할 클래스 slug
+                </span>
+                <input
+                  value={selectedSlug}
+                  onChange={(event) => setSelectedSlug(event.target.value)}
+                  className="rounded-150 border border-border-default bg-background-default px-150 py-100 font-designer-14r text-text-default"
+                  placeholder="자동 테스트를 실행하면 자동으로 채워집니다"
+                />
+              </label>
+              <div className="flex flex-col gap-100">
+                {courses?.content.map((course) => (
+                  <button
+                    key={course.courseId}
+                    type="button"
+                    onClick={() => setSelectedSlug(course.slug)}
+                    className={cn(
+                      'rounded-150 border px-150 py-125 text-left',
+                      selectedSlug === course.slug
+                        ? 'border-border-brand bg-background-accent-rose-subtle'
+                        : 'border-border-default bg-background-default',
+                    )}
+                  >
+                    <span className="font-designer-15b text-text-default">
+                      {course.title}
+                    </span>
+                    <span className="font-designer-13r block text-text-subtle">
+                      {course.slug} · {course.status}
+                    </span>
+                  </button>
+                ))}
+                {courses && courses.content.length === 0 && (
+                  <p className="font-designer-14r text-text-subtle">
+                    OPEN 코스가 없습니다.
+                  </p>
+                )}
+              </div>
+              {courses && (
+                <p className="font-designer-13r text-text-subtlest">
+                  총 {courses.totalElements}개 OPEN 클래스 · 현재 page{' '}
+                  {courses.page} · 다음 페이지{' '}
+                  {courses.hasNext ? '있음' : '없음'}
                 </p>
               )}
-            </div>
-            {courses && (
-              <p className="font-designer-13r text-text-subtlest">
-                총 {courses.totalElements}개 OPEN 클래스 · 현재 page{' '}
-                {courses.page} · 다음 페이지 {courses.hasNext ? '있음' : '없음'}
-              </p>
-            )}
-          </SmokeCard>
+            </SmokeCard>
 
-          <SmokeCard
-            title="3. 상세 화면 계약 확인"
-            endpoint="GET /api/v1/courses/{slug}"
-            result={detailResult}
-            verifies="선택한 slug의 상세 정보와 구매/무료등록 가능 여부가 사용자 API로 내려오는지 확인합니다."
-          >
-            {detail ? (
-              <div className="flex flex-col gap-100">
-                <h2 className="font-designer-22b text-text-default">
-                  {detail.title}
-                </h2>
-                <p className="font-designer-14r text-text-subtle">
-                  {detail.description}
-                </p>
-                <ContractNote
-                  title="이 상세 조회가 성공하면"
-                  description="공개 slug로 접근했을 때 숨김 클래스가 아니고, 사용자에게 보여줄 가격/등록 상태 판단이 내려온다는 뜻입니다."
-                />
-                <KeyValue
-                  label="사용자 접근 상태"
-                  value={viewerStatusLabel[detail.viewerStatus]}
-                />
-                <KeyValue label="courseId" value={String(detail.courseId)} />
-                <KeyValue
-                  label="무료 등록"
-                  value={booleanLabel(detail.freeEnrollmentAvailable)}
-                />
-                <KeyValue
-                  label="구매"
-                  value={booleanLabel(detail.purchaseAvailable)}
-                />
-                <KeyValue
-                  label="가격 플랜 수"
-                  value={`${detail.plans?.length ?? 0}개`}
-                />
-              </div>
-            ) : (
-              <EmptyMessage text="아직 상세를 조회하지 않았습니다. 먼저 slug를 선택하고 A-02 상세 버튼을 누르세요." />
-            )}
-          </SmokeCard>
-
-          <SmokeCard
-            title="4. 커리큘럼 잠금 정책 확인"
-            endpoint="GET /api/v1/courses/{slug}/curriculum"
-            result={curriculumResult}
-            verifies="무료 레슨은 열려 있고 유료 레슨은 잠겨 있는지, 챕터/레슨 수가 맞는지 확인합니다."
-          >
-            {curriculum ? (
-              <div className="flex flex-col gap-150">
-                <div className="grid grid-cols-3 gap-100">
-                  <Metric label="챕터 수" value={curriculum.totalChapters} />
-                  <Metric label="레슨 수" value={curriculum.totalLessons} />
-                  <Metric label="진행 일수" value={curriculum.durationDays} />
-                </div>
+            <SmokeCard
+              title="상세 확인"
+              endpoint="GET /api/v1/courses/{slug}"
+              result={detailResult}
+              verifies="선택한 slug의 제목, 설명, 무료 등록 가능 여부, 구매 가능 여부가 내려오는지 확인합니다."
+            >
+              <SmokeButton
+                onClick={loadDetail}
+                isLoading={detailResult.state === 'loading'}
+              >
+                수동: 선택 slug 상세 조회
+              </SmokeButton>
+              {detail ? (
                 <div className="flex flex-col gap-100">
-                  {curriculum.chapters.map((chapter) => (
-                    <article
-                      key={chapter.chapterId}
-                      className="rounded-150 border border-border-default bg-background-default p-150"
-                    >
-                      <h3 className="font-designer-15b text-text-default">
-                        CH {chapter.chapterNumber}. {chapter.title}
-                      </h3>
-                      <p className="font-designer-13r text-text-subtlest">
-                        {chapter.lessons.length}개 레슨 · 예상{' '}
-                        {chapter.estimatedMinutes}분
-                      </p>
-                      <ul className="mt-100 flex flex-col gap-75">
-                        {chapter.lessons.map((lesson) => (
-                          <li
-                            key={lesson.lessonId}
-                            className="font-designer-13r flex items-center justify-between text-text-subtle"
-                          >
-                            <span>
-                              L{lesson.order}. {lesson.title}
-                            </span>
-                            <span>{lesson.locked ? '잠김' : '무료 공개'}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </article>
-                  ))}
+                  <h2 className="font-designer-22b text-text-default">
+                    {detail.title}
+                  </h2>
+                  <p className="font-designer-14r text-text-subtle">
+                    {detail.description}
+                  </p>
+                  <ContractNote
+                    title="상세 조회 성공 의미"
+                    description="공개 slug로 접근 가능하고, 사용자에게 보여줄 가격/등록 상태 판단이 내려왔다는 뜻입니다."
+                  />
+                  <KeyValue
+                    label="사용자 접근 상태"
+                    value={viewerStatusLabel[detail.viewerStatus]}
+                  />
+                  <KeyValue label="courseId" value={String(detail.courseId)} />
+                  <KeyValue
+                    label="무료 등록"
+                    value={booleanLabel(detail.freeEnrollmentAvailable)}
+                  />
+                  <KeyValue
+                    label="구매"
+                    value={booleanLabel(detail.purchaseAvailable)}
+                  />
+                  <KeyValue
+                    label="가격 플랜 수"
+                    value={`${detail.plans?.length ?? 0}개`}
+                  />
                 </div>
-              </div>
-            ) : (
-              <EmptyMessage text="아직 커리큘럼을 조회하지 않았습니다. A-04 커리큘럼 버튼을 누르세요." />
-            )}
-          </SmokeCard>
+              ) : (
+                <EmptyMessage text="자동 테스트를 실행하면 상세 결과가 여기에 표시됩니다." />
+              )}
+            </SmokeCard>
+
+            <SmokeCard
+              title="커리큘럼 확인"
+              endpoint="GET /api/v1/courses/{slug}/curriculum"
+              result={curriculumResult}
+              verifies="무료 레슨은 열려 있고 유료 레슨은 잠겨 있는지, 챕터/레슨 수가 맞는지 확인합니다."
+            >
+              <SmokeButton
+                onClick={loadCurriculum}
+                isLoading={curriculumResult.state === 'loading'}
+              >
+                수동: 선택 slug 커리큘럼 조회
+              </SmokeButton>
+              {curriculum ? (
+                <div className="flex flex-col gap-150">
+                  <div className="grid grid-cols-3 gap-100">
+                    <Metric label="챕터 수" value={curriculum.totalChapters} />
+                    <Metric label="레슨 수" value={curriculum.totalLessons} />
+                    <Metric label="진행 일수" value={curriculum.durationDays} />
+                  </div>
+                  <div className="flex flex-col gap-100">
+                    {curriculum.chapters.map((chapter) => (
+                      <article
+                        key={chapter.chapterId}
+                        className="rounded-150 border border-border-default bg-background-default p-150"
+                      >
+                        <h3 className="font-designer-15b text-text-default">
+                          CH {chapter.chapterNumber}. {chapter.title}
+                        </h3>
+                        <p className="font-designer-13r text-text-subtlest">
+                          {chapter.lessons.length}개 레슨 · 예상{' '}
+                          {chapter.estimatedMinutes}분
+                        </p>
+                        <ul className="mt-100 flex flex-col gap-75">
+                          {chapter.lessons.map((lesson) => (
+                            <li
+                              key={lesson.lessonId}
+                              className="font-designer-13r flex items-center justify-between text-text-subtle"
+                            >
+                              <span>
+                                L{lesson.order}. {lesson.title}
+                              </span>
+                              <span>
+                                {lesson.locked ? '잠김' : '무료 공개'}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </article>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <EmptyMessage text="자동 테스트를 실행하면 커리큘럼 결과가 여기에 표시됩니다." />
+              )}
+            </SmokeCard>
+          </section>
         </section>
       </section>
     </main>
   );
 }
 
-function GuideStep({
+function ScenarioStepCard({
   description,
+  state,
   step,
   title,
 }: {
   description: string;
-  step: string;
+  state: SmokeState;
+  step: number;
   title: string;
 }) {
   return (
-    <div className="rounded-150 bg-background-alternative p-150">
-      <p className="font-designer-12b text-text-brand">STEP {step}</p>
-      <h2 className="font-designer-15b mt-50 text-text-default">{title}</h2>
+    <div
+      className={cn(
+        'rounded-150 border p-150',
+        state === 'success' &&
+          'border-border-success bg-background-accent-green-subtle',
+        state === 'error' &&
+          'border-border-error bg-background-accent-red-subtle',
+        state === 'loading' &&
+          'border-border-warning bg-background-accent-yellow-subtle',
+        state === 'idle' && 'border-border-default bg-background-alternative',
+      )}
+    >
+      <div className="flex items-center justify-between gap-100">
+        <p className="font-designer-12b text-text-brand">STEP {step}</p>
+        <StatusBadge state={state} />
+      </div>
+      <h3 className="font-designer-15b mt-75 text-text-default">{title}</h3>
       <p className="font-designer-13r mt-50 text-text-subtle">{description}</p>
     </div>
   );
@@ -487,17 +669,23 @@ function SmokeButton({
   children,
   isLoading,
   onClick,
+  variant = 'secondary',
 }: {
   children: React.ReactNode;
   isLoading: boolean;
   onClick: () => void;
+  variant?: 'primary' | 'secondary';
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={isLoading}
-      className="rounded-150 bg-background-brand-default px-200 py-125 font-designer-14b text-text-inverse disabled:opacity-50"
+      className={cn(
+        'rounded-150 bg-background-brand-default font-designer-14b text-text-inverse disabled:opacity-50',
+        variant === 'primary' && 'px-300 py-175 shadow-2',
+        variant === 'secondary' && 'px-200 py-125',
+      )}
     >
       {isLoading ? '요청 중...' : children}
     </button>
@@ -535,16 +723,31 @@ function SmokeCard({
           확인 내용: {verifies}
         </p>
       )}
-      {result.error && (
-        <div className="mb-150 rounded-150 border border-border-error bg-background-accent-red-subtle p-150">
-          <p className="font-designer-13b text-text-error">
-            {result.error.status ? `${result.error.status} · ` : ''}
-            {result.error.message}
-          </p>
-        </div>
-      )}
+      {result.error && <ErrorMessage error={result.error} className="mb-150" />}
       <div className="flex flex-col gap-150">{children}</div>
     </article>
+  );
+}
+
+function ErrorMessage({
+  className,
+  error,
+}: {
+  className?: string;
+  error: ClassApiError;
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-150 border border-border-error bg-background-accent-red-subtle p-150',
+        className,
+      )}
+    >
+      <p className="font-designer-13b text-text-error">
+        {error.status ? `${error.status} · ` : ''}
+        {error.message}
+      </p>
+    </div>
   );
 }
 

--- a/src/features/class-domain-test/ui/class-domain-test-page.tsx
+++ b/src/features/class-domain-test/ui/class-domain-test-page.tsx
@@ -8,6 +8,7 @@ import {
   type ClassCourseDetail,
   type ClassCourseSummary,
   type ClassCurriculum,
+  type ClassPlan,
   type ClassPageResponse,
   createClassAdminSample,
   getClassCourseDetail,
@@ -324,34 +325,36 @@ export default function ClassDomainTestPage() {
     }
   }, [resetReadResults, updateScenarioStep]);
 
-  return (
-    <main className="bg-background-alternative min-h-screen w-full px-300 py-400">
-      <section className="mx-auto flex w-full max-w-screen-xl flex-col gap-250">
-        <header className="rounded-250 border border-border-default bg-background-default p-300 shadow-2">
-          <p className="font-designer-14b text-text-brand">LOCAL CLASS TEST</p>
-          <h1 className="font-designer-28b text-text-default">
-            클래스 기능이 연결됐는지 확인하기
-          </h1>
-          <p className="font-designer-15r mt-100 text-text-subtle">
-            이 화면은 실제 운영자 화면이 아닙니다. 로컬 테스트용으로 클래스와
-            레슨을 하나 만들고, 그 클래스가 사용자 공개 API에서 보이는지
-            확인합니다. 처음 보는 사람은 아래 큰 버튼 하나만 누르면 됩니다.
-          </p>
-        </header>
+  const primaryCourse = detail ?? courses?.content.at(0);
+  const heroTitle =
+    detail?.title ?? primaryCourse?.title ?? '바이브코딩 입문자 클래스';
+  const heroDescription =
+    detail?.description ??
+    '실제 v0.6 화면 흐름처럼 코스 랜딩, 상세 결제 카드, 학습 여정, 레슨 미리보기를 한 화면에서 확인합니다.';
+  const visiblePlans = detail?.plans ?? [];
+  const firstChapter = curriculum?.chapters.at(0);
+  const firstLesson = firstChapter?.lessons.at(0);
+  const paidLesson =
+    firstChapter?.lessons.find((lesson) => lesson.locked) ??
+    firstChapter?.lessons.at(1);
 
-        <section className="rounded-250 border-2 border-border-brand bg-background-default p-300 shadow-2">
-          <div className="flex flex-col gap-150 lg:flex-row lg:items-start lg:justify-between">
-            <div>
+  return (
+    <main className="min-h-screen bg-background-alternative text-text-default">
+      <section className="mx-auto flex w-full max-w-screen-xl flex-col gap-300 px-300 py-300">
+        <header className="rounded-300 border border-border-default bg-background-default p-300 shadow-2">
+          <div className="flex flex-col gap-200 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-screen-md">
               <p className="font-designer-14b text-text-brand">
-                가장 쉬운 사용법
+                CLASS v0.6 LOCAL E2E
               </p>
-              <h2 className="font-designer-24b mt-50 text-text-default">
-                1번 버튼만 누르세요
-              </h2>
-              <p className="font-designer-14r mt-75 text-text-subtle">
-                자동으로 관리자 로그인, 클래스 생성, 공개 목록 조회,
-                상세/커리큘럼 조회를 순서대로 실행합니다. 네 단계가 모두 초록색
-                성공이면 테스트 통과입니다.
+              <h1 className="font-designer-32b mt-75 text-text-default">
+                화면맵 흐름대로 클래스 기능을 눌러보기
+              </h1>
+              <p className="font-designer-15r mt-100 text-text-subtle">
+                이 페이지는 개발자용 JSON 확인 화면이 아니라, v0.6 screen-map의
+                주요 화면을 얕게 재현한 로컬 검증용 미니 프론트입니다. 아래 버튼
+                하나로 데이터를 만들고, 랜딩 → 코스상세 → 학습여정 → 레슨
+                미리보기 구조에서 결과를 확인합니다.
               </p>
             </div>
             <SmokeButton
@@ -359,7 +362,7 @@ export default function ClassDomainTestPage() {
               onClick={runLocalScenario}
               isLoading={scenarioResult.state === 'loading'}
             >
-              1번: 자동 테스트 시작
+              로컬 데이터 만들고 화면 채우기
             </SmokeButton>
           </div>
           {scenarioResult.error && (
@@ -376,57 +379,320 @@ export default function ClassDomainTestPage() {
               />
             ))}
           </div>
-          {scenarioResult.state === 'success' && adminCreateResult && (
-            <div className="mt-200 rounded-150 bg-background-accent-green-subtle p-150">
-              <p className="font-designer-15b text-text-success">
-                테스트 완료: 방금 만든 클래스가 공개 API에서 조회됩니다.
-              </p>
-              <p className="font-designer-13r mt-50 break-all text-text-subtle">
-                생성된 slug: {adminCreateResult.slug}
+        </header>
+
+        <section className="grid gap-200 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <article className="rounded-300 border border-border-default bg-background-default p-300 shadow-2">
+            <div className="grid gap-250 lg:grid-cols-[minmax(0,1fr)_280px]">
+              <div className="flex flex-col gap-175">
+                <div className="flex flex-wrap gap-75">
+                  <span className="rounded-500 bg-background-accent-rose-subtle px-125 py-50 font-designer-12b text-text-brand">
+                    S-코스상세-A
+                  </span>
+                  <span className="rounded-500 bg-background-alternative px-125 py-50 font-designer-12b text-text-subtle">
+                    A-02 상세/가격
+                  </span>
+                </div>
+                <h2 className="font-designer-36b text-text-default">
+                  {heroTitle}
+                </h2>
+                <p className="font-designer-16r text-text-subtle">
+                  {heroDescription}
+                </p>
+                <div className="grid gap-100 md:grid-cols-3">
+                  <Metric
+                    label="완주 예상일"
+                    value={curriculum?.durationDays ?? 5}
+                  />
+                  <Metric label="챕터" value={curriculum?.totalChapters ?? 5} />
+                  <Metric label="레슨" value={curriculum?.totalLessons ?? 20} />
+                </div>
+                <div className="rounded-250 bg-background-alternative p-200">
+                  <p className="font-designer-14b text-text-default">
+                    이런 분들이 들으면 좋아요
+                  </p>
+                  <div className="mt-125 grid gap-100 md:grid-cols-3">
+                    {[
+                      '처음 웹서비스를 만드는 입문자',
+                      'AI 도구를 실전 프로젝트에 쓰고 싶은 사람',
+                      '혼자 막히지 않고 완주하고 싶은 사람',
+                    ].map((item) => (
+                      <div
+                        key={item}
+                        className="rounded-150 bg-background-default p-150 font-designer-13r text-text-subtle"
+                      >
+                        {item}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <aside className="rounded-250 border-2 border-border-brand bg-background-default p-200 shadow-2">
+                <p className="font-designer-14b text-text-brand">
+                  얼리버드 플랜
+                </p>
+                <div className="mt-150 flex flex-col gap-125">
+                  {visiblePlans.length > 0 ? (
+                    visiblePlans.map((plan) => (
+                      <PlanCard key={plan.planCode} plan={plan} />
+                    ))
+                  ) : (
+                    <EmptyMessage text="상세 조회 후 가격 플랜이 표시됩니다." />
+                  )}
+                </div>
+                <div className="mt-175 flex flex-col gap-100">
+                  <button
+                    type="button"
+                    className="rounded-150 bg-background-brand-default px-200 py-150 font-designer-15b text-text-inverse"
+                  >
+                    참가하기
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-150 border border-border-default px-200 py-150 font-designer-15b text-text-default"
+                  >
+                    무료 코스 시작하기
+                  </button>
+                </div>
+                {detail && (
+                  <p className="font-designer-12r mt-125 text-text-subtlest">
+                    현재 상태: {viewerStatusLabel[detail.viewerStatus]}
+                  </p>
+                )}
+              </aside>
+            </div>
+          </article>
+
+          <aside className="flex flex-col gap-150 rounded-300 border border-border-default bg-background-default p-250 shadow-1">
+            <div>
+              <p className="font-designer-14b text-text-brand">테스트 조작</p>
+              <h2 className="font-designer-20b text-text-default">
+                무엇을 누르면 되나요?
+              </h2>
+              <p className="font-designer-13r mt-75 text-text-subtle">
+                처음에는 위의 큰 버튼만 누르세요. 실패하면 아래 개별 버튼으로
+                어느 API 단계가 막혔는지 확인합니다.
               </p>
             </div>
-          )}
+            <SmokeButton
+              onClick={runPublicReadSmoke}
+              isLoading={coursesResult.state === 'loading'}
+            >
+              공개 목록/상세/커리큘럼 다시 조회
+            </SmokeButton>
+            <SmokeButton
+              onClick={loginAdmin}
+              isLoading={adminResult.state === 'loading'}
+            >
+              운영자 로그인만 실행
+            </SmokeButton>
+            <SmokeButton
+              onClick={createAdminSample}
+              isLoading={adminResult.state === 'loading'}
+            >
+              코스+레슨 생성만 실행
+            </SmokeButton>
+            <label className="flex flex-col gap-75">
+              <span className="font-designer-13b text-text-subtle">
+                직접 확인할 slug
+              </span>
+              <input
+                value={selectedSlug}
+                onChange={(event) => setSelectedSlug(event.target.value)}
+                className="rounded-150 border border-border-default bg-background-default px-150 py-100 font-designer-14r text-text-default"
+                placeholder="예: vibe-coding-intro"
+              />
+            </label>
+            <div className="flex gap-100">
+              <SmokeButton
+                onClick={loadDetail}
+                isLoading={detailResult.state === 'loading'}
+              >
+                상세
+              </SmokeButton>
+              <SmokeButton
+                onClick={loadCurriculum}
+                isLoading={curriculumResult.state === 'loading'}
+              >
+                커리큘럼
+              </SmokeButton>
+            </div>
+            {adminCreateResult && (
+              <ContractNote
+                title="생성 완료"
+                description={`courseId ${adminCreateResult.courseId}, lesson ${adminCreateResult.lessonIds.length}개가 생성됐습니다.`}
+              />
+            )}
+          </aside>
         </section>
 
-        <section className="flex flex-col gap-150">
-          <div>
-            <p className="font-designer-14b text-text-brand">세부 결과</p>
-            <h2 className="font-designer-22b text-text-default">
-              자동 테스트가 실제로 확인한 내용
-            </h2>
-          </div>
-          <SmokeCard
-            title="운영자 데이터 만들기"
-            endpoint="POST /growth/test/login → POST /admin/courses → POST /admin/courses/{courseId}/lessons"
-            result={adminResult}
-            verifies="관리자 권한으로 테스트용 공개 클래스와 무료/유료 레슨을 만들 수 있는지 확인합니다."
+        <section className="grid gap-200 lg:grid-cols-3">
+          <ScreenCard
+            screenId="S-코스목록"
+            title="클래스 목록"
+            subtitle="A-01 공개 코스 목록"
+            result={coursesResult}
           >
-            <div className="flex flex-wrap gap-100">
-              <SmokeButton
-                onClick={loginAdmin}
-                isLoading={adminResult.state === 'loading'}
-              >
-                수동: 운영자 로그인
-              </SmokeButton>
-              <SmokeButton
-                onClick={createAdminSample}
-                isLoading={adminResult.state === 'loading'}
-              >
-                수동: 코스+레슨 생성
-              </SmokeButton>
+            <div className="flex flex-col gap-100">
+              {courses?.content.map((course) => (
+                <button
+                  key={course.courseId}
+                  type="button"
+                  onClick={() => setSelectedSlug(course.slug)}
+                  className={cn(
+                    'rounded-200 border p-150 text-left',
+                    selectedSlug === course.slug
+                      ? 'border-border-brand bg-background-accent-rose-subtle'
+                      : 'border-border-default bg-background-default',
+                  )}
+                >
+                  <p className="font-designer-15b text-text-default">
+                    {course.title}
+                  </p>
+                  <p className="font-designer-13r mt-50 break-all text-text-subtle">
+                    {course.slug}
+                  </p>
+                  <p className="font-designer-12b mt-75 text-text-brand">
+                    자세히 보기
+                  </p>
+                </button>
+              ))}
+              {courses && courses.content.length === 0 && (
+                <EmptyMessage text="OPEN 클래스가 없습니다." />
+              )}
+              {!courses && (
+                <EmptyMessage text="큰 버튼을 누르면 코스 카드가 표시됩니다." />
+              )}
             </div>
-            <p className="font-designer-13r text-text-subtle">
-              자동 테스트가 실패했을 때만 개별 버튼으로 어느 단계가 문제인지
-              확인하세요. accessToken은 화면에 노출하지 않습니다.
-            </p>
-            {adminCreateResult && (
-              <div className="grid gap-100 md:grid-cols-3">
-                <Metric
-                  label="생성된 courseId"
-                  value={adminCreateResult.courseId}
+          </ScreenCard>
+
+          <ScreenCard
+            screenId="S-학습여정-무료/결제자"
+            title="학습 여정 맵"
+            subtitle="A-03/A-06 형태 미리보기"
+            result={curriculumResult}
+          >
+            <div className="rounded-200 bg-background-accent-green-subtle p-150">
+              <p className="font-designer-14b text-text-success">
+                한 레슨씩, 순서대로 따라가면 됩니다
+              </p>
+              <p className="font-designer-13r mt-50 text-text-subtle">
+                {detail?.viewerStatus === 'PAID'
+                  ? '결제자 화면에서는 전체 레슨이 열립니다.'
+                  : '무료 화면에서는 첫 레슨 이후 결제 CTA가 노출됩니다.'}
+              </p>
+            </div>
+            <div className="mt-150 flex flex-col gap-100">
+              {firstChapter?.lessons.map((lesson, index) => (
+                <div
+                  key={lesson.lessonId}
+                  className="flex items-center gap-100 rounded-150 bg-background-alternative p-125"
+                >
+                  <span
+                    className={cn(
+                      'flex h-250 w-250 items-center justify-center rounded-full font-designer-12b',
+                      lesson.locked
+                        ? 'bg-background-default text-text-subtlest'
+                        : 'bg-background-brand-default text-text-inverse',
+                    )}
+                  >
+                    {index + 1}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="font-designer-14b text-text-default">
+                      Lesson {lesson.order}. {lesson.title}
+                    </p>
+                    <p className="font-designer-12r text-text-subtle">
+                      {lesson.locked
+                        ? '잠김 · 결제 후 열림'
+                        : '무료 공개 · 바로 시작 가능'}
+                    </p>
+                  </div>
+                </div>
+              )) ?? (
+                <EmptyMessage text="커리큘럼 조회 후 여정 노드가 표시됩니다." />
+              )}
+            </div>
+          </ScreenCard>
+
+          <ScreenCard
+            screenId="S-레슨상세/돌아보기"
+            title="레슨 진입 미리보기"
+            subtitle="A-05/B-01 화면 감각"
+            result={curriculumResult}
+          >
+            <div className="rounded-200 bg-background-default p-150 shadow-1">
+              <p className="font-designer-12b text-text-brand">NEXT LESSON</p>
+              <h3 className="font-designer-18b mt-50 text-text-default">
+                {firstLesson
+                  ? `Lesson ${firstLesson.order}. ${firstLesson.title}`
+                  : 'Lesson 01. 무료 첫 레슨'}
+              </h3>
+              <div className="mt-125 rounded-200 bg-background-alternative p-200 text-center font-designer-14b text-text-subtle">
+                비디오/실습 영역
+              </div>
+            </div>
+            <div className="rounded-200 border border-border-default bg-background-default p-150">
+              <p className="font-designer-14b text-text-default">
+                클래스 돌아보기
+              </p>
+              <p className="font-designer-13r mt-50 text-text-subtle">
+                오늘 가장 신기했던 코드와 막혔던 지점을 작성하고 다음 레슨으로
+                넘어갑니다.
+              </p>
+            </div>
+            {paidLesson && (
+              <ContractNote
+                title="잠금 정책 확인"
+                description={`${paidLesson.title}은 ${paidLesson.locked ? '잠김 상태' : '열림 상태'}로 내려왔습니다.`}
+              />
+            )}
+          </ScreenCard>
+        </section>
+
+        <section className="grid gap-200 lg:grid-cols-2">
+          <SmokeCard
+            title="상세 API가 화면에 반영한 판단"
+            endpoint="GET /api/v1/courses/{slug}"
+            result={detailResult}
+            verifies="viewerStatus, 무료 등록, 구매 가능 여부, 플랜 가격이 실제 화면 카드에 반영되는지 확인합니다."
+          >
+            {detail ? (
+              <div className="flex flex-col gap-75">
+                <KeyValue
+                  label="사용자 접근 상태"
+                  value={viewerStatusLabel[detail.viewerStatus]}
                 />
+                <KeyValue
+                  label="무료 등록"
+                  value={booleanLabel(detail.freeEnrollmentAvailable)}
+                />
+                <KeyValue
+                  label="구매"
+                  value={booleanLabel(detail.purchaseAvailable)}
+                />
+                <KeyValue
+                  label="가격 플랜 수"
+                  value={`${detail.plans?.length ?? 0}개`}
+                />
+              </div>
+            ) : (
+              <EmptyMessage text="상세 조회 후 판단 결과가 표시됩니다." />
+            )}
+          </SmokeCard>
+
+          <SmokeCard
+            title="운영자 생성 smoke"
+            endpoint="POST /admin/courses → POST /admin/courses/{courseId}/lessons"
+            result={adminResult}
+            verifies="로컬 백엔드에서 운영자 API로 화면 검증용 코스와 레슨을 직접 만들 수 있는지 확인합니다."
+          >
+            {adminCreateResult ? (
+              <div className="grid gap-100 md:grid-cols-3">
+                <Metric label="courseId" value={adminCreateResult.courseId} />
                 <Metric
-                  label="생성된 레슨 수"
+                  label="lesson"
                   value={adminCreateResult.lessonIds.length}
                 />
                 <div className="rounded-150 bg-background-alternative p-150">
@@ -436,180 +702,10 @@ export default function ClassDomainTestPage() {
                   </p>
                 </div>
               </div>
+            ) : (
+              <EmptyMessage text="로컬 데이터 만들기 버튼을 누르면 생성 결과가 표시됩니다." />
             )}
           </SmokeCard>
-
-          <section className="grid gap-200 lg:grid-cols-3">
-            <SmokeCard
-              title="공개 목록 확인"
-              endpoint="GET /api/v1/courses?status=OPEN&page=0&size=20"
-              result={coursesResult}
-              verifies="방금 만든 OPEN 클래스가 사용자 공개 목록에 노출되는지 확인합니다."
-            >
-              <div className="flex flex-wrap gap-100">
-                <SmokeButton
-                  onClick={runPublicReadSmoke}
-                  isLoading={coursesResult.state === 'loading'}
-                >
-                  수동: 공개 조회 전체 실행
-                </SmokeButton>
-                <SmokeButton
-                  onClick={loadCourses}
-                  isLoading={coursesResult.state === 'loading'}
-                >
-                  수동: 목록만 조회
-                </SmokeButton>
-              </div>
-              <label className="flex flex-col gap-75">
-                <span className="font-designer-13b text-text-subtle">
-                  테스트할 클래스 slug
-                </span>
-                <input
-                  value={selectedSlug}
-                  onChange={(event) => setSelectedSlug(event.target.value)}
-                  className="rounded-150 border border-border-default bg-background-default px-150 py-100 font-designer-14r text-text-default"
-                  placeholder="자동 테스트를 실행하면 자동으로 채워집니다"
-                />
-              </label>
-              <div className="flex flex-col gap-100">
-                {courses?.content.map((course) => (
-                  <button
-                    key={course.courseId}
-                    type="button"
-                    onClick={() => setSelectedSlug(course.slug)}
-                    className={cn(
-                      'rounded-150 border px-150 py-125 text-left',
-                      selectedSlug === course.slug
-                        ? 'border-border-brand bg-background-accent-rose-subtle'
-                        : 'border-border-default bg-background-default',
-                    )}
-                  >
-                    <span className="font-designer-15b text-text-default">
-                      {course.title}
-                    </span>
-                    <span className="font-designer-13r block text-text-subtle">
-                      {course.slug} · {course.status}
-                    </span>
-                  </button>
-                ))}
-                {courses && courses.content.length === 0 && (
-                  <p className="font-designer-14r text-text-subtle">
-                    OPEN 코스가 없습니다.
-                  </p>
-                )}
-              </div>
-              {courses && (
-                <p className="font-designer-13r text-text-subtlest">
-                  총 {courses.totalElements}개 OPEN 클래스 · 현재 page{' '}
-                  {courses.page} · 다음 페이지{' '}
-                  {courses.hasNext ? '있음' : '없음'}
-                </p>
-              )}
-            </SmokeCard>
-
-            <SmokeCard
-              title="상세 확인"
-              endpoint="GET /api/v1/courses/{slug}"
-              result={detailResult}
-              verifies="선택한 slug의 제목, 설명, 무료 등록 가능 여부, 구매 가능 여부가 내려오는지 확인합니다."
-            >
-              <SmokeButton
-                onClick={loadDetail}
-                isLoading={detailResult.state === 'loading'}
-              >
-                수동: 선택 slug 상세 조회
-              </SmokeButton>
-              {detail ? (
-                <div className="flex flex-col gap-100">
-                  <h2 className="font-designer-22b text-text-default">
-                    {detail.title}
-                  </h2>
-                  <p className="font-designer-14r text-text-subtle">
-                    {detail.description}
-                  </p>
-                  <ContractNote
-                    title="상세 조회 성공 의미"
-                    description="공개 slug로 접근 가능하고, 사용자에게 보여줄 가격/등록 상태 판단이 내려왔다는 뜻입니다."
-                  />
-                  <KeyValue
-                    label="사용자 접근 상태"
-                    value={viewerStatusLabel[detail.viewerStatus]}
-                  />
-                  <KeyValue label="courseId" value={String(detail.courseId)} />
-                  <KeyValue
-                    label="무료 등록"
-                    value={booleanLabel(detail.freeEnrollmentAvailable)}
-                  />
-                  <KeyValue
-                    label="구매"
-                    value={booleanLabel(detail.purchaseAvailable)}
-                  />
-                  <KeyValue
-                    label="가격 플랜 수"
-                    value={`${detail.plans?.length ?? 0}개`}
-                  />
-                </div>
-              ) : (
-                <EmptyMessage text="자동 테스트를 실행하면 상세 결과가 여기에 표시됩니다." />
-              )}
-            </SmokeCard>
-
-            <SmokeCard
-              title="커리큘럼 확인"
-              endpoint="GET /api/v1/courses/{slug}/curriculum"
-              result={curriculumResult}
-              verifies="무료 레슨은 열려 있고 유료 레슨은 잠겨 있는지, 챕터/레슨 수가 맞는지 확인합니다."
-            >
-              <SmokeButton
-                onClick={loadCurriculum}
-                isLoading={curriculumResult.state === 'loading'}
-              >
-                수동: 선택 slug 커리큘럼 조회
-              </SmokeButton>
-              {curriculum ? (
-                <div className="flex flex-col gap-150">
-                  <div className="grid grid-cols-3 gap-100">
-                    <Metric label="챕터 수" value={curriculum.totalChapters} />
-                    <Metric label="레슨 수" value={curriculum.totalLessons} />
-                    <Metric label="진행 일수" value={curriculum.durationDays} />
-                  </div>
-                  <div className="flex flex-col gap-100">
-                    {curriculum.chapters.map((chapter) => (
-                      <article
-                        key={chapter.chapterId}
-                        className="rounded-150 border border-border-default bg-background-default p-150"
-                      >
-                        <h3 className="font-designer-15b text-text-default">
-                          CH {chapter.chapterNumber}. {chapter.title}
-                        </h3>
-                        <p className="font-designer-13r text-text-subtlest">
-                          {chapter.lessons.length}개 레슨 · 예상{' '}
-                          {chapter.estimatedMinutes}분
-                        </p>
-                        <ul className="mt-100 flex flex-col gap-75">
-                          {chapter.lessons.map((lesson) => (
-                            <li
-                              key={lesson.lessonId}
-                              className="font-designer-13r flex items-center justify-between text-text-subtle"
-                            >
-                              <span>
-                                L{lesson.order}. {lesson.title}
-                              </span>
-                              <span>
-                                {lesson.locked ? '잠김' : '무료 공개'}
-                              </span>
-                            </li>
-                          ))}
-                        </ul>
-                      </article>
-                    ))}
-                  </div>
-                </div>
-              ) : (
-                <EmptyMessage text="자동 테스트를 실행하면 커리큘럼 결과가 여기에 표시됩니다." />
-              )}
-            </SmokeCard>
-          </section>
         </section>
       </section>
     </main>
@@ -662,6 +758,71 @@ function ContractNote({
       <p className="font-designer-13b text-text-success">{title}</p>
       <p className="font-designer-13r mt-50 text-text-subtle">{description}</p>
     </div>
+  );
+}
+
+function PlanCard({ plan }: { plan: ClassPlan }) {
+  return (
+    <div className="rounded-200 border border-border-default bg-background-alternative p-150">
+      <div className="flex items-start justify-between gap-100">
+        <div>
+          <p className="font-designer-15b text-text-default">{plan.name}</p>
+          {plan.subtitle && (
+            <p className="font-designer-12r mt-50 text-text-subtle">
+              {plan.subtitle}
+            </p>
+          )}
+        </div>
+        <p className="font-designer-18b text-text-brand">
+          {(
+            plan.earlyBirdPrice ??
+            plan.regularPriceAfterEb ??
+            0
+          ).toLocaleString()}
+          원
+        </p>
+      </div>
+      <ul className="mt-125 flex flex-col gap-50">
+        {plan.items.map((item) => (
+          <li
+            key={item.code}
+            className="font-designer-12r flex items-center justify-between gap-100 text-text-subtle"
+          >
+            <span>{item.label}</span>
+            <span>{item.valueAmount.toLocaleString()}원 가치</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ScreenCard({
+  children,
+  result,
+  screenId,
+  subtitle,
+  title,
+}: {
+  children: React.ReactNode;
+  result: SmokeResult;
+  screenId: string;
+  subtitle: string;
+  title: string;
+}) {
+  return (
+    <article className="rounded-300 border border-border-default bg-background-default p-250 shadow-1">
+      <div className="mb-175 flex items-start justify-between gap-150">
+        <div>
+          <p className="font-designer-12b text-text-brand">{screenId}</p>
+          <h2 className="font-designer-20b mt-50 text-text-default">{title}</h2>
+          <p className="font-designer-13r mt-50 text-text-subtle">{subtitle}</p>
+        </div>
+        <StatusBadge state={result.state} />
+      </div>
+      <div className="flex flex-col gap-150">{children}</div>
+      {result.error && <ErrorMessage error={result.error} className="mt-150" />}
+    </article>
   );
 }
 

--- a/src/features/class-domain-test/ui/class-domain-test-page.tsx
+++ b/src/features/class-domain-test/ui/class-domain-test-page.tsx
@@ -28,6 +28,25 @@ const initialSmokeResult: SmokeResult = {
   state: 'idle',
 };
 
+const viewerStatusLabel: Record<ClassCourseDetail['viewerStatus'], string> = {
+  ANONYMOUS: '비로그인 사용자로 상세를 조회했습니다.',
+  LOGIN_ONLY: '로그인하면 무료 등록을 시작할 수 있는 공개 클래스입니다.',
+  FREE_ENROLLED: '무료 등록을 마친 사용자로 조회했습니다.',
+  PAID: '결제 완료 사용자로 전체 접근 가능합니다.',
+};
+
+const booleanLabel = (value: ClassCourseDetail['freeEnrollmentAvailable']) => {
+  if (value === true) {
+    return '가능';
+  }
+
+  if (value === false) {
+    return '불가';
+  }
+
+  return '응답 없음';
+};
+
 export default function ClassDomainTestPage() {
   const [courses, setCourses] =
     useState<ClassPageResponse<ClassCourseSummary>>();
@@ -187,14 +206,31 @@ export default function ClassDomainTestPage() {
     <main className="bg-background-alternative min-h-screen w-full px-300 py-400">
       <section className="mx-auto flex w-full max-w-screen-xl flex-col gap-250">
         <header className="rounded-250 border border-border-default bg-background-default p-300 shadow-2">
-          <p className="font-designer-14b text-text-brand">E2E TEST HARNESS</p>
+          <p className="font-designer-14b text-text-brand">LOCAL CLASS TEST</p>
           <h1 className="font-designer-28b text-text-default">
-            Class domain API smoke page
+            클래스 생성 → 공개 조회 확인
           </h1>
           <p className="font-designer-15r mt-100 text-text-subtle">
-            디자인 완성도보다 실제 backend class API 호출 확인에 집중하는 임시
-            페이지입니다.
+            버튼을 순서대로 누르면서 운영자 API로 만든 클래스가 사용자 공개
+            API에서 바로 보이는지 확인하는 로컬 테스트 화면입니다.
           </p>
+          <div className="mt-200 grid gap-100 md:grid-cols-3">
+            <GuideStep
+              step="1"
+              title="운영자 로그인"
+              description="로컬 test login으로 admin token을 준비합니다."
+            />
+            <GuideStep
+              step="2"
+              title="코스+레슨 생성"
+              description="admin API로 공개 코스와 레슨 2개를 만듭니다."
+            />
+            <GuideStep
+              step="3"
+              title="목록/상세/커리큘럼 확인"
+              description="public API가 방금 만든 데이터를 반환하면 통과입니다."
+            />
+          </div>
           <div className="mt-250 flex flex-wrap gap-100">
             <SmokeButton
               onClick={runSmoke}
@@ -223,29 +259,38 @@ export default function ClassDomainTestPage() {
           </div>
         </header>
 
-        <SmokeCard title="L-admin 운영자 생성 smoke" result={adminResult}>
+        <SmokeCard
+          title="1. 운영자 데이터 만들기"
+          endpoint="POST /growth/test/login → POST /admin/courses → POST /admin/courses/{courseId}/lessons"
+          result={adminResult}
+          verifies="관리자가 브라우저에서 테스트용 공개 클래스와 무료/유료 레슨을 만들 수 있는지 확인합니다."
+        >
           <div className="flex flex-wrap gap-100">
             <SmokeButton
               onClick={loginAdmin}
               isLoading={adminResult.state === 'loading'}
             >
-              운영자 테스트 로그인
+              1) 운영자 테스트 로그인
             </SmokeButton>
             <SmokeButton
               onClick={createAdminSample}
               isLoading={adminResult.state === 'loading'}
             >
-              코스+레슨 생성
+              2) 코스+레슨 생성
             </SmokeButton>
           </div>
-          <p className="font-designer-13r text-text-subtlest">
-            accessToken은 화면에 노출하지 않고 브라우저 state에만 보관합니다.
+          <p className="font-designer-13r text-text-subtle">
+            성공하면 새 slug가 자동 선택되고, 아래 목록/상세/커리큘럼에서 같은
+            클래스가 조회됩니다. accessToken은 화면에 노출하지 않습니다.
           </p>
           {adminCreateResult && (
             <div className="grid gap-100 md:grid-cols-3">
-              <Metric label="courseId" value={adminCreateResult.courseId} />
               <Metric
-                label="lessons"
+                label="생성된 courseId"
+                value={adminCreateResult.courseId}
+              />
+              <Metric
+                label="생성된 레슨 수"
                 value={adminCreateResult.lessonIds.length}
               />
               <div className="rounded-150 bg-background-alternative p-150">
@@ -259,16 +304,21 @@ export default function ClassDomainTestPage() {
         </SmokeCard>
 
         <section className="grid gap-200 lg:grid-cols-3">
-          <SmokeCard title="A-01 GET /courses" result={coursesResult}>
+          <SmokeCard
+            title="2. 공개 목록에서 보이는지 확인"
+            endpoint="GET /api/v1/courses?status=OPEN&page=0&size=20"
+            result={coursesResult}
+            verifies="방금 만든 OPEN 클래스가 사용자 공개 목록에 노출되는지 확인합니다."
+          >
             <label className="flex flex-col gap-75">
               <span className="font-designer-13b text-text-subtle">
-                선택 slug
+                테스트할 클래스 slug
               </span>
               <input
                 value={selectedSlug}
                 onChange={(event) => setSelectedSlug(event.target.value)}
                 className="rounded-150 border border-border-default bg-background-default px-150 py-100 font-designer-14r text-text-default"
-                placeholder="vibe-coding-intro"
+                placeholder="먼저 A-01 목록 또는 코스+레슨 생성을 실행하세요"
               />
             </label>
             <div className="flex flex-col gap-100">
@@ -300,13 +350,18 @@ export default function ClassDomainTestPage() {
             </div>
             {courses && (
               <p className="font-designer-13r text-text-subtlest">
-                page {courses.page} / total {courses.totalElements} / hasNext{' '}
-                {String(courses.hasNext)}
+                총 {courses.totalElements}개 OPEN 클래스 · 현재 page{' '}
+                {courses.page} · 다음 페이지 {courses.hasNext ? '있음' : '없음'}
               </p>
             )}
           </SmokeCard>
 
-          <SmokeCard title="A-02 GET /courses/{slug}" result={detailResult}>
+          <SmokeCard
+            title="3. 상세 화면 계약 확인"
+            endpoint="GET /api/v1/courses/{slug}"
+            result={detailResult}
+            verifies="선택한 slug의 상세 정보와 구매/무료등록 가능 여부가 사용자 API로 내려오는지 확인합니다."
+          >
             {detail ? (
               <div className="flex flex-col gap-100">
                 <h2 className="font-designer-22b text-text-default">
@@ -315,36 +370,45 @@ export default function ClassDomainTestPage() {
                 <p className="font-designer-14r text-text-subtle">
                   {detail.description}
                 </p>
-                <KeyValue label="viewerStatus" value={detail.viewerStatus} />
+                <ContractNote
+                  title="이 상세 조회가 성공하면"
+                  description="공개 slug로 접근했을 때 숨김 클래스가 아니고, 사용자에게 보여줄 가격/등록 상태 판단이 내려온다는 뜻입니다."
+                />
+                <KeyValue
+                  label="사용자 접근 상태"
+                  value={viewerStatusLabel[detail.viewerStatus]}
+                />
                 <KeyValue label="courseId" value={String(detail.courseId)} />
                 <KeyValue
-                  label="freeEnrollmentAvailable"
-                  value={String(detail.freeEnrollmentAvailable)}
+                  label="무료 등록"
+                  value={booleanLabel(detail.freeEnrollmentAvailable)}
                 />
                 <KeyValue
-                  label="purchaseAvailable"
-                  value={String(detail.purchaseAvailable)}
+                  label="구매"
+                  value={booleanLabel(detail.purchaseAvailable)}
                 />
                 <KeyValue
-                  label="plans"
-                  value={String(detail.plans?.length ?? 0)}
+                  label="가격 플랜 수"
+                  value={`${detail.plans?.length ?? 0}개`}
                 />
               </div>
             ) : (
-              <EmptyMessage text="상세 응답이 아직 없습니다." />
+              <EmptyMessage text="아직 상세를 조회하지 않았습니다. 먼저 slug를 선택하고 A-02 상세 버튼을 누르세요." />
             )}
           </SmokeCard>
 
           <SmokeCard
-            title="A-04 GET /courses/{slug}/curriculum"
+            title="4. 커리큘럼 잠금 정책 확인"
+            endpoint="GET /api/v1/courses/{slug}/curriculum"
             result={curriculumResult}
+            verifies="무료 레슨은 열려 있고 유료 레슨은 잠겨 있는지, 챕터/레슨 수가 맞는지 확인합니다."
           >
             {curriculum ? (
               <div className="flex flex-col gap-150">
                 <div className="grid grid-cols-3 gap-100">
-                  <Metric label="chapters" value={curriculum.totalChapters} />
-                  <Metric label="lessons" value={curriculum.totalLessons} />
-                  <Metric label="days" value={curriculum.durationDays} />
+                  <Metric label="챕터 수" value={curriculum.totalChapters} />
+                  <Metric label="레슨 수" value={curriculum.totalLessons} />
+                  <Metric label="진행 일수" value={curriculum.durationDays} />
                 </div>
                 <div className="flex flex-col gap-100">
                   {curriculum.chapters.map((chapter) => (
@@ -356,8 +420,8 @@ export default function ClassDomainTestPage() {
                         CH {chapter.chapterNumber}. {chapter.title}
                       </h3>
                       <p className="font-designer-13r text-text-subtlest">
-                        {chapter.lessons.length} lessons ·{' '}
-                        {chapter.estimatedMinutes} min
+                        {chapter.lessons.length}개 레슨 · 예상{' '}
+                        {chapter.estimatedMinutes}분
                       </p>
                       <ul className="mt-100 flex flex-col gap-75">
                         {chapter.lessons.map((lesson) => (
@@ -368,7 +432,7 @@ export default function ClassDomainTestPage() {
                             <span>
                               L{lesson.order}. {lesson.title}
                             </span>
-                            <span>{lesson.locked ? 'LOCKED' : 'OPEN'}</span>
+                            <span>{lesson.locked ? '잠김' : '무료 공개'}</span>
                           </li>
                         ))}
                       </ul>
@@ -377,12 +441,45 @@ export default function ClassDomainTestPage() {
                 </div>
               </div>
             ) : (
-              <EmptyMessage text="커리큘럼 응답이 아직 없습니다." />
+              <EmptyMessage text="아직 커리큘럼을 조회하지 않았습니다. A-04 커리큘럼 버튼을 누르세요." />
             )}
           </SmokeCard>
         </section>
       </section>
     </main>
+  );
+}
+
+function GuideStep({
+  description,
+  step,
+  title,
+}: {
+  description: string;
+  step: string;
+  title: string;
+}) {
+  return (
+    <div className="rounded-150 bg-background-alternative p-150">
+      <p className="font-designer-12b text-text-brand">STEP {step}</p>
+      <h2 className="font-designer-15b mt-50 text-text-default">{title}</h2>
+      <p className="font-designer-13r mt-50 text-text-subtle">{description}</p>
+    </div>
+  );
+}
+
+function ContractNote({
+  description,
+  title,
+}: {
+  description: string;
+  title: string;
+}) {
+  return (
+    <div className="rounded-150 bg-background-accent-green-subtle p-150">
+      <p className="font-designer-13b text-text-success">{title}</p>
+      <p className="font-designer-13r mt-50 text-text-subtle">{description}</p>
+    </div>
   );
 }
 
@@ -409,19 +506,35 @@ function SmokeButton({
 
 function SmokeCard({
   children,
+  endpoint,
   result,
   title,
+  verifies,
 }: {
   children: React.ReactNode;
+  endpoint?: string;
   result: SmokeResult;
   title: string;
+  verifies?: string;
 }) {
   return (
     <article className="rounded-250 border border-border-default bg-background-default p-250 shadow-1">
-      <div className="mb-200 flex items-center justify-between gap-150">
-        <h2 className="font-designer-18b text-text-default">{title}</h2>
+      <div className="mb-150 flex items-start justify-between gap-150">
+        <div className="flex flex-col gap-50">
+          <h2 className="font-designer-18b text-text-default">{title}</h2>
+          {endpoint && (
+            <code className="font-designer-12r break-all text-text-subtlest">
+              {endpoint}
+            </code>
+          )}
+        </div>
         <StatusBadge state={result.state} />
       </div>
+      {verifies && (
+        <p className="font-designer-13r mb-150 text-text-subtle">
+          확인 내용: {verifies}
+        </p>
+      )}
       {result.error && (
         <div className="mb-150 rounded-150 border border-border-error bg-background-accent-red-subtle p-150">
           <p className="font-designer-13b text-text-error">
@@ -439,7 +552,7 @@ function StatusBadge({ state }: { state: SmokeState }) {
   return (
     <span
       className={cn(
-        'rounded-500 px-125 py-50 font-designer-12b',
+        'rounded-500 px-125 py-50 font-designer-12b shrink-0 whitespace-nowrap',
         state === 'success' &&
           'bg-background-accent-green-subtle text-text-success',
         state === 'error' && 'bg-background-accent-red-subtle text-text-error',
@@ -448,7 +561,10 @@ function StatusBadge({ state }: { state: SmokeState }) {
         state === 'idle' && 'bg-background-alternative text-text-subtle',
       )}
     >
-      {state.toUpperCase()}
+      {state === 'idle' && '대기'}
+      {state === 'loading' && '요청 중'}
+      {state === 'success' && '성공'}
+      {state === 'error' && '실패'}
     </span>
   );
 }


### PR DESCRIPTION
## 작업 내용
- `/class-test` 경로에 클래스 API smoke 페이지를 추가했습니다.
- 초보자용 자동 테스트 흐름을 추가했습니다.
  - `1번: 자동 테스트 시작` 버튼 하나로 관리자 로그인 → 클래스/레슨 생성 → 공개 목록 조회 → 상세/커리큘럼 조회를 순서대로 실행합니다.
  - 각 단계가 `대기/요청 중/성공/실패`로 표시됩니다.
- 세부 결과 영역에서는 자동 테스트가 실제로 확인한 API 응답을 사람이 읽는 문구로 보여줍니다.
- 수동 버튼은 자동 테스트 실패 시 원인 분리용으로만 보이게 정리했습니다.

## 변경 이유
- backend 클래스 도메인 PR stack(#967~#969)을 브라우저에서 직접 생성→조회 흐름으로 검증하기 위한 최소 프론트 harness가 필요했습니다.
- 기존 화면은 `SUCCESS`, `viewerStatus`, `plans` 같은 raw field 중심이라 초보자가 “뭘 눌러야 하는지 / 성공 의미가 뭔지” 이해하기 어려웠습니다.

## 로컬 실행 조건
- backend repo에서 #969 포함 stack branch(`feat/class-admin-content-api-11`)를 `dev.local`로 띄우면 이 페이지의 운영자 생성 smoke가 동작합니다.
- frontend는 `/class-test`에서 로컬 backend API를 호출합니다.

## 검증 방법
- [x] `yarn eslint src/features/class-domain-test/ui/class-domain-test-page.tsx --fix`
- [x] `yarn tsc --noEmit`
- [x] `curl http://localhost:3000/class-test` → 200, `1번: 자동 테스트 시작` 렌더 확인
- [x] Playwright: `/class-test` 접속 → `1번: 자동 테스트 시작` 클릭 → `테스트 완료` 표시 확인

## 브랜치 정보
- base: develop
- head: class-test
- 기준 range: origin/develop..HEAD

## Backend 의존성
- 로컬 검증 시 backend branch: `feat/class-admin-content-api-11`
- backend stack PR:
  - #967 `feat/class-admin-schema-9`
  - #968 `feat/class-public-curriculum-api-10`
  - #969 `feat/class-admin-content-api-11`

## 남은 리스크
- 이 페이지는 production 사용자 flow가 아니라 로컬/검증용 smoke harness입니다.
- `/growth/test/login` 기반이므로 운영자 인증 방식은 실제 운영자 UI 구현 시 정식 auth flow로 교체해야 합니다.
- accessToken은 화면에 렌더하지 않고 React state에만 보관합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
- 클래스 기능 테스트 페이지 추가
- 공개 과정 목록 및 상세 정보 조회 기능 구현
- 관리자 테스트 멤버 로그인 및 샘플 과정 생성 기능 추가
- E2E 테스트 시나리오 실행 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->