### PR TITLE
fix: 클래스 관리자 코스 운영 안정화

### DIFF
--- a/src/app/(admin)/admin/courses/lessons/[lessonId]/page.tsx
+++ b/src/app/(admin)/admin/courses/lessons/[lessonId]/page.tsx
@@ -1,0 +1,10 @@
+import AdminLessonDetailPageClient from '@/components/admin/courses/admin-lesson-detail-page-client';
+
+export default async function AdminLessonDetailPage({
+  params,
+}: {
+  params: Promise<{ lessonId: string }>;
+}) {
+  const { lessonId } = await params;
+  return <AdminLessonDetailPageClient lessonId={Number(lessonId)} />;
+}

--- a/src/app/(admin)/admin/courses/page.tsx
+++ b/src/app/(admin)/admin/courses/page.tsx
@@ -1,0 +1,5 @@
+import AdminCourseManagementPageClient from '@/components/admin/courses/admin-course-management-page-client';
+
+export default function AdminCoursesPage() {
+  return <AdminCourseManagementPageClient />;
+}

--- a/src/components/admin/courses/admin-course-field.tsx
+++ b/src/components/admin/courses/admin-course-field.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+interface AdminCourseFieldProps {
+  label: string;
+  children: ReactNode;
+  helper?: string;
+}
+
+export default function AdminCourseField({
+  label,
+  children,
+  helper,
+}: AdminCourseFieldProps) {
+  return (
+    <div className="flex flex-col gap-75">
+      <span className="font-designer-13m text-text-subtle">{label}</span>
+      {children}
+      {helper ? (
+        <span className="font-designer-12r text-text-subtlest">{helper}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/admin/courses/admin-course-form-sections.tsx
+++ b/src/components/admin/courses/admin-course-form-sections.tsx
@@ -1,0 +1,340 @@
+import type { ChangeEvent } from 'react';
+import AdminCourseField from '@/components/admin/courses/admin-course-field';
+import AdminCourseThumbnailField from '@/components/admin/courses/admin-course-thumbnail-field';
+import Button from '@/components/common/ui/button';
+import { BaseInput, NativeSelect } from '@/components/common/ui/input';
+import BorderedTextarea from '@/components/common/ui/input/bordered-textarea';
+import type {
+  AdminCourseFormValues,
+  AdminCourseStatus,
+} from '@/features/admin/course-management/model/admin-course-management-contract';
+
+interface AdminCourseFormContentProps {
+  courseForm: AdminCourseFormValues;
+  courseFormMode: 'create' | 'edit';
+  courseThumbnailFileName?: string;
+  courseThumbnailHasFile: boolean;
+  courseThumbnailPreviewUrl?: string;
+  courseThumbnailStatusText: string;
+  handleChangeCourseThumbnail: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleClearCourseThumbnailSelection: () => void;
+  handleQuickCourseStatusChange: (status: AdminCourseStatus) => void;
+  handleSubmitCourse: () => void;
+  isCourseFormLocked: boolean;
+  isQuickCourseStatusChangeEnabled: boolean;
+  isUploadingCourseThumbnail: boolean;
+  resetCourseForm: () => void;
+  selectedCourseStatus?: AdminCourseStatus;
+  statusOptions: Array<{ value: AdminCourseStatus; label: string }>;
+  thumbnailAccept: string;
+  updateCourseFormField: <K extends keyof AdminCourseFormValues>(
+    key: K,
+    value: AdminCourseFormValues[K],
+  ) => void;
+  toDateTimeLocal: (value?: string) => string;
+  toKstOffsetDateTime: (value: string) => string | undefined;
+  updateCoursePending: boolean;
+}
+
+export function AdminCourseFormContent({
+  courseForm,
+  courseFormMode,
+  courseThumbnailFileName,
+  courseThumbnailHasFile,
+  courseThumbnailPreviewUrl,
+  courseThumbnailStatusText,
+  handleChangeCourseThumbnail,
+  handleClearCourseThumbnailSelection,
+  handleQuickCourseStatusChange,
+  handleSubmitCourse,
+  isCourseFormLocked,
+  isQuickCourseStatusChangeEnabled,
+  isUploadingCourseThumbnail,
+  resetCourseForm,
+  selectedCourseStatus,
+  statusOptions,
+  thumbnailAccept,
+  toDateTimeLocal,
+  toKstOffsetDateTime,
+  updateCourseFormField,
+  updateCoursePending,
+}: AdminCourseFormContentProps) {
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-150">
+        <AdminCourseField
+          label="Slug"
+          helper="소문자, 숫자, 하이픈만 허용됩니다. 운영용 식별자이며 코스 찾기는 목록 선택으로 진행합니다."
+        >
+          <BaseInput
+            size="m"
+            disabled={isCourseFormLocked}
+            value={courseForm.slug}
+            placeholder="class-v0-6"
+            onValueChange={(slug) => updateCourseFormField('slug', slug)}
+          />
+        </AdminCourseField>
+        <AdminCourseField label="상태">
+          <NativeSelect
+            disabled={isCourseFormLocked}
+            value={courseForm.status}
+            onChange={(event) =>
+              updateCourseFormField(
+                'status',
+                event.target.value as AdminCourseStatus,
+              )
+            }
+          >
+            {statusOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </NativeSelect>
+        </AdminCourseField>
+        <AdminCourseField label="제목">
+          <BaseInput
+            size="m"
+            disabled={isCourseFormLocked}
+            value={courseForm.title}
+            placeholder="제로원 클래스"
+            onValueChange={(title) => updateCourseFormField('title', title)}
+          />
+        </AdminCourseField>
+        <AdminCourseField
+          label="카드 헤드라인"
+          helper="코스 카드 상단에 짧게 노출할 한 줄 메시지입니다."
+        >
+          <BaseInput
+            size="m"
+            disabled={isCourseFormLocked}
+            value={courseForm.cardHeadline}
+            placeholder="퇴근 후 바로 만드는 바이브 코딩"
+            onValueChange={(cardHeadline) =>
+              updateCourseFormField('cardHeadline', cardHeadline)
+            }
+          />
+        </AdminCourseField>
+        <AdminCourseField
+          label="카드 요약"
+          helper="코스 카드 본문에 노출할 1~2줄 요약입니다."
+        >
+          <BaseInput
+            size="m"
+            disabled={isCourseFormLocked}
+            value={courseForm.cardSummary}
+            placeholder="5일 동안 MVP를 완성하는 실전형 클래스"
+            onValueChange={(cardSummary) =>
+              updateCourseFormField('cardSummary', cardSummary)
+            }
+          />
+        </AdminCourseField>
+        <AdminCourseField
+          label="정가"
+          helper="정가와 현재 할인가를 각각 입력합니다."
+        >
+          <BaseInput
+            size="m"
+            type="number"
+            min={0}
+            disabled={isCourseFormLocked}
+            value={courseForm.regularPrice}
+            placeholder="59900"
+            onValueChange={(regularPrice) =>
+              updateCourseFormField('regularPrice', regularPrice)
+            }
+          />
+        </AdminCourseField>
+        <AdminCourseField label="할인가">
+          <BaseInput
+            size="m"
+            type="number"
+            min={0}
+            disabled={isCourseFormLocked}
+            value={courseForm.discountPrice}
+            placeholder="39900"
+            onValueChange={(discountPrice) =>
+              updateCourseFormField('discountPrice', discountPrice)
+            }
+          />
+        </AdminCourseField>
+        <AdminCourseField label="기간(일)" helper="durationDays로 저장됩니다.">
+          <BaseInput
+            size="m"
+            type="number"
+            min={1}
+            disabled={isCourseFormLocked}
+            value={courseForm.durationDays}
+            placeholder="5"
+            onValueChange={(durationDays) =>
+              updateCourseFormField('durationDays', durationDays)
+            }
+          />
+        </AdminCourseField>
+      </div>
+      <div className="mt-150 flex flex-col gap-150">
+        <AdminCourseField
+          label="빠른 상태 변경"
+          helper={
+            courseFormMode === 'edit'
+              ? '비공개(HIDDEN)로 바꾼 뒤에도 다시 오픈 예정/공개로 변경할 수 있습니다.'
+              : '기존 코스를 수정 중일 때만 사용할 수 있습니다.'
+          }
+        >
+          <div className="flex flex-wrap gap-75">
+            {statusOptions.map((option) => (
+              <Button
+                key={option.value}
+                color={
+                  selectedCourseStatus === option.value
+                    ? 'secondary'
+                    : 'outlined'
+                }
+                size="xsmall"
+                disabled={
+                  !isQuickCourseStatusChangeEnabled || isCourseFormLocked
+                }
+                loading={
+                  updateCoursePending && selectedCourseStatus !== option.value
+                }
+                onClick={() => handleQuickCourseStatusChange(option.value)}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+        </AdminCourseField>
+        <AdminCourseField
+          label="썸네일 이미지"
+          helper="코스 목록 카드에 노출되는 대표 이미지입니다. URL 직접 입력 대신 이미지 파일을 첨부하면 저장 시 자동 업로드됩니다."
+        >
+          <AdminCourseThumbnailField
+            accept={thumbnailAccept}
+            canClear={courseThumbnailHasFile}
+            fileName={courseThumbnailFileName}
+            isUploading={isCourseFormLocked}
+            previewUrl={courseThumbnailPreviewUrl}
+            statusText={courseThumbnailStatusText}
+            onChange={handleChangeCourseThumbnail}
+            onClear={handleClearCourseThumbnailSelection}
+          />
+        </AdminCourseField>
+        <AdminCourseField label="얼리버드 종료 시각(KST)">
+          <BaseInput
+            size="m"
+            type="datetime-local"
+            disabled={isCourseFormLocked}
+            value={toDateTimeLocal(courseForm.earlyBirdEndsAt)}
+            onValueChange={(value) =>
+              updateCourseFormField(
+                'earlyBirdEndsAt',
+                toKstOffsetDateTime(value) ?? null,
+              )
+            }
+          />
+        </AdminCourseField>
+        <AdminCourseField
+          label="카드 태그"
+          helper="쉼표 또는 줄바꿈으로 여러 태그를 구분합니다. 카드 인원/학습/추천/탐색 카운트는 서버 계산값이라 여기서 입력하지 않습니다."
+        >
+          <BorderedTextarea
+            disabled={isCourseFormLocked}
+            value={courseForm.cardTags}
+            placeholder="혜택, Claude Pro 1개월 Gift"
+            onChange={(event) =>
+              updateCourseFormField('cardTags', event.target.value)
+            }
+          />
+        </AdminCourseField>
+        <AdminCourseField label="설명">
+          <BorderedTextarea
+            disabled={isCourseFormLocked}
+            value={courseForm.description}
+            placeholder="공개 상세 화면에 노출될 클래스 소개를 입력하세요."
+            onChange={(event) =>
+              updateCourseFormField('description', event.target.value)
+            }
+          />
+        </AdminCourseField>
+      </div>
+      <div className="mt-150 flex justify-end gap-75">
+        <Button
+          color="outlined"
+          size="small"
+          disabled={isCourseFormLocked}
+          onClick={resetCourseForm}
+        >
+          초기화
+        </Button>
+        <Button
+          size="small"
+          disabled={isCourseFormLocked}
+          loading={isCourseFormLocked}
+          onClick={handleSubmitCourse}
+        >
+          {isUploadingCourseThumbnail
+            ? '썸네일 업로드 중...'
+            : courseFormMode === 'create'
+              ? '코스 생성'
+              : '코스 저장'}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+interface AdminCourseCompletionMessageContentProps {
+  completionMessage: string;
+  completionMessageHydrating: boolean;
+  completionMessageUpdatedAt?: string;
+  effectiveCourseId?: number;
+  formatDateTime: (value?: string) => string;
+  onChangeCompletionMessage: (value: string) => void;
+  onSaveCompletionMessage: () => void;
+  upsertCompletionMessagePending: boolean;
+}
+
+export function AdminCourseCompletionMessageContent({
+  completionMessage,
+  completionMessageHydrating,
+  completionMessageUpdatedAt,
+  effectiveCourseId,
+  formatDateTime,
+  onChangeCompletionMessage,
+  onSaveCompletionMessage,
+  upsertCompletionMessagePending,
+}: AdminCourseCompletionMessageContentProps) {
+  return (
+    <>
+      <BorderedTextarea
+        disabled={
+          !effectiveCourseId ||
+          completionMessageHydrating ||
+          upsertCompletionMessagePending
+        }
+        value={completionMessage}
+        placeholder="완주를 축하합니다! 다음 단계로 이어갈 수 있도록 안내 메시지를 입력하세요."
+        onChange={(event) => onChangeCompletionMessage(event.target.value)}
+      />
+      <div className="mt-150 flex items-center justify-between gap-100">
+        <span className="font-designer-13r text-text-subtlest">
+          {completionMessageHydrating
+            ? '완주 메시지를 불러오는 중입니다.'
+            : `마지막 저장: ${formatDateTime(completionMessageUpdatedAt)}`}
+        </span>
+        <Button
+          size="small"
+          disabled={
+            !effectiveCourseId ||
+            completionMessageHydrating ||
+            upsertCompletionMessagePending
+          }
+          loading={upsertCompletionMessagePending}
+          onClick={onSaveCompletionMessage}
+        >
+          메시지 저장
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/src/components/admin/courses/admin-course-management-page-client.tsx
+++ b/src/components/admin/courses/admin-course-management-page-client.tsx
@@ -1,0 +1,1535 @@
+'use client';
+import {
+  type ChangeEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  AdminCourseCompletionMessageContent,
+  AdminCourseFormContent,
+} from '@/components/admin/courses/admin-course-form-sections';
+import {
+  AdminCourseListContent,
+  AdminCourseOverviewContent,
+} from '@/components/admin/courses/admin-course-overview-sections';
+import {
+  AdminLessonBuilderFeedContent,
+  AdminLessonManagementContent,
+  AdminLessonQnaContent,
+  AdminLessonRetrospectivesContent,
+} from '@/components/admin/courses/admin-lesson-management-sections';
+import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import Badge from '@/components/common/ui/badge';
+import Button from '@/components/common/ui/button';
+import { uploadAdminCourseImage } from '@/features/admin/course-management/model/admin-course-image-upload';
+import type {
+  AdminBuilderFeedCurationRequest,
+  AdminCourseFormValues,
+  AdminCourseStatus,
+  AdminCourseSummary,
+  AdminLessonBulkUpdateRequest,
+  AdminLessonSummary,
+  AdminLessonUpsertRequest,
+} from '@/features/admin/course-management/model/admin-course-management-contract';
+import {
+  useAdminAutoCourseSelection,
+  useAdminBuilderFeedDraftSync,
+  useAdminCompletionMessageSync,
+  useAdminLessonContextResetSync,
+  useAdminLessonHydrationSync,
+  useAdminPendingCourseSelectionSync,
+  useAdminQnaSelectionSync,
+  useAdminStatusFilterResetSync,
+} from '@/features/admin/course-management/model/admin-course-management-effects';
+import { getAdminCourseManagementLocks } from '@/features/admin/course-management/model/admin-course-management-locks';
+import {
+  ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS,
+  ADMIN_COURSE_MARKDOWN_MAX_IMAGE_FILE_SIZE,
+  normalizeAdminCourseMarkdownContent,
+} from '@/features/admin/course-management/model/admin-course-markdown';
+import {
+  getAdminLessonPayloadValidationError,
+  toAdminCoursePayload,
+  toAdminCourseUpdateRequest,
+  toAdminLessonPayload,
+  useAdminCompletionMessageQuery,
+  useAdminCourseLessonsQuery,
+  useAdminCoursesQuery,
+  useBulkUpdateAdminLessonsMutation,
+  useAdminLessonDetailQuery,
+  useAdminLessonBuilderFeedsQuery,
+  useAdminLessonQnaDetailQuery,
+  useAdminLessonQnasQuery,
+  useAdminLessonRetrospectivesQuery,
+  useCreateAdminLessonQnaAnswerMutation,
+  useUpdateAdminBuilderFeedCurationMutation,
+  useCreateAdminCourseMutation,
+  useCreateAdminLessonMutation,
+  useDeleteAdminCourseMutation,
+  useDeleteAdminLessonMutation,
+  useReorderAdminLessonsMutation,
+  useUpdateAdminCourseMutation,
+  useUpdateAdminLessonMutation,
+  useUpsertAdminCompletionMessageMutation,
+} from '@/features/admin/course-management/model/use-admin-course-management-query';
+import { useToastStore } from '@/stores/use-toast-store';
+
+const COURSE_STATUS_OPTIONS: Array<{
+  value: AdminCourseStatus;
+  label: string;
+  color: 'green' | 'orange' | 'gray';
+}> = [
+  { value: 'OPEN', label: '공개', color: 'green' },
+  { value: 'COMING_SOON', label: '오픈 예정', color: 'orange' },
+  { value: 'HIDDEN', label: '비공개', color: 'gray' },
+];
+
+const COURSE_THUMBNAIL_INPUT_ACCEPT =
+  ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS.map(
+    (extension) => `.${extension}`,
+  ).join(',');
+
+const emptyCourseForm: AdminCourseFormValues = {
+  slug: '',
+  title: '',
+  cardHeadline: '',
+  cardSummary: '',
+  cardTags: '',
+  regularPrice: '',
+  discountPrice: '',
+  description: '',
+  thumbnailUrl: '',
+  status: 'COMING_SOON',
+  durationDays: '',
+  earlyBirdEndsAt: null,
+};
+
+const emptyLessonForm: AdminLessonUpsertRequest = {
+  chapterNumber: 1,
+  lessonNumber: 1,
+  title: '',
+  content: '',
+  estimatedMinutes: 30,
+  retrospectivePurpose: 'PRACTICE_PROOF',
+  isFree: false,
+  isPublished: false,
+};
+
+const getStatusMeta = (status: AdminCourseStatus) =>
+  COURSE_STATUS_OPTIONS.find((option) => option.value === status) ??
+  COURSE_STATUS_OPTIONS[2];
+
+const formatDateTime = (value?: string) => {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+};
+
+const toDateTimeLocal = (value?: string) => {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hour = String(date.getHours()).padStart(2, '0');
+  const minute = String(date.getMinutes()).padStart(2, '0');
+
+  return `${year}-${month}-${day}T${hour}:${minute}`;
+};
+
+const toKstOffsetDateTime = (value: string) => {
+  if (!value) return undefined;
+
+  return `${value}:00+09:00`;
+};
+
+const Section = ({
+  title,
+  description,
+  children,
+  className,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+  className?: string;
+}) => (
+  <section
+    className={cn(
+      'border-border-default bg-background-default rounded-150 border p-200',
+      className,
+    )}
+  >
+    <div className="mb-150">
+      <h2 className="font-designer-20b text-text-default">{title}</h2>
+      {description && (
+        <p className="font-designer-14r text-text-subtle mt-50">
+          {description}
+        </p>
+      )}
+    </div>
+    {children}
+  </section>
+);
+
+const CourseStatusBadge = ({ status }: { status: AdminCourseStatus }) => {
+  const meta = getStatusMeta(status);
+
+  return (
+    <Badge color={meta.color} shape="rectangle">
+      {meta.label}
+    </Badge>
+  );
+};
+
+export default function AdminCourseManagementPageClient() {
+  const [statusFilter, setStatusFilter] = useState<AdminCourseStatus | ''>('');
+  const [page, setPage] = useState(1);
+  const [courseSearch, setCourseSearch] = useState('');
+  const [lessonSearch, setLessonSearch] = useState('');
+  const [lessonPublishedFilter, setLessonPublishedFilter] = useState<
+    'ALL' | 'PUBLISHED' | 'UNPUBLISHED'
+  >('ALL');
+  const [lessonAccessFilter, setLessonAccessFilter] = useState<
+    'ALL' | 'FREE' | 'PAID'
+  >('ALL');
+  const [selectedCourseId, setSelectedCourseId] = useState<
+    number | undefined
+  >();
+  const [pendingSelectedCourseId, setPendingSelectedCourseId] = useState<
+    number | undefined
+  >();
+  const [selectedLessonIds, setSelectedLessonIds] = useState<number[]>([]);
+  const [courseFormMode, setCourseFormMode] = useState<'create' | 'edit'>(
+    'create',
+  );
+  const [editingCourseId, setEditingCourseId] = useState<number | undefined>();
+  const [courseForm, setCourseForm] =
+    useState<AdminCourseFormValues>(emptyCourseForm);
+  const [courseFormTouchedFields, setCourseFormTouchedFields] = useState<
+    Partial<Record<keyof AdminCourseFormValues, boolean>>
+  >({});
+  const [courseThumbnailFile, setCourseThumbnailFile] = useState<File | null>(
+    null,
+  );
+  const [courseThumbnailPreviewUrl, setCourseThumbnailPreviewUrl] = useState<
+    string | null
+  >(null);
+  const [isUploadingCourseThumbnail, setIsUploadingCourseThumbnail] =
+    useState(false);
+  const [lessonFormMode, setLessonFormMode] = useState<'create' | 'edit'>(
+    'create',
+  );
+  const [editingLessonId, setEditingLessonId] = useState<number | undefined>();
+  const [selectedQnaId, setSelectedQnaId] = useState<number | undefined>();
+  const [qnaAnswerContent, setQnaAnswerContent] = useState('');
+  const [builderFeedOrderDrafts, setBuilderFeedOrderDrafts] = useState<
+    Record<number, string>
+  >({});
+  const builderFeedOrderSourceValuesRef = useRef<Record<number, string>>({});
+  const [isAwaitingBuilderFeedRefresh, setIsAwaitingBuilderFeedRefresh] =
+    useState(false);
+  const [lessonForm, setLessonForm] =
+    useState<AdminLessonUpsertRequest>(emptyLessonForm);
+  const [lessonEditorResetVersion, setLessonEditorResetVersion] = useState(0);
+  const [hydratedLessonId, setHydratedLessonId] = useState<number | undefined>(
+    undefined,
+  );
+  const [hydratedLessonSnapshot, setHydratedLessonSnapshot] = useState('');
+  const [completionMessage, setCompletionMessage] = useState('');
+  const [
+    hydratedCompletionMessageCourseId,
+    setHydratedCompletionMessageCourseId,
+  ] = useState<number | undefined>(undefined);
+  const currentEffectiveCourseIdRef = useRef<number | undefined>(undefined);
+  const preserveCourseSelectionOnFilterResetRef = useRef(false);
+  const suppressNextAutoCourseSelectionRef = useRef(false);
+  const completionMessageSourceRef = useRef<{
+    courseId?: number;
+    message: string;
+  }>({
+    message: '',
+  });
+  const currentCompletionMessageRef = useRef('');
+  const currentSelectedQnaIdRef = useRef<number | undefined>(undefined);
+  const currentQnaAnswerContentRef = useRef('');
+  const showInfoToast = useCallback((message: string) => {
+    useToastStore.getState().showToast(message, 'info');
+  }, []);
+
+  const courseParams = useMemo(
+    () => ({
+      status: statusFilter || undefined,
+      page: page - 1,
+      size: 20,
+    }),
+    [page, statusFilter],
+  );
+
+  const coursesQuery = useAdminCoursesQuery(courseParams);
+  const visibleCourses = useMemo(
+    () => coursesQuery.data?.content ?? [],
+    [coursesQuery.data?.content],
+  );
+
+  const filteredCourses = useMemo(() => {
+    const keyword = courseSearch.trim().toLowerCase();
+    const courses = visibleCourses;
+    if (!keyword) return courses;
+
+    return courses.filter((course) =>
+      [course.title, course.slug].some((value) =>
+        value.toLowerCase().includes(keyword),
+      ),
+    );
+  }, [courseSearch, visibleCourses]);
+
+  const selectedCourse = visibleCourses.find(
+    (course) => course.courseId === selectedCourseId,
+  );
+  const effectiveCourseId = selectedCourse?.courseId ?? selectedCourseId;
+  const totalCoursePages = Math.max(coursesQuery.data?.totalPages ?? 1, 1);
+  const isSelectedCourseHiddenBySearch =
+    Boolean(courseSearch.trim()) &&
+    Boolean(selectedCourse) &&
+    !filteredCourses.some(
+      (course) => course.courseId === selectedCourse.courseId,
+    );
+
+  const lessonsQuery = useAdminCourseLessonsQuery(effectiveCourseId);
+  const filteredLessons = useMemo(() => {
+    const keyword = lessonSearch.trim().toLowerCase();
+    const lessons = lessonsQuery.data ?? [];
+
+    return lessons.filter((lesson) => {
+      const matchKeyword =
+        !keyword ||
+        [lesson.title, `${lesson.chapterNumber}-${lesson.lessonNumber}`].some(
+          (value) => value.toLowerCase().includes(keyword),
+        );
+      const matchPublished =
+        lessonPublishedFilter === 'ALL' ||
+        (lessonPublishedFilter === 'PUBLISHED' && lesson.isPublished) ||
+        (lessonPublishedFilter === 'UNPUBLISHED' && !lesson.isPublished);
+      const matchAccess =
+        lessonAccessFilter === 'ALL' ||
+        (lessonAccessFilter === 'FREE' && lesson.isFree) ||
+        (lessonAccessFilter === 'PAID' && !lesson.isFree);
+
+      return matchKeyword && matchPublished && matchAccess;
+    });
+  }, [
+    lessonAccessFilter,
+    lessonPublishedFilter,
+    lessonSearch,
+    lessonsQuery.data,
+  ]);
+  const lessonDetailQuery = useAdminLessonDetailQuery(editingLessonId);
+  const lessonDetailSnapshot = lessonDetailQuery.data
+    ? JSON.stringify({
+        chapterNumber: lessonDetailQuery.data.chapterNumber,
+        lessonNumber: lessonDetailQuery.data.lessonNumber,
+        title: lessonDetailQuery.data.title,
+        content: normalizeAdminCourseMarkdownContent(
+          lessonDetailQuery.data.content,
+        ),
+        estimatedMinutes: lessonDetailQuery.data.estimatedMinutes,
+        retrospectivePurpose: lessonDetailQuery.data.retrospectivePurpose,
+        isFree: lessonDetailQuery.data.isFree,
+        isPublished: lessonDetailQuery.data.isPublished,
+      })
+    : '';
+  const lessonQnasQuery = useAdminLessonQnasQuery(editingLessonId);
+  const lessonRetrospectivesQuery =
+    useAdminLessonRetrospectivesQuery(editingLessonId);
+  const lessonBuilderFeedsQuery =
+    useAdminLessonBuilderFeedsQuery(editingLessonId);
+  const qnaDetailQuery = useAdminLessonQnaDetailQuery(selectedQnaId);
+  const completionMessageQuery =
+    useAdminCompletionMessageQuery(effectiveCourseId);
+
+  const createCourseMutation = useCreateAdminCourseMutation();
+  const updateCourseMutation = useUpdateAdminCourseMutation();
+  const deleteCourseMutation = useDeleteAdminCourseMutation();
+  const createLessonMutation = useCreateAdminLessonMutation();
+  const updateLessonMutation = useUpdateAdminLessonMutation();
+  const deleteLessonMutation = useDeleteAdminLessonMutation();
+  const bulkUpdateLessonsMutation = useBulkUpdateAdminLessonsMutation();
+  const reorderLessonsMutation = useReorderAdminLessonsMutation();
+  const createLessonQnaAnswerMutation = useCreateAdminLessonQnaAnswerMutation();
+  const updateBuilderFeedCurationMutation =
+    useUpdateAdminBuilderFeedCurationMutation();
+  const upsertCompletionMessageMutation =
+    useUpsertAdminCompletionMessageMutation();
+  useAdminPendingCourseSelectionSync({
+    coursesFetching: coursesQuery.isFetching,
+    pendingSelectedCourseId,
+    setPendingSelectedCourseId,
+    setSelectedCourseId,
+    showInfoToast,
+    suppressNextAutoCourseSelectionRef,
+    visibleCourseIds: visibleCourses.map((course) => course.courseId),
+  });
+
+  useAdminAutoCourseSelection({
+    coursesFetching: coursesQuery.isFetching,
+    pendingSelectedCourseId,
+    selectedCourseId,
+    setSelectedCourseId,
+    suppressNextAutoCourseSelectionRef,
+    visibleCourseIds: visibleCourses.map((course) => course.courseId),
+  });
+
+  useAdminStatusFilterResetSync({
+    preserveCourseSelectionOnFilterResetRef,
+    setPage,
+    setSelectedCourseId,
+    statusFilter,
+  });
+
+  useEffect(() => {
+    if (page <= totalCoursePages) {
+      return;
+    }
+
+    setPage(totalCoursePages);
+  }, [page, totalCoursePages]);
+
+  useAdminLessonContextResetSync({
+    effectiveCourseId,
+    setBuilderFeedOrderDrafts,
+    setEditingLessonId,
+    setHydratedLessonId,
+    setHydratedLessonSnapshot,
+    setLessonEditorResetVersion,
+    setLessonForm,
+    setLessonFormMode,
+    setQnaAnswerContent,
+    setSelectedLessonIds,
+    setSelectedQnaId,
+  });
+
+  useAdminCompletionMessageSync({
+    completionMessage,
+    completionMessageData: completionMessageQuery.data,
+    completionMessageSourceRef,
+    currentCompletionMessageRef,
+    currentEffectiveCourseIdRef,
+    effectiveCourseId,
+    hydratedCompletionMessageCourseId,
+    setCompletionMessage,
+    setHydratedCompletionMessageCourseId,
+  });
+
+  useAdminLessonHydrationSync({
+    hydratedLessonSnapshot,
+    lessonDetail: lessonDetailQuery.data
+      ? {
+          ...lessonDetailQuery.data,
+          content: lessonDetailQuery.data.content,
+        }
+      : undefined,
+    lessonDetailSnapshot,
+    lessonFormMode,
+    setHydratedLessonId,
+    setHydratedLessonSnapshot,
+    setLessonForm,
+  });
+
+  useAdminQnaSelectionSync({
+    currentQnaAnswerContentRef,
+    currentSelectedQnaIdRef,
+    qnaAnswerContent,
+    qnas: lessonQnasQuery.data?.qnas ?? [],
+    qnasFetching: lessonQnasQuery.isFetching,
+    selectedQnaId,
+    setQnaAnswerContent,
+    setSelectedQnaId,
+  });
+
+  useAdminBuilderFeedDraftSync({
+    builderFeedOrderSourceValuesRef,
+    editingLessonId,
+    feeds: lessonBuilderFeedsQuery.data?.feeds ?? [],
+    isAwaitingBuilderFeedRefresh,
+    lessonBuilderFeedsFetching: lessonBuilderFeedsQuery.isFetching,
+    setBuilderFeedOrderDrafts,
+    setIsAwaitingBuilderFeedRefresh,
+    updateBuilderFeedCurationPending:
+      updateBuilderFeedCurationMutation.isPending,
+  });
+
+  useEffect(() => {
+    setSelectedLessonIds((prev) =>
+      prev.filter((lessonId) =>
+        filteredLessons.some((lesson) => lesson.lessonId === lessonId),
+      ),
+    );
+  }, [filteredLessons]);
+
+  useEffect(() => {
+    if (
+      lessonFormMode !== 'create' ||
+      typeof editingLessonId === 'number' ||
+      lessonForm.title ||
+      lessonForm.content ||
+      lessonForm.chapterNumber !== emptyLessonForm.chapterNumber ||
+      lessonForm.lessonNumber !== emptyLessonForm.lessonNumber ||
+      lessonForm.estimatedMinutes !== emptyLessonForm.estimatedMinutes ||
+      lessonForm.retrospectivePurpose !==
+        emptyLessonForm.retrospectivePurpose ||
+      lessonForm.isFree !== emptyLessonForm.isFree ||
+      lessonForm.isPublished !== emptyLessonForm.isPublished
+    ) {
+      return;
+    }
+
+    const suggestedLessonNumber = (lessonsQuery.data?.length ?? 0) + 1;
+    if (lessonForm.lessonNumber === suggestedLessonNumber) {
+      return;
+    }
+
+    setLessonForm((prev) => ({
+      ...prev,
+      lessonNumber: suggestedLessonNumber,
+    }));
+  }, [editingLessonId, lessonForm, lessonFormMode, lessonsQuery.data]);
+
+  useEffect(() => {
+    if (!courseThumbnailFile) {
+      setCourseThumbnailPreviewUrl(null);
+      return;
+    }
+
+    const previewUrl = URL.createObjectURL(courseThumbnailFile);
+    setCourseThumbnailPreviewUrl(previewUrl);
+
+    return () => {
+      URL.revokeObjectURL(previewUrl);
+    };
+  }, [courseThumbnailFile]);
+
+  const updateCourseFormField = <FieldName extends keyof AdminCourseFormValues>(
+    field: FieldName,
+    value: AdminCourseFormValues[FieldName],
+  ) => {
+    setCourseForm((prev) => ({ ...prev, [field]: value }));
+    setCourseFormTouchedFields((prev) => ({ ...prev, [field]: true }));
+  };
+
+  const clearPendingCourseSelection = useCallback(() => {
+    setPendingSelectedCourseId(undefined);
+  }, []);
+
+  const revealCourseInAllStatusFilter = useCallback(
+    (courseId: number, nextStatus: AdminCourseStatus) => {
+      if (!statusFilter || statusFilter === nextStatus) {
+        return;
+      }
+
+      preserveCourseSelectionOnFilterResetRef.current = true;
+      setPendingSelectedCourseId(courseId);
+      setStatusFilter('');
+    },
+    [statusFilter],
+  );
+
+  const resetCourseForm = useCallback(
+    ({
+      preservePendingSelection = false,
+    }: {
+      preservePendingSelection?: boolean;
+    } = {}) => {
+      setCourseFormMode('create');
+      setEditingCourseId(undefined);
+      setCourseForm(emptyCourseForm);
+      setCourseFormTouchedFields({});
+      setCourseThumbnailFile(null);
+      setCourseThumbnailPreviewUrl(null);
+      if (!preservePendingSelection) {
+        clearPendingCourseSelection();
+      }
+    },
+    [clearPendingCourseSelection],
+  );
+  const isCourseFormLocked =
+    isUploadingCourseThumbnail ||
+    createCourseMutation.isPending ||
+    updateCourseMutation.isPending;
+
+  const handleSelectCourse = (courseId: number) => {
+    if (
+      isCourseFormLocked ||
+      createLessonMutation.isPending ||
+      updateLessonMutation.isPending ||
+      deleteLessonMutation.isPending ||
+      bulkUpdateLessonsMutation.isPending ||
+      reorderLessonsMutation.isPending ||
+      updateBuilderFeedCurationMutation.isPending ||
+      createLessonQnaAnswerMutation.isPending ||
+      upsertCompletionMessageMutation.isPending
+    ) {
+      return;
+    }
+
+    clearPendingCourseSelection();
+    setSelectedCourseId(courseId);
+  };
+
+  useEffect(() => {
+    if (
+      courseFormMode !== 'edit' ||
+      !editingCourseId ||
+      pendingSelectedCourseId
+    ) {
+      return;
+    }
+
+    if (editingCourseId === selectedCourseId) {
+      return;
+    }
+
+    resetCourseForm();
+  }, [
+    courseFormMode,
+    editingCourseId,
+    pendingSelectedCourseId,
+    resetCourseForm,
+    selectedCourseId,
+  ]);
+
+  const resetLessonForm = ({
+    nextLessonNumber = (lessonsQuery.data?.length ?? 0) + 1,
+  }: {
+    nextLessonNumber?: number;
+  } = {}) => {
+    setLessonFormMode('create');
+    setEditingLessonId(undefined);
+    setHydratedLessonId(undefined);
+    setHydratedLessonSnapshot('');
+    setSelectedQnaId(undefined);
+    setQnaAnswerContent('');
+    setLessonEditorResetVersion((prev) => prev + 1);
+    setLessonForm({
+      ...emptyLessonForm,
+      lessonNumber: nextLessonNumber,
+    });
+  };
+
+  const handleEditCourse = (course: AdminCourseSummary) => {
+    if (
+      isCourseFormLocked ||
+      createLessonMutation.isPending ||
+      updateLessonMutation.isPending ||
+      deleteLessonMutation.isPending ||
+      bulkUpdateLessonsMutation.isPending ||
+      reorderLessonsMutation.isPending ||
+      updateBuilderFeedCurationMutation.isPending ||
+      createLessonQnaAnswerMutation.isPending ||
+      upsertCompletionMessageMutation.isPending
+    ) {
+      return;
+    }
+
+    clearPendingCourseSelection();
+    setCourseFormMode('edit');
+    setEditingCourseId(course.courseId);
+    setSelectedCourseId(course.courseId);
+    setCourseFormTouchedFields({});
+    setCourseThumbnailFile(null);
+    setCourseThumbnailPreviewUrl(null);
+    setCourseForm({
+      ...emptyCourseForm,
+      slug: course.slug,
+      title: course.title,
+      status: course.status,
+    });
+  };
+
+  const handleChangeCourseThumbnail = (
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
+    const selectedFile = event.target.files?.[0];
+    event.target.value = '';
+
+    if (!selectedFile) {
+      return;
+    }
+
+    const fileExtension =
+      selectedFile.name.split('.').pop()?.toLowerCase() ?? '';
+    if (
+      !ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS.includes(
+        fileExtension as (typeof ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS)[number],
+      )
+    ) {
+      useToastStore
+        .getState()
+        .showToast(
+          'jpg, jpeg, png, webp, gif, heic, heif 형식만 업로드할 수 있습니다.',
+          'info',
+        );
+      return;
+    }
+
+    if (selectedFile.size > ADMIN_COURSE_MARKDOWN_MAX_IMAGE_FILE_SIZE) {
+      useToastStore
+        .getState()
+        .showToast('썸네일 이미지는 5MB 이하만 업로드할 수 있습니다.', 'info');
+      return;
+    }
+
+    setCourseThumbnailFile(selectedFile);
+    setCourseFormTouchedFields((prev) => ({ ...prev, thumbnailUrl: true }));
+  };
+
+  const handleClearCourseThumbnailSelection = () => {
+    setCourseThumbnailFile(null);
+    setCourseThumbnailPreviewUrl(null);
+    setCourseFormTouchedFields((prev) => {
+      if (!prev.thumbnailUrl) {
+        return prev;
+      }
+
+      const next = { ...prev };
+      delete next.thumbnailUrl;
+      return next;
+    });
+  };
+
+  const handleSubmitCourse = async () => {
+    if (isCourseFormLocked) {
+      return;
+    }
+
+    if (courseFormMode === 'create' && !courseThumbnailFile) {
+      useToastStore
+        .getState()
+        .showToast('코스 썸네일 이미지를 첨부해주세요.', 'info');
+      return;
+    }
+
+    let uploadedThumbnailUrl = courseForm.thumbnailUrl;
+
+    if (courseThumbnailFile) {
+      try {
+        setIsUploadingCourseThumbnail(true);
+        uploadedThumbnailUrl =
+          await uploadAdminCourseImage(courseThumbnailFile);
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : '코스 이미지를 업로드하지 못했습니다. 다시 시도해주세요.';
+        useToastStore.getState().showToast(message, 'error');
+        return;
+      } finally {
+        setIsUploadingCourseThumbnail(false);
+      }
+    }
+
+    const payload = toAdminCoursePayload({
+      ...courseForm,
+      thumbnailUrl: uploadedThumbnailUrl,
+    });
+
+    if (courseFormMode === 'create') {
+      try {
+        const response = await createCourseMutation.mutateAsync(payload);
+        setPendingSelectedCourseId(response.courseId);
+        setCourseSearch('');
+        setStatusFilter('');
+        setPage(1);
+        resetCourseForm({ preservePendingSelection: true });
+      } catch {
+        return;
+      }
+      return;
+    }
+
+    if (!editingCourseId) return;
+
+    const updateRequest = toAdminCourseUpdateRequest({
+      basePayload: {
+        ...payload,
+        thumbnailUrl: courseThumbnailFile
+          ? uploadedThumbnailUrl
+          : payload.thumbnailUrl,
+      },
+      touchedFields: courseFormTouchedFields,
+    });
+
+    if (Object.keys(updateRequest).length === 0) {
+      useToastStore.getState().showToast('수정한 항목이 없습니다.', 'info');
+      return;
+    }
+
+    try {
+      await updateCourseMutation.mutateAsync({
+        courseId: editingCourseId,
+        request: updateRequest,
+      });
+    } catch {
+      return;
+    }
+
+    if (courseFormTouchedFields.status) {
+      revealCourseInAllStatusFilter(editingCourseId, payload.status);
+    }
+
+    setCourseThumbnailFile(null);
+    setCourseThumbnailPreviewUrl(null);
+    setCourseForm((prev) => ({
+      ...prev,
+      thumbnailUrl: uploadedThumbnailUrl,
+    }));
+    setCourseFormTouchedFields({});
+  };
+
+  const handleDeleteCourse = (course: AdminCourseSummary) => {
+    if (deleteCourseMutation.isPending) return;
+
+    const confirmed = window.confirm(
+      `${course.title} 코스를 삭제할까요? 수강 이력이 있으면 실제 삭제되지 않고 비공개 처리됩니다.`,
+    );
+    if (!confirmed) return;
+
+    deleteCourseMutation.mutate(course.courseId, {
+      onSuccess: (response) => {
+        if (response.deleted) {
+          if (
+            selectedCourseId === course.courseId ||
+            editingCourseId === course.courseId
+          ) {
+            setSelectedCourseId(undefined);
+            resetCourseForm();
+            resetLessonForm();
+          }
+          return;
+        }
+
+        if (response.status === 'HIDDEN') {
+          preserveCourseSelectionOnFilterResetRef.current = true;
+          setPendingSelectedCourseId(course.courseId);
+
+          if (statusFilter && statusFilter !== 'HIDDEN') {
+            setStatusFilter('');
+          }
+        }
+
+        if (
+          courseFormMode === 'edit' &&
+          editingCourseId === course.courseId &&
+          response.status
+        ) {
+          setCourseForm((prev) => ({
+            ...prev,
+            status: response.status ?? prev.status,
+          }));
+        }
+      },
+    });
+  };
+
+  const handleEditLesson = (lesson: AdminLessonSummary) => {
+    if (
+      createLessonMutation.isPending ||
+      updateLessonMutation.isPending ||
+      updateBuilderFeedCurationMutation.isPending ||
+      createLessonQnaAnswerMutation.isPending ||
+      isAwaitingBuilderFeedRefresh ||
+      (lessonFormMode === 'edit' &&
+        typeof editingLessonId === 'number' &&
+        hydratedLessonId !== editingLessonId)
+    ) {
+      return;
+    }
+
+    setLessonFormMode('edit');
+    setEditingLessonId(lesson.lessonId);
+    setHydratedLessonId(undefined);
+    setHydratedLessonSnapshot('');
+    setSelectedQnaId(undefined);
+    setQnaAnswerContent('');
+    setLessonEditorResetVersion((prev) => prev + 1);
+    setLessonForm({
+      chapterNumber: lesson.chapterNumber,
+      lessonNumber: lesson.lessonNumber,
+      title: lesson.title,
+      content: '',
+      estimatedMinutes: 30,
+      retrospectivePurpose: lesson.retrospectivePurpose,
+      isFree: lesson.isFree,
+      isPublished: lesson.isPublished,
+    });
+  };
+
+  const handleSubmitLesson = () => {
+    if (
+      !effectiveCourseId ||
+      createLessonMutation.isPending ||
+      updateLessonMutation.isPending
+    ) {
+      return;
+    }
+    const payload = toAdminLessonPayload(lessonForm);
+    const validationError = getAdminLessonPayloadValidationError(payload);
+
+    if (validationError) {
+      useToastStore.getState().showToast(validationError, 'info');
+      return;
+    }
+
+    if (lessonFormMode === 'create') {
+      createLessonMutation.mutate(
+        { courseId: effectiveCourseId, request: payload },
+        {
+          onSuccess: () =>
+            resetLessonForm({
+              nextLessonNumber: (lessonsQuery.data?.length ?? 0) + 2,
+            }),
+        },
+      );
+      return;
+    }
+
+    if (!editingLessonId) return;
+    updateLessonMutation.mutate(
+      {
+        courseId: effectiveCourseId,
+        lessonId: editingLessonId,
+        request: {
+          chapterNumber: payload.chapterNumber || undefined,
+          lessonNumber: payload.lessonNumber || undefined,
+          title: payload.title,
+          content: payload.content,
+          estimatedMinutes: payload.estimatedMinutes || undefined,
+          retrospectivePurpose: payload.retrospectivePurpose,
+          isFree: payload.isFree,
+          isPublished: payload.isPublished,
+        },
+      },
+      { onSuccess: () => resetLessonForm() },
+    );
+  };
+
+  const {
+    isCompletionMessageHydrating,
+    isCourseSelectionLocked,
+    isLessonContextLocked,
+    isLessonDetailHydrating,
+    isLessonFormLocked,
+    isLessonListInteractionLocked,
+    isLessonMutationPending,
+    isQuickCourseStatusChangeEnabled,
+  } = getAdminCourseManagementLocks({
+    bulkUpdateLessonsPending: bulkUpdateLessonsMutation.isPending,
+    courseFormMode,
+    createCoursePending: createCourseMutation.isPending,
+    createLessonPending: createLessonMutation.isPending,
+    createLessonQnaAnswerPending: createLessonQnaAnswerMutation.isPending,
+    deleteLessonPending: deleteLessonMutation.isPending,
+    editingCourseId,
+    editingLessonId,
+    effectiveCourseId,
+    hasSelectedCourse: Boolean(selectedCourse),
+    hydratedCompletionMessageCourseId,
+    hydratedLessonId,
+    isAwaitingBuilderFeedRefresh,
+    isUploadingCourseThumbnail,
+    lessonFormMode,
+    reorderLessonsPending: reorderLessonsMutation.isPending,
+    selectedCourseId: selectedCourse?.courseId,
+    upsertCompletionMessagePending: upsertCompletionMessageMutation.isPending,
+    updateBuilderFeedCurationPending:
+      updateBuilderFeedCurationMutation.isPending,
+    updateCoursePending: updateCourseMutation.isPending,
+    updateLessonPending: updateLessonMutation.isPending,
+  });
+
+  const toFeaturedOrder = (
+    draftValue: string | undefined,
+    fallbackOrder: number,
+  ) => {
+    const parsedValue = Number.parseInt(draftValue ?? '', 10);
+    if (Number.isFinite(parsedValue) && parsedValue > 0) {
+      return parsedValue;
+    }
+
+    return fallbackOrder > 0 ? fallbackOrder : 1;
+  };
+
+  const handleDeleteLesson = (lesson: AdminLessonSummary) => {
+    if (!effectiveCourseId || isLessonListInteractionLocked) return;
+    const confirmed = window.confirm(
+      `${lesson.title} 레슨을 삭제할까요? 수강 이력이 있으면 실제 삭제되지 않고 비게시 처리됩니다.`,
+    );
+    if (!confirmed) return;
+
+    deleteLessonMutation.mutate(
+      {
+        courseId: effectiveCourseId,
+        lessonId: lesson.lessonId,
+      },
+      {
+        onSuccess: (response) => {
+          if (response.deleted) {
+            if (editingLessonId === lesson.lessonId) {
+              resetLessonForm();
+            }
+            return;
+          }
+
+          if (
+            lessonFormMode === 'edit' &&
+            editingLessonId === lesson.lessonId &&
+            typeof response.isPublished === 'boolean'
+          ) {
+            setLessonForm((prev) => ({
+              ...prev,
+              isPublished: response.isPublished,
+            }));
+          }
+        },
+      },
+    );
+  };
+
+  const handleQuickCourseStatusChange = (status: AdminCourseStatus) => {
+    if (!selectedCourse || updateCourseMutation.isPending) return;
+    updateCourseMutation.mutate(
+      {
+        courseId: selectedCourse.courseId,
+        request: { status },
+      },
+      {
+        onSuccess: () => {
+          revealCourseInAllStatusFilter(selectedCourse.courseId, status);
+
+          if (
+            courseFormMode === 'edit' &&
+            editingCourseId === selectedCourse.courseId
+          ) {
+            setCourseForm((prev) => ({ ...prev, status }));
+          }
+        },
+      },
+    );
+  };
+
+  const handleToggleLessonSelection = (lessonId: number) => {
+    if (isLessonListInteractionLocked) return;
+    setSelectedLessonIds((prev) =>
+      prev.includes(lessonId)
+        ? prev.filter((id) => id !== lessonId)
+        : [...prev, lessonId],
+    );
+  };
+
+  const handleToggleSelectAllLessons = () => {
+    if (isLessonListInteractionLocked) return;
+    if (filteredLessons.length === 0) return;
+    const filteredLessonIds = filteredLessons.map((lesson) => lesson.lessonId);
+    const allSelected = filteredLessonIds.every((lessonId) =>
+      selectedLessonIds.includes(lessonId),
+    );
+
+    setSelectedLessonIds((prev) =>
+      allSelected
+        ? prev.filter((lessonId) => !filteredLessonIds.includes(lessonId))
+        : Array.from(new Set([...prev, ...filteredLessonIds])),
+    );
+  };
+
+  const handleBulkLessonUpdate = (
+    request: Omit<AdminLessonBulkUpdateRequest, 'lessonIds'>,
+    confirmMessage: string,
+  ) => {
+    if (
+      !effectiveCourseId ||
+      selectedLessonIds.length === 0 ||
+      isLessonListInteractionLocked
+    ) {
+      return;
+    }
+    if (!window.confirm(confirmMessage)) return;
+
+    bulkUpdateLessonsMutation.mutate(
+      {
+        courseId: effectiveCourseId,
+        request: {
+          lessonIds: selectedLessonIds,
+          ...request,
+        },
+      },
+      {
+        onSuccess: () => {
+          setSelectedLessonIds([]);
+
+          if (
+            typeof editingLessonId === 'number' &&
+            selectedLessonIds.includes(editingLessonId)
+          ) {
+            setLessonForm((prev) => ({
+              ...prev,
+              isFree: request.isFree ?? prev.isFree,
+              isPublished: request.isPublished ?? prev.isPublished,
+            }));
+          }
+        },
+      },
+    );
+  };
+
+  const handleMoveLesson = (lessonId: number, direction: -1 | 1) => {
+    if (
+      !effectiveCourseId ||
+      !lessonsQuery.data ||
+      isLessonListInteractionLocked
+    ) {
+      return;
+    }
+    const currentIndex = lessonsQuery.data.findIndex(
+      (lesson) => lesson.lessonId === lessonId,
+    );
+    const nextIndex = currentIndex + direction;
+    if (
+      currentIndex < 0 ||
+      nextIndex < 0 ||
+      nextIndex >= lessonsQuery.data.length
+    ) {
+      return;
+    }
+
+    const nextLessons = [...lessonsQuery.data];
+    const [target] = nextLessons.splice(currentIndex, 1);
+    nextLessons.splice(nextIndex, 0, target);
+
+    reorderLessonsMutation.mutate(
+      {
+        courseId: effectiveCourseId,
+        request: {
+          orderedLessonIds: nextLessons.map((lesson) => lesson.lessonId),
+        },
+      },
+      {
+        onSuccess: () => {
+          if (typeof editingLessonId === 'number') {
+            setHydratedLessonId(undefined);
+            setHydratedLessonSnapshot('');
+          }
+        },
+      },
+    );
+  };
+
+  const handleSaveCompletionMessage = () => {
+    if (!effectiveCourseId || upsertCompletionMessageMutation.isPending) return;
+
+    const courseId = effectiveCourseId;
+    const submittedMessage = completionMessage;
+    upsertCompletionMessageMutation.mutate(
+      {
+        courseId,
+        request: { message: submittedMessage },
+      },
+      {
+        onSuccess: (response) => {
+          if (currentEffectiveCourseIdRef.current !== courseId) {
+            return;
+          }
+
+          const nextMessage = response.message ?? '';
+          if (currentCompletionMessageRef.current === submittedMessage) {
+            setCompletionMessage(nextMessage);
+          }
+          setHydratedCompletionMessageCourseId(courseId);
+          completionMessageSourceRef.current = {
+            courseId,
+            message: nextMessage,
+          };
+        },
+      },
+    );
+  };
+
+  const handleCopySlug = async (slug: string) => {
+    if (!navigator?.clipboard) return;
+
+    try {
+      await navigator.clipboard.writeText(slug);
+      useToastStore.getState().showToast('slug를 복사했습니다.', 'success');
+    } catch {
+      useToastStore.getState().showToast('slug 복사에 실패했습니다.', 'error');
+    }
+  };
+
+  const handleSubmitQnaAnswer = () => {
+    if (createLessonQnaAnswerMutation.isPending) return;
+    if (!selectedQnaId || !qnaAnswerContent.trim()) return;
+    const submittedQnaId = selectedQnaId;
+    const submittedContent = qnaAnswerContent;
+
+    createLessonQnaAnswerMutation.mutate(
+      { qnaId: submittedQnaId, content: submittedContent },
+      {
+        onSuccess: () => {
+          if (
+            currentSelectedQnaIdRef.current !== submittedQnaId ||
+            currentQnaAnswerContentRef.current !== submittedContent
+          ) {
+            return;
+          }
+
+          setQnaAnswerContent('');
+        },
+      },
+    );
+  };
+
+  const handleToggleBuilderFeedCuration = ({
+    feedId,
+    currentOperatorPick,
+    currentFeatured,
+    nextOperatorPick = currentOperatorPick,
+    nextFeatured = currentFeatured,
+  }: {
+    feedId: number;
+    currentOperatorPick: boolean;
+    currentFeatured: boolean;
+    nextOperatorPick?: boolean;
+    nextFeatured?: boolean;
+  }) => {
+    if (!editingLessonId) return;
+    if (
+      updateBuilderFeedCurationMutation.isPending ||
+      isAwaitingBuilderFeedRefresh
+    ) {
+      return;
+    }
+
+    const draftValue = builderFeedOrderDrafts[feedId];
+    const fallbackOrder =
+      lessonBuilderFeedsQuery.data?.feeds.find((feed) => feed.feedId === feedId)
+        ?.featuredOrder ?? 1;
+    const featuredOrder = nextFeatured
+      ? toFeaturedOrder(draftValue, fallbackOrder)
+      : null;
+
+    setIsAwaitingBuilderFeedRefresh(true);
+    updateBuilderFeedCurationMutation.mutate(
+      {
+        feedId,
+        lessonId: editingLessonId,
+        request: {
+          operatorPick: nextOperatorPick,
+          featured: nextFeatured,
+          featuredOrder,
+        } satisfies AdminBuilderFeedCurationRequest,
+      },
+      {
+        onSuccess: () => {
+          const nextValue = featuredOrder ? String(featuredOrder) : '';
+          setBuilderFeedOrderDrafts((prev) => ({
+            ...prev,
+            [feedId]: nextValue,
+          }));
+          builderFeedOrderSourceValuesRef.current = {
+            ...builderFeedOrderSourceValuesRef.current,
+            [feedId]: nextValue,
+          };
+        },
+        onError: () => {
+          setIsAwaitingBuilderFeedRefresh(false);
+        },
+      },
+    );
+  };
+
+  const selectedQna = qnaDetailQuery.data;
+  const isLessonListFiltered =
+    lessonSearch.trim().length > 0 ||
+    lessonPublishedFilter !== 'ALL' ||
+    lessonAccessFilter !== 'ALL';
+  const lessonSummaries = lessonsQuery.data ?? [];
+  const publishedLessonCount = lessonSummaries.filter(
+    (lesson) => lesson.isPublished,
+  ).length;
+  const freeLessonCount = lessonSummaries.filter(
+    (lesson) => lesson.isFree,
+  ).length;
+  const allFilteredLessonsSelected =
+    filteredLessons.length > 0 &&
+    filteredLessons.every((lesson) =>
+      selectedLessonIds.includes(lesson.lessonId),
+    );
+
+  return (
+    <main className="flex flex-col gap-200 p-200">
+      <div className="flex items-start justify-between gap-200">
+        <div>
+          <h1 className="font-designer-24b text-text-default">클래스 관리</h1>
+          <p className="font-designer-14r text-text-subtle mt-75">
+            코스 공개 상태, 레슨 구성, 돌아보기 목적, 완주 메시지를 관리자 API
+            기준으로 관리합니다.
+          </p>
+        </div>
+        <Button
+          color="outlined"
+          size="small"
+          disabled={isCourseSelectionLocked}
+          onClick={() => resetCourseForm()}
+        >
+          새 코스 입력
+        </Button>
+      </div>
+
+      <Section
+        title="운영 요약"
+        description={
+          selectedCourse
+            ? `${selectedCourse.title} 기준 운영 상태판입니다.`
+            : '코스를 선택하면 운영 요약을 확인할 수 있습니다.'
+        }
+      >
+        <AdminCourseOverviewContent
+          builderFeedCount={lessonBuilderFeedsQuery.data?.feeds.length ?? 0}
+          editingLessonId={editingLessonId}
+          freeLessonCount={freeLessonCount}
+          lessonCount={lessonSummaries.length}
+          publishedLessonCount={publishedLessonCount}
+          qnaCount={lessonQnasQuery.data?.totalCount ?? 0}
+          retrospectiveCount={
+            lessonRetrospectivesQuery.data?.retrospectives.length ?? 0
+          }
+          selectedCourse={selectedCourse}
+          selectedStatusLabel={
+            selectedCourse ? getStatusMeta(selectedCourse.status).label : '-'
+          }
+        />
+      </Section>
+
+      <Section
+        title="코스 목록"
+        description="코스는 제목 중심으로 선택하고 slug는 보조 식별자로만 확인합니다. 관리자 운영은 목록/버튼 중심으로 진행합니다."
+      >
+        <AdminCourseListContent
+          courseSearch={courseSearch}
+          coursesLoading={coursesQuery.isLoading}
+          deleteCoursePending={deleteCourseMutation.isPending}
+          filteredCourses={filteredCourses}
+          formatDateTime={formatDateTime}
+          isCourseSelectionLocked={isCourseSelectionLocked}
+          isSelectedCourseHiddenBySearch={isSelectedCourseHiddenBySearch}
+          onCopySlug={handleCopySlug}
+          onDeleteCourse={handleDeleteCourse}
+          onEditCourse={handleEditCourse}
+          onResetCourseSearch={() => setCourseSearch('')}
+          onSelectCourse={handleSelectCourse}
+          onSetCourseSearch={setCourseSearch}
+          onSetPage={setPage}
+          onSetStatusFilter={setStatusFilter}
+          page={page}
+          renderCourseStatusBadge={(status) => (
+            <CourseStatusBadge status={status} />
+          )}
+          selectedCourseId={selectedCourseId}
+          statusFilter={statusFilter}
+          statusOptions={COURSE_STATUS_OPTIONS}
+          totalCourses={coursesQuery.data?.totalElements ?? 0}
+          totalPages={coursesQuery.data?.totalPages ?? 1}
+          visibleCourses={visibleCourses}
+        />
+      </Section>
+
+      <div className="grid grid-cols-2 gap-200">
+        <Section
+          title={courseFormMode === 'create' ? '코스 생성' : '코스 수정'}
+          description={
+            courseFormMode === 'create'
+              ? 'slug는 URL 식별자이지만 관리 흐름은 목록/버튼으로 진행합니다.'
+              : '현재 코스 상세 조회 API가 없어 수정한 필드만 부분 반영합니다. 비어 보이는 칸이 기존 운영값 없음이라는 뜻은 아닙니다.'
+          }
+        >
+          <AdminCourseFormContent
+            courseForm={courseForm}
+            courseFormMode={courseFormMode}
+            courseThumbnailFileName={courseThumbnailFile?.name}
+            courseThumbnailHasFile={Boolean(courseThumbnailFile)}
+            courseThumbnailPreviewUrl={
+              courseThumbnailPreviewUrl || courseForm.thumbnailUrl || undefined
+            }
+            courseThumbnailStatusText={
+              courseThumbnailFile?.name ||
+              (courseForm.thumbnailUrl
+                ? '현재 저장된 썸네일 이미지가 있습니다.'
+                : '선택된 파일이 없습니다.')
+            }
+            handleChangeCourseThumbnail={handleChangeCourseThumbnail}
+            handleClearCourseThumbnailSelection={
+              handleClearCourseThumbnailSelection
+            }
+            handleQuickCourseStatusChange={handleQuickCourseStatusChange}
+            handleSubmitCourse={handleSubmitCourse}
+            isCourseFormLocked={isCourseFormLocked}
+            isQuickCourseStatusChangeEnabled={isQuickCourseStatusChangeEnabled}
+            isUploadingCourseThumbnail={isUploadingCourseThumbnail}
+            resetCourseForm={() => resetCourseForm()}
+            selectedCourseStatus={selectedCourse?.status}
+            statusOptions={COURSE_STATUS_OPTIONS}
+            thumbnailAccept={COURSE_THUMBNAIL_INPUT_ACCEPT}
+            toDateTimeLocal={toDateTimeLocal}
+            toKstOffsetDateTime={toKstOffsetDateTime}
+            updateCourseFormField={updateCourseFormField}
+            updateCoursePending={updateCourseMutation.isPending}
+          />
+        </Section>
+
+        <Section
+          title="완주 메시지"
+          description={
+            selectedCourse
+              ? `${selectedCourse.title} 완주 페이지에 노출할 운영자 메시지입니다.`
+              : '코스를 선택하면 완주 메시지를 관리할 수 있습니다.'
+          }
+        >
+          <AdminCourseCompletionMessageContent
+            completionMessage={completionMessage}
+            completionMessageHydrating={isCompletionMessageHydrating}
+            completionMessageUpdatedAt={completionMessageQuery.data?.updatedAt}
+            effectiveCourseId={effectiveCourseId}
+            formatDateTime={formatDateTime}
+            onChangeCompletionMessage={setCompletionMessage}
+            onSaveCompletionMessage={handleSaveCompletionMessage}
+            upsertCompletionMessagePending={
+              upsertCompletionMessageMutation.isPending
+            }
+          />
+        </Section>
+      </div>
+
+      <Section
+        title="레슨 관리"
+        description={
+          selectedCourse
+            ? `${selectedCourse.title}의 챕터/레슨, 돌아보기 목적, 무료 공개, 게시 상태를 관리합니다.`
+            : '코스를 선택하면 레슨 목록이 표시됩니다.'
+        }
+      >
+        <AdminLessonManagementContent
+          allFilteredLessonsSelected={allFilteredLessonsSelected}
+          bulkUpdateLessonsMutationPending={bulkUpdateLessonsMutation.isPending}
+          createLessonMutationPending={isLessonMutationPending}
+          deleteLessonMutationPending={deleteLessonMutation.isPending}
+          editingLessonId={editingLessonId}
+          effectiveCourseId={effectiveCourseId}
+          filteredLessons={filteredLessons}
+          formatDateTime={formatDateTime}
+          handleBulkLessonUpdate={handleBulkLessonUpdate}
+          handleDeleteLesson={handleDeleteLesson}
+          handleEditLesson={handleEditLesson}
+          handleMoveLesson={handleMoveLesson}
+          handleSubmitLesson={handleSubmitLesson}
+          handleToggleLessonSelection={handleToggleLessonSelection}
+          handleToggleSelectAllLessons={handleToggleSelectAllLessons}
+          isLessonContextLocked={isLessonContextLocked}
+          isLessonDetailHydrating={isLessonDetailHydrating}
+          isLessonFormLocked={isLessonFormLocked}
+          isLessonListFiltered={isLessonListFiltered}
+          isLessonListInteractionLocked={isLessonListInteractionLocked}
+          lessonAccessFilter={lessonAccessFilter}
+          lessonDetailQueryIsFetching={lessonDetailQuery.isFetching}
+          lessonEditorStateKey={
+            lessonFormMode === 'edit' && editingLessonId
+              ? `edit:${hydratedLessonId ?? editingLessonId}:${lessonEditorResetVersion}`
+              : `create:${lessonEditorResetVersion}`
+          }
+          lessonForm={lessonForm}
+          lessonFormMode={lessonFormMode}
+          lessonPublishedFilter={lessonPublishedFilter}
+          lessonSearch={lessonSearch}
+          lessonsQueryIsLoading={lessonsQuery.isLoading}
+          reorderLessonsMutationPending={reorderLessonsMutation.isPending}
+          resetLessonForm={() => resetLessonForm()}
+          selectedLessonIds={selectedLessonIds}
+          setLessonAccessFilter={setLessonAccessFilter}
+          setLessonForm={setLessonForm}
+          setLessonPublishedFilter={setLessonPublishedFilter}
+          setLessonSearch={setLessonSearch}
+          updateLessonMutationPending={updateLessonMutation.isPending}
+        />
+      </Section>
+
+      <Section
+        title="레슨 돌아보기 제출 목록"
+        description={
+          editingLessonId
+            ? '선택한 레슨에 실제로 제출된 인증/결과물/주관식 답변을 확인합니다.'
+            : '레슨 돌아보기를 보려면 먼저 위에서 레슨 수정 버튼을 눌러 대상 레슨을 선택하세요.'
+        }
+      >
+        <AdminLessonRetrospectivesContent
+          editingLessonId={editingLessonId}
+          formatDateTime={formatDateTime}
+          lessonRetrospectives={lessonRetrospectivesQuery.data?.retrospectives}
+          lessonRetrospectivesLoading={lessonRetrospectivesQuery.isLoading}
+        />
+      </Section>
+
+      <Section
+        title="Builder Feed 운영"
+        description={
+          editingLessonId
+            ? '선택한 레슨의 결과물 피드를 보고 operator pick / showcase 노출 순서를 관리합니다.'
+            : 'Builder Feed 운영을 하려면 먼저 위에서 레슨 수정 버튼을 눌러 대상 레슨을 선택하세요.'
+        }
+      >
+        <AdminLessonBuilderFeedContent
+          builderFeedOrderDrafts={builderFeedOrderDrafts}
+          editingLessonId={editingLessonId}
+          feeds={lessonBuilderFeedsQuery.data?.feeds}
+          formatDateTime={formatDateTime}
+          handleToggleBuilderFeedCuration={handleToggleBuilderFeedCuration}
+          isAwaitingBuilderFeedRefresh={isAwaitingBuilderFeedRefresh}
+          isLoading={lessonBuilderFeedsQuery.isLoading}
+          setBuilderFeedOrderDrafts={setBuilderFeedOrderDrafts}
+        />
+      </Section>
+
+      <Section
+        title="레슨 QnA 관리"
+        description={
+          editingLessonId
+            ? '선택한 레슨의 질문을 확인하고 관리자 답변을 남깁니다. 숨김/비게시 레슨도 admin API로 확인합니다.'
+            : '레슨 QnA를 보려면 먼저 위에서 레슨 수정 버튼을 눌러 대상 레슨을 선택하세요.'
+        }
+      >
+        <AdminLessonQnaContent
+          answerMutationPending={createLessonQnaAnswerMutation.isPending}
+          editingLessonId={editingLessonId}
+          formatDateTime={formatDateTime}
+          handleSubmitQnaAnswer={handleSubmitQnaAnswer}
+          qnaAnswerContent={qnaAnswerContent}
+          qnaCount={lessonQnasQuery.data?.totalCount ?? 0}
+          qnaDetailLoading={qnaDetailQuery.isLoading}
+          qnaListLoading={lessonQnasQuery.isLoading}
+          qnas={lessonQnasQuery.data?.qnas}
+          selectedQna={selectedQna}
+          selectedQnaId={selectedQnaId}
+          setQnaAnswerContent={setQnaAnswerContent}
+          setSelectedQnaId={setSelectedQnaId}
+        />
+      </Section>
+    </main>
+  );
+}

--- a/src/components/admin/courses/admin-course-markdown-editor.tsx
+++ b/src/components/admin/courses/admin-course-markdown-editor.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { memo, useEffect, useRef, useState } from 'react';
+import MarkdownEditor from '@/components/common/ui/editor/markdown-editor';
+import { uploadAdminCourseImage } from '@/features/admin/course-management/model/admin-course-image-upload';
+import {
+  ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS,
+  ADMIN_COURSE_MARKDOWN_MAX_IMAGE_COUNT,
+  ADMIN_COURSE_MARKDOWN_MAX_IMAGE_FILE_SIZE,
+  normalizeAdminCourseMarkdownContent,
+} from '@/features/admin/course-management/model/admin-course-markdown';
+
+interface AdminCourseMarkdownEditorProps {
+  editorStateKey?: string;
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+}
+
+function AdminCourseMarkdownEditor({
+  editorStateKey,
+  value,
+  onChange,
+  placeholder,
+}: AdminCourseMarkdownEditorProps) {
+  const normalizedValue = normalizeAdminCourseMarkdownContent(value);
+  const lastSourceValueRef = useRef(normalizedValue);
+
+  const [draftValue, setDraftValue] = useState(() => normalizedValue);
+
+  useEffect(() => {
+    setDraftValue(normalizedValue);
+    lastSourceValueRef.current = normalizedValue;
+  }, [editorStateKey, normalizedValue]);
+
+  useEffect(() => {
+    if (lastSourceValueRef.current === normalizedValue) {
+      return;
+    }
+
+    setDraftValue((prevDraftValue) => {
+      if (prevDraftValue !== lastSourceValueRef.current) {
+        return prevDraftValue;
+      }
+
+      return normalizedValue;
+    });
+    lastSourceValueRef.current = normalizedValue;
+  }, [normalizedValue]);
+
+  return (
+    <div className="admin-course-markdown-editor">
+      <MarkdownEditor
+        value={draftValue}
+        onChange={(next) => {
+          setDraftValue(next);
+          onChange(next);
+        }}
+        placeholder={placeholder}
+        normalizeContent={normalizeAdminCourseMarkdownContent}
+        imageConfig={{
+          allowedImageExtensions:
+            ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS,
+          maxImageCount: ADMIN_COURSE_MARKDOWN_MAX_IMAGE_COUNT,
+          maxImageFileSize: ADMIN_COURSE_MARKDOWN_MAX_IMAGE_FILE_SIZE,
+          uploadImageFile: uploadAdminCourseImage,
+        }}
+      />
+      <style jsx global>{`
+        .admin-course-markdown-editor .tiptap-editor {
+          min-height: var(--spacing-650);
+        }
+
+        .admin-course-markdown-editor .tiptap-editor .tiptap > * {
+          max-width: 100%;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+export default memo(AdminCourseMarkdownEditor);

--- a/src/components/admin/courses/admin-course-markdown-field.tsx
+++ b/src/components/admin/courses/admin-course-markdown-field.tsx
@@ -1,0 +1,41 @@
+import AdminCourseField from '@/components/admin/courses/admin-course-field';
+import AdminCourseMarkdownEditor from '@/components/admin/courses/admin-course-markdown-editor';
+
+interface AdminCourseMarkdownFieldProps {
+  value: string;
+  onChange: (content: string) => void;
+  placeholder: string;
+  helper?: string;
+  editorStateKey?: string;
+  isHydrating?: boolean;
+  hydratingText?: string;
+}
+
+export default function AdminCourseMarkdownField({
+  value,
+  onChange,
+  placeholder,
+  helper,
+  editorStateKey,
+  isHydrating = false,
+  hydratingText = '본문을 불러오는 중입니다.',
+}: AdminCourseMarkdownFieldProps) {
+  return (
+    <AdminCourseField label="본문" helper={helper}>
+      <div className="border-border-default rounded-100 overflow-hidden border">
+        {isHydrating ? (
+          <div className="font-designer-14r text-text-subtle bg-background-subtlest flex min-h-260 items-center justify-center px-150 py-125">
+            {hydratingText}
+          </div>
+        ) : (
+          <AdminCourseMarkdownEditor
+            editorStateKey={editorStateKey}
+            value={value}
+            placeholder={placeholder}
+            onChange={onChange}
+          />
+        )}
+      </div>
+    </AdminCourseField>
+  );
+}

--- a/src/components/admin/courses/admin-course-overview-sections.tsx
+++ b/src/components/admin/courses/admin-course-overview-sections.tsx
@@ -1,0 +1,322 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import Button from '@/components/common/ui/button';
+import { BaseInput, NativeSelect } from '@/components/common/ui/input';
+import Pagination from '@/components/common/ui/pagination';
+import type {
+  AdminCourseStatus,
+  AdminCourseSummary,
+} from '@/features/admin/course-management/model/admin-course-management-contract';
+
+interface AdminCourseOverviewContentProps {
+  builderFeedCount: number;
+  editingLessonId?: number;
+  freeLessonCount: number;
+  lessonCount: number;
+  publishedLessonCount: number;
+  qnaCount: number;
+  retrospectiveCount: number;
+  selectedCourse?: AdminCourseSummary;
+  selectedStatusLabel: string;
+}
+
+export function AdminCourseOverviewContent({
+  builderFeedCount,
+  editingLessonId,
+  freeLessonCount,
+  lessonCount,
+  publishedLessonCount,
+  qnaCount,
+  retrospectiveCount,
+  selectedCourse,
+  selectedStatusLabel,
+}: AdminCourseOverviewContentProps) {
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-125 md:grid-cols-4">
+        <div className="border-border-default rounded-100 border p-150">
+          <p className="font-designer-12r text-text-subtle">코스 상태</p>
+          <p className="font-designer-20b text-text-default mt-50">
+            {selectedCourse ? selectedStatusLabel : '-'}
+          </p>
+        </div>
+        <div className="border-border-default rounded-100 border p-150">
+          <p className="font-designer-12r text-text-subtle">총 레슨</p>
+          <p className="font-designer-20b text-text-default mt-50">
+            {lessonCount}개
+          </p>
+        </div>
+        <div className="border-border-default rounded-100 border p-150">
+          <p className="font-designer-12r text-text-subtle">게시 / 비게시</p>
+          <p className="font-designer-20b text-text-default mt-50">
+            {publishedLessonCount} /{' '}
+            {Math.max(lessonCount - publishedLessonCount, 0)}
+          </p>
+        </div>
+        <div className="border-border-default rounded-100 border p-150">
+          <p className="font-designer-12r text-text-subtle">무료 / 유료</p>
+          <p className="font-designer-20b text-text-default mt-50">
+            {freeLessonCount} / {Math.max(lessonCount - freeLessonCount, 0)}
+          </p>
+        </div>
+      </div>
+      {editingLessonId && (
+        <div className="mt-125 grid grid-cols-3 gap-125">
+          <div className="border-border-default rounded-100 border p-150">
+            <p className="font-designer-12r text-text-subtle">선택 레슨 QnA</p>
+            <p className="font-designer-20b text-text-default mt-50">
+              {qnaCount}개
+            </p>
+          </div>
+          <div className="border-border-default rounded-100 border p-150">
+            <p className="font-designer-12r text-text-subtle">
+              선택 레슨 돌아보기
+            </p>
+            <p className="font-designer-20b text-text-default mt-50">
+              {retrospectiveCount}개
+            </p>
+          </div>
+          <div className="border-border-default rounded-100 border p-150">
+            <p className="font-designer-12r text-text-subtle">
+              선택 레슨 Builder Feed
+            </p>
+            <p className="font-designer-20b text-text-default mt-50">
+              {builderFeedCount}개
+            </p>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+interface AdminCourseListContentProps {
+  courseSearch: string;
+  coursesLoading: boolean;
+  filteredCourses: AdminCourseSummary[];
+  isCourseSelectionLocked: boolean;
+  isSelectedCourseHiddenBySearch: boolean;
+  onCopySlug: (slug: string) => void;
+  onEditCourse: (course: AdminCourseSummary) => void;
+  onDeleteCourse: (course: AdminCourseSummary) => void;
+  onResetCourseSearch: () => void;
+  onSelectCourse: (courseId: number) => void;
+  onSetCourseSearch: (value: string) => void;
+  onSetPage: (page: number) => void;
+  onSetStatusFilter: (value: AdminCourseStatus | '') => void;
+  page: number;
+  renderCourseStatusBadge: (status: AdminCourseStatus) => ReactNode;
+  selectedCourseId?: number;
+  statusFilter: AdminCourseStatus | '';
+  statusOptions: Array<{ value: AdminCourseStatus; label: string }>;
+  totalCourses: number;
+  totalPages: number;
+  visibleCourses: AdminCourseSummary[];
+  formatDateTime: (value: string) => string;
+  deleteCoursePending: boolean;
+}
+
+export function AdminCourseListContent({
+  courseSearch,
+  coursesLoading,
+  deleteCoursePending,
+  filteredCourses,
+  formatDateTime,
+  isCourseSelectionLocked,
+  isSelectedCourseHiddenBySearch,
+  onCopySlug,
+  onDeleteCourse,
+  onEditCourse,
+  onResetCourseSearch,
+  onSelectCourse,
+  onSetCourseSearch,
+  onSetPage,
+  onSetStatusFilter,
+  page,
+  renderCourseStatusBadge,
+  selectedCourseId,
+  statusFilter,
+  statusOptions,
+  totalCourses,
+  totalPages,
+  visibleCourses,
+}: AdminCourseListContentProps) {
+  return (
+    <>
+      <div className="mb-150 flex items-center justify-between gap-150">
+        <div className="flex items-center gap-100">
+          <span className="font-designer-13m text-text-subtle">상태</span>
+          <NativeSelect
+            disabled={isCourseSelectionLocked}
+            value={statusFilter}
+            onChange={(event) =>
+              onSetStatusFilter(event.target.value as AdminCourseStatus | '')
+            }
+          >
+            <option value="">전체</option>
+            {statusOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </NativeSelect>
+        </div>
+        <div className="flex items-center gap-100">
+          <BaseInput
+            size="m"
+            disabled={isCourseSelectionLocked}
+            value={courseSearch}
+            placeholder="코스 제목으로 찾기"
+            onValueChange={onSetCourseSearch}
+          />
+          <span className="font-designer-13r text-text-subtlest">
+            총 {totalCourses}개
+          </span>
+        </div>
+      </div>
+
+      <div className="border-border-default rounded-100 overflow-hidden border">
+        <table className="w-full">
+          <thead className="bg-background-alternative border-border-default border-b">
+            <tr>
+              <th className="font-designer-13m text-text-subtle py-100 pl-150 text-left">
+                코스
+              </th>
+              <th className="font-designer-13m text-text-subtle py-100 pl-100 text-left">
+                상태
+              </th>
+              <th className="font-designer-13m text-text-subtle py-100 pl-100 text-left">
+                레슨/수강
+              </th>
+              <th className="font-designer-13m text-text-subtle py-100 pl-100 text-left">
+                수정일
+              </th>
+              <th className="py-100 pr-150" />
+            </tr>
+          </thead>
+          <tbody>
+            {coursesLoading && (
+              <tr>
+                <td
+                  className="font-designer-14r text-text-subtle py-300 text-center"
+                  colSpan={5}
+                >
+                  코스 목록을 불러오는 중입니다.
+                </td>
+              </tr>
+            )}
+            {!coursesLoading && filteredCourses.length === 0 && (
+              <tr>
+                <td
+                  className="font-designer-14r text-text-subtle py-300 text-center"
+                  colSpan={5}
+                >
+                  <div className="flex flex-col items-center gap-100">
+                    <span>
+                      {visibleCourses.length === 0
+                        ? '등록된 코스가 없습니다.'
+                        : '검색 조건에 맞는 코스가 없습니다.'}
+                    </span>
+                    {isSelectedCourseHiddenBySearch && (
+                      <div className="flex flex-col items-center gap-75">
+                        <span className="font-designer-13r text-text-subtlest">
+                          현재 선택된 코스는 검색 결과에서 숨겨져 있습니다.
+                        </span>
+                        <Button
+                          color="secondary"
+                          size="xsmall"
+                          disabled={isCourseSelectionLocked}
+                          onClick={onResetCourseSearch}
+                        >
+                          검색 초기화
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            )}
+            {filteredCourses.map((course) => (
+              <tr
+                key={course.courseId}
+                className={cn(
+                  'border-border-default border-b',
+                  selectedCourseId === course.courseId &&
+                    'bg-fill-brand-subtle-default',
+                )}
+              >
+                <td className="p-0">
+                  <button
+                    className="flex h-full w-full flex-col items-start gap-25 px-150 py-150 text-left"
+                    disabled={isCourseSelectionLocked}
+                    onClick={() => onSelectCourse(course.courseId)}
+                    type="button"
+                  >
+                    <span className="font-designer-14m text-text-default">
+                      {course.title}
+                    </span>
+                    <span className="font-designer-13r text-text-subtlest">
+                      slug: {course.slug} · ID {course.courseId}
+                    </span>
+                  </button>
+                </td>
+                <td className="py-150 pl-100">
+                  {renderCourseStatusBadge(course.status)}
+                </td>
+                <td className="font-designer-14r text-text-default py-150 pl-100">
+                  {course.lessonCount}개 / {course.enrolledCount}명
+                </td>
+                <td className="font-designer-14r text-text-default py-150 pl-100">
+                  {formatDateTime(course.updatedAt)}
+                </td>
+                <td className="py-150 pr-150">
+                  <div className="flex justify-end gap-75">
+                    <Button
+                      color="secondary"
+                      size="xsmall"
+                      onClick={() => onCopySlug(course.slug)}
+                    >
+                      slug 복사
+                    </Button>
+                    <Button
+                      color="secondary"
+                      size="xsmall"
+                      disabled={isCourseSelectionLocked}
+                      onClick={() => onEditCourse(course)}
+                    >
+                      수정
+                    </Button>
+                    <Button
+                      color="outlined"
+                      size="xsmall"
+                      disabled={deleteCoursePending}
+                      loading={deleteCoursePending}
+                      onClick={() => onDeleteCourse(course)}
+                    >
+                      삭제
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {totalPages > 1 && (
+        <Pagination
+          className="mt-200"
+          page={page}
+          totalPages={totalPages}
+          onChangePage={(nextPage) => {
+            if (isCourseSelectionLocked) {
+              return;
+            }
+
+            onSetPage(nextPage);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/admin/courses/admin-course-thumbnail-field.tsx
+++ b/src/components/admin/courses/admin-course-thumbnail-field.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import Image from 'next/image';
+import { type ChangeEvent, memo, useRef } from 'react';
+import Button from '@/components/common/ui/button';
+
+interface AdminCourseThumbnailFieldProps {
+  accept: string;
+  canClear?: boolean;
+  fileName?: string;
+  isUploading?: boolean;
+  previewUrl?: string;
+  statusText?: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onClear: () => void;
+}
+
+function AdminCourseThumbnailField({
+  accept,
+  canClear = false,
+  fileName,
+  isUploading = false,
+  previewUrl,
+  statusText,
+  onChange,
+  onClear,
+}: AdminCourseThumbnailFieldProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="border-border-default bg-background-subtlest rounded-100 flex flex-col gap-100 border p-125">
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        className="hidden"
+        onChange={onChange}
+      />
+      <div className="flex flex-wrap items-center gap-75">
+        <Button
+          color="secondary"
+          size="small"
+          disabled={isUploading}
+          onClick={() => inputRef.current?.click()}
+        >
+          썸네일 선택
+        </Button>
+        {canClear && (
+          <Button
+            color="outlined"
+            size="small"
+            disabled={isUploading}
+            onClick={onClear}
+          >
+            선택 해제
+          </Button>
+        )}
+        <span className="font-designer-12r text-text-subtle">
+          {statusText || fileName || '선택된 파일이 없습니다.'}
+        </span>
+      </div>
+      {previewUrl ? (
+        <div className="border-border-subtle bg-background-default rounded-100 overflow-hidden border">
+          <Image
+            src={previewUrl}
+            alt="코스 썸네일 미리보기"
+            width={1200}
+            height={630}
+            unoptimized
+            className="h-auto max-h-400 w-full object-cover"
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default memo(AdminCourseThumbnailField);

--- a/src/components/admin/courses/admin-lesson-detail-page-client.tsx
+++ b/src/components/admin/courses/admin-lesson-detail-page-client.tsx
@@ -1,0 +1,896 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import AdminCourseField from '@/components/admin/courses/admin-course-field';
+import AdminCourseMarkdownField from '@/components/admin/courses/admin-course-markdown-field';
+import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import Badge from '@/components/common/ui/badge';
+import Button from '@/components/common/ui/button';
+import { BaseInput, NativeSelect } from '@/components/common/ui/input';
+import BorderedTextarea from '@/components/common/ui/input/bordered-textarea';
+import type {
+  AdminBuilderFeedCurationRequest,
+  AdminLessonQnaListItem,
+  AdminLessonUpsertRequest,
+  AdminRetrospectivePurpose,
+} from '@/features/admin/course-management/model/admin-course-management-contract';
+import { normalizeAdminCourseMarkdownContent } from '@/features/admin/course-management/model/admin-course-markdown';
+import {
+  ADMIN_RETROSPECTIVE_PURPOSE_OPTIONS,
+  getAdminRetrospectivePurposeMeta,
+} from '@/features/admin/course-management/model/admin-course-presentation';
+import {
+  getAdminLessonPayloadValidationError,
+  toAdminLessonPayload,
+  useAdminLessonBuilderFeedsQuery,
+  useAdminLessonDetailQuery,
+  useAdminLessonQnaDetailQuery,
+  useAdminLessonQnasQuery,
+  useAdminLessonRetrospectivesQuery,
+  useCreateAdminLessonQnaAnswerMutation,
+  useUpdateAdminBuilderFeedCurationMutation,
+  useUpdateAdminLessonMutation,
+} from '@/features/admin/course-management/model/use-admin-course-management-query';
+import { useToastStore } from '@/stores/use-toast-store';
+
+const emptyLessonForm: AdminLessonUpsertRequest = {
+  chapterNumber: 1,
+  lessonNumber: 1,
+  title: '',
+  content: '',
+  estimatedMinutes: 30,
+  retrospectivePurpose: 'PRACTICE_PROOF',
+  isFree: false,
+  isPublished: false,
+};
+
+const formatDateTime = (value: string | null) => {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+};
+
+export default function AdminLessonDetailPageClient({
+  lessonId,
+}: {
+  lessonId: number;
+}) {
+  const lessonDetailQuery = useAdminLessonDetailQuery(lessonId);
+  const lessonRetrospectivesQuery = useAdminLessonRetrospectivesQuery(lessonId);
+  const lessonBuilderFeedsQuery = useAdminLessonBuilderFeedsQuery(lessonId);
+  const lessonQnasQuery = useAdminLessonQnasQuery(lessonId);
+  const updateLessonMutation = useUpdateAdminLessonMutation();
+  const updateBuilderFeedCurationMutation =
+    useUpdateAdminBuilderFeedCurationMutation();
+  const createLessonQnaAnswerMutation = useCreateAdminLessonQnaAnswerMutation();
+
+  const [selectedQnaId, setSelectedQnaId] = useState<number | undefined>();
+  const qnaDetailQuery = useAdminLessonQnaDetailQuery(selectedQnaId);
+  const [qnaAnswerContent, setQnaAnswerContent] = useState('');
+  const currentSelectedQnaIdRef = useRef<number | undefined>(undefined);
+  const currentQnaAnswerContentRef = useRef('');
+  const [builderFeedOrderDrafts, setBuilderFeedOrderDrafts] = useState<
+    Record<number, string>
+  >({});
+  const builderFeedOrderSourceValuesRef = useRef<Record<number, string>>({});
+  const [isAwaitingBuilderFeedRefresh, setIsAwaitingBuilderFeedRefresh] =
+    useState(false);
+  const [lessonForm, setLessonForm] =
+    useState<AdminLessonUpsertRequest>(emptyLessonForm);
+  const [hydratedLessonSnapshot, setHydratedLessonSnapshot] = useState('');
+  const [isAwaitingLessonRefresh, setIsAwaitingLessonRefresh] = useState(false);
+
+  const isLessonFormLocked =
+    updateLessonMutation.isPending || isAwaitingLessonRefresh;
+
+  const lessonDetailSnapshot = lessonDetailQuery.data
+    ? JSON.stringify({
+        chapterNumber: lessonDetailQuery.data.chapterNumber,
+        lessonNumber: lessonDetailQuery.data.lessonNumber,
+        title: lessonDetailQuery.data.title,
+        content: normalizeAdminCourseMarkdownContent(
+          lessonDetailQuery.data.content,
+        ),
+        estimatedMinutes: lessonDetailQuery.data.estimatedMinutes,
+        retrospectivePurpose: lessonDetailQuery.data.retrospectivePurpose,
+        isFree: lessonDetailQuery.data.isFree,
+        isPublished: lessonDetailQuery.data.isPublished,
+      })
+    : '';
+
+  useEffect(() => {
+    if (!lessonDetailQuery.data) return;
+    if (hydratedLessonSnapshot === lessonDetailSnapshot) return;
+
+    setLessonForm({
+      chapterNumber: lessonDetailQuery.data.chapterNumber,
+      lessonNumber: lessonDetailQuery.data.lessonNumber,
+      title: lessonDetailQuery.data.title,
+      content: normalizeAdminCourseMarkdownContent(
+        lessonDetailQuery.data.content,
+      ),
+      estimatedMinutes: lessonDetailQuery.data.estimatedMinutes,
+      retrospectivePurpose: lessonDetailQuery.data.retrospectivePurpose,
+      isFree: lessonDetailQuery.data.isFree,
+      isPublished: lessonDetailQuery.data.isPublished,
+    });
+    setHydratedLessonSnapshot(lessonDetailSnapshot);
+  }, [hydratedLessonSnapshot, lessonDetailQuery.data, lessonDetailSnapshot]);
+
+  useEffect(() => {
+    if (
+      !isAwaitingLessonRefresh ||
+      updateLessonMutation.isPending ||
+      lessonDetailQuery.isFetching
+    ) {
+      return;
+    }
+
+    setIsAwaitingLessonRefresh(false);
+  }, [
+    isAwaitingLessonRefresh,
+    lessonDetailQuery.isFetching,
+    updateLessonMutation.isPending,
+  ]);
+
+  useEffect(() => {
+    const qnas = lessonQnasQuery.data?.qnas ?? [];
+
+    if (lessonQnasQuery.isFetching && qnas.length === 0) {
+      return;
+    }
+
+    if (qnas.length === 0) {
+      setSelectedQnaId(undefined);
+      return;
+    }
+
+    if (selectedQnaId && qnas.some((qna) => qna.qnaId === selectedQnaId)) {
+      return;
+    }
+
+    setSelectedQnaId(qnas[0].qnaId);
+  }, [lessonQnasQuery.data?.qnas, lessonQnasQuery.isFetching, selectedQnaId]);
+
+  useEffect(() => {
+    setQnaAnswerContent('');
+  }, [selectedQnaId]);
+
+  useEffect(() => {
+    currentSelectedQnaIdRef.current = selectedQnaId;
+  }, [selectedQnaId]);
+
+  useEffect(() => {
+    currentQnaAnswerContentRef.current = qnaAnswerContent;
+  }, [qnaAnswerContent]);
+
+  useEffect(() => {
+    if (!lessonBuilderFeedsQuery.data?.feeds.length) {
+      setBuilderFeedOrderDrafts({});
+      builderFeedOrderSourceValuesRef.current = {};
+      return;
+    }
+
+    const nextSourceValues = Object.fromEntries(
+      lessonBuilderFeedsQuery.data.feeds.map((feed) => [
+        feed.feedId,
+        feed.featuredOrder ? String(feed.featuredOrder) : '',
+      ]),
+    );
+
+    setBuilderFeedOrderDrafts((prevDrafts) => {
+      const nextDrafts: Record<number, string> = {};
+
+      lessonBuilderFeedsQuery.data?.feeds.forEach((feed) => {
+        const serverValue = nextSourceValues[feed.feedId] ?? '';
+        const previousSourceValue =
+          builderFeedOrderSourceValuesRef.current[feed.feedId];
+        const previousDraftValue = prevDrafts[feed.feedId];
+
+        nextDrafts[feed.feedId] =
+          previousDraftValue !== undefined &&
+          previousDraftValue !== previousSourceValue
+            ? previousDraftValue
+            : serverValue;
+      });
+
+      return nextDrafts;
+    });
+    builderFeedOrderSourceValuesRef.current = nextSourceValues;
+  }, [lessonBuilderFeedsQuery.data?.feeds]);
+
+  useEffect(() => {
+    if (
+      !isAwaitingBuilderFeedRefresh ||
+      updateBuilderFeedCurationMutation.isPending ||
+      lessonBuilderFeedsQuery.isFetching
+    ) {
+      return;
+    }
+
+    setIsAwaitingBuilderFeedRefresh(false);
+  }, [
+    isAwaitingBuilderFeedRefresh,
+    lessonBuilderFeedsQuery.isFetching,
+    updateBuilderFeedCurationMutation.isPending,
+  ]);
+
+  const toFeaturedOrder = (
+    draftValue: string | undefined,
+    fallbackOrder: number,
+  ) => {
+    const parsedValue = Number.parseInt(draftValue ?? '', 10);
+    if (Number.isFinite(parsedValue) && parsedValue > 0) {
+      return parsedValue;
+    }
+
+    return fallbackOrder > 0 ? fallbackOrder : 1;
+  };
+
+  const handleSubmitLesson = () => {
+    if (isLessonFormLocked) {
+      return;
+    }
+
+    const payload = toAdminLessonPayload(lessonForm);
+    const validationError = getAdminLessonPayloadValidationError(payload);
+
+    if (validationError) {
+      useToastStore.getState().showToast(validationError, 'info');
+      return;
+    }
+
+    setIsAwaitingLessonRefresh(true);
+    updateLessonMutation.mutate(
+      {
+        lessonId,
+        request: {
+          chapterNumber: payload.chapterNumber || undefined,
+          lessonNumber: payload.lessonNumber || undefined,
+          title: payload.title,
+          content: payload.content,
+          estimatedMinutes: payload.estimatedMinutes || undefined,
+          retrospectivePurpose: payload.retrospectivePurpose,
+          isFree: payload.isFree,
+          isPublished: payload.isPublished,
+        },
+      },
+      {
+        onError: () => {
+          setIsAwaitingLessonRefresh(false);
+        },
+      },
+    );
+  };
+
+  const handleToggleBuilderFeedCuration = ({
+    feedId,
+    currentOperatorPick,
+    currentFeatured,
+    nextOperatorPick = currentOperatorPick,
+    nextFeatured = currentFeatured,
+  }: {
+    feedId: number;
+    currentOperatorPick: boolean;
+    currentFeatured: boolean;
+    nextOperatorPick?: boolean;
+    nextFeatured?: boolean;
+  }) => {
+    if (
+      updateBuilderFeedCurationMutation.isPending ||
+      isAwaitingBuilderFeedRefresh
+    ) {
+      return;
+    }
+
+    const draftValue = builderFeedOrderDrafts[feedId];
+    const fallbackOrder =
+      lessonBuilderFeedsQuery.data?.feeds.find((feed) => feed.feedId === feedId)
+        ?.featuredOrder ?? 1;
+    const featuredOrder = nextFeatured
+      ? toFeaturedOrder(draftValue, fallbackOrder)
+      : null;
+
+    setIsAwaitingBuilderFeedRefresh(true);
+    updateBuilderFeedCurationMutation.mutate(
+      {
+        feedId,
+        lessonId,
+        request: {
+          operatorPick: nextOperatorPick,
+          featured: nextFeatured,
+          featuredOrder,
+        } satisfies AdminBuilderFeedCurationRequest,
+      },
+      {
+        onSuccess: () => {
+          const nextValue = featuredOrder ? String(featuredOrder) : '';
+          setBuilderFeedOrderDrafts((prev) => ({
+            ...prev,
+            [feedId]: nextValue,
+          }));
+          builderFeedOrderSourceValuesRef.current = {
+            ...builderFeedOrderSourceValuesRef.current,
+            [feedId]: nextValue,
+          };
+        },
+        onError: () => {
+          setIsAwaitingBuilderFeedRefresh(false);
+        },
+      },
+    );
+  };
+
+  const handleSubmitQnaAnswer = () => {
+    if (createLessonQnaAnswerMutation.isPending) return;
+    if (!selectedQnaId || !qnaAnswerContent.trim()) return;
+    const submittedQnaId = selectedQnaId;
+    const submittedContent = qnaAnswerContent;
+
+    createLessonQnaAnswerMutation.mutate(
+      { qnaId: submittedQnaId, content: submittedContent },
+      {
+        onSuccess: () => {
+          if (
+            currentSelectedQnaIdRef.current !== submittedQnaId ||
+            currentQnaAnswerContentRef.current !== submittedContent
+          ) {
+            return;
+          }
+
+          setQnaAnswerContent('');
+        },
+      },
+    );
+  };
+
+  if (lessonDetailQuery.isLoading) {
+    return <div className="p-200">레슨 상세를 불러오는 중입니다.</div>;
+  }
+
+  if (!lessonDetailQuery.data) {
+    return <div className="p-200">레슨을 찾을 수 없습니다.</div>;
+  }
+
+  return (
+    <main className="flex flex-col gap-200 p-200">
+      <div className="flex items-start justify-between gap-150">
+        <div>
+          <Link
+            href="/admin/courses"
+            className="font-designer-13m text-text-brand underline"
+          >
+            클래스 관리로 돌아가기
+          </Link>
+          <h1 className="font-designer-24b text-text-default mt-75">
+            {lessonForm.title}
+          </h1>
+          <div className="mt-75 flex flex-wrap gap-50">
+            <Badge color={lessonForm.isPublished ? 'green' : 'gray'}>
+              {lessonForm.isPublished ? '게시' : '비게시'}
+            </Badge>
+            <Badge color={lessonForm.isFree ? 'blue' : 'gray'}>
+              {lessonForm.isFree ? '무료' : '유료'}
+            </Badge>
+            <Badge
+              color={
+                getAdminRetrospectivePurposeMeta(
+                  lessonForm.retrospectivePurpose,
+                ).color
+              }
+            >
+              {
+                getAdminRetrospectivePurposeMeta(
+                  lessonForm.retrospectivePurpose,
+                ).label
+              }
+            </Badge>
+          </div>
+        </div>
+        <div className="flex gap-75">
+          <Button
+            size="small"
+            disabled={isLessonFormLocked}
+            loading={isLessonFormLocked}
+            onClick={handleSubmitLesson}
+          >
+            레슨 저장
+          </Button>
+        </div>
+      </div>
+
+      <section className="border-border-default bg-background-default rounded-150 border p-200">
+        <div className="grid grid-cols-3 gap-150">
+          <AdminCourseField label="챕터">
+            <BaseInput
+              size="m"
+              type="number"
+              min={1}
+              disabled={isLessonFormLocked}
+              value={String(lessonForm.chapterNumber)}
+              onValueChange={(chapterNumber) =>
+                setLessonForm((prev) => ({
+                  ...prev,
+                  chapterNumber: Number(chapterNumber),
+                }))
+              }
+            />
+          </AdminCourseField>
+          <AdminCourseField label="레슨">
+            <BaseInput
+              size="m"
+              type="number"
+              min={1}
+              disabled={isLessonFormLocked}
+              value={String(lessonForm.lessonNumber)}
+              onValueChange={(lessonNumber) =>
+                setLessonForm((prev) => ({
+                  ...prev,
+                  lessonNumber: Number(lessonNumber),
+                }))
+              }
+            />
+          </AdminCourseField>
+          <AdminCourseField label="예상 시간(분)">
+            <BaseInput
+              size="m"
+              type="number"
+              min={1}
+              disabled={isLessonFormLocked}
+              value={String(lessonForm.estimatedMinutes)}
+              onValueChange={(estimatedMinutes) =>
+                setLessonForm((prev) => ({
+                  ...prev,
+                  estimatedMinutes: Number(estimatedMinutes),
+                }))
+              }
+            />
+          </AdminCourseField>
+        </div>
+        <div className="mt-150 flex flex-col gap-150">
+          <AdminCourseField label="레슨 제목">
+            <BaseInput
+              size="m"
+              disabled={isLessonFormLocked}
+              value={lessonForm.title}
+              onValueChange={(title) =>
+                setLessonForm((prev) => ({ ...prev, title }))
+              }
+            />
+          </AdminCourseField>
+          <AdminCourseField
+            label="돌아보기 목적"
+            helper={
+              getAdminRetrospectivePurposeMeta(lessonForm.retrospectivePurpose)
+                .helper
+            }
+          >
+            <NativeSelect
+              disabled={isLessonFormLocked}
+              value={lessonForm.retrospectivePurpose}
+              onChange={(event) =>
+                setLessonForm((prev) => ({
+                  ...prev,
+                  retrospectivePurpose: event.target
+                    .value as AdminRetrospectivePurpose,
+                }))
+              }
+            >
+              {ADMIN_RETROSPECTIVE_PURPOSE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </NativeSelect>
+          </AdminCourseField>
+          <div className="grid grid-cols-2 gap-150">
+            <AdminCourseField label="무료 공개">
+              <NativeSelect
+                disabled={isLessonFormLocked}
+                value={lessonForm.isFree ? 'true' : 'false'}
+                onChange={(event) =>
+                  setLessonForm((prev) => ({
+                    ...prev,
+                    isFree: event.target.value === 'true',
+                  }))
+                }
+              >
+                <option value="false">유료 레슨</option>
+                <option value="true">무료 레슨</option>
+              </NativeSelect>
+            </AdminCourseField>
+            <AdminCourseField label="게시 상태">
+              <NativeSelect
+                disabled={isLessonFormLocked}
+                value={lessonForm.isPublished ? 'true' : 'false'}
+                onChange={(event) =>
+                  setLessonForm((prev) => ({
+                    ...prev,
+                    isPublished: event.target.value === 'true',
+                  }))
+                }
+              >
+                <option value="false">비게시</option>
+                <option value="true">게시</option>
+              </NativeSelect>
+            </AdminCourseField>
+          </div>
+          <AdminCourseMarkdownField
+            editorStateKey={String(lessonId)}
+            value={lessonForm.content}
+            isHydrating={isLessonFormLocked}
+            hydratingText="레슨 저장 중입니다."
+            placeholder="레슨 본문을 작성하세요. 마크다운/이미지 붙여넣기, 드래그 앤 드롭, 코드블록, 제목을 사용할 수 있습니다."
+            onChange={(content) =>
+              setLessonForm((prev) => ({
+                ...prev,
+                content,
+              }))
+            }
+          />
+        </div>
+      </section>
+
+      <section className="border-border-default bg-background-default rounded-150 border p-200">
+        <h2 className="font-designer-18b text-text-default mb-100">
+          돌아보기 제출
+        </h2>
+        {lessonRetrospectivesQuery.isLoading ? (
+          <p className="font-designer-14r text-text-subtle">
+            돌아보기 제출 목록을 불러오는 중입니다.
+          </p>
+        ) : (lessonRetrospectivesQuery.data?.retrospectives.length ?? 0) ===
+          0 ? (
+          <p className="font-designer-14r text-text-subtle">
+            제출된 돌아보기가 없습니다.
+          </p>
+        ) : (
+          <div className="grid gap-125">
+            {lessonRetrospectivesQuery.data?.retrospectives.map((retro) => (
+              <article
+                key={retro.retrospectiveId}
+                className="border-border-default rounded-100 border p-150"
+              >
+                <div className="mb-75 flex flex-wrap items-center gap-75">
+                  <Badge
+                    color={
+                      retro.purpose === 'SUBJECTIVE_QUIZ' ? 'orange' : 'blue'
+                    }
+                  >
+                    {getAdminRetrospectivePurposeMeta(retro.purpose).label}
+                  </Badge>
+                  <Badge color="green">
+                    이해도 {retro.understandingScore}/5
+                  </Badge>
+                  {retro.artifactType && (
+                    <Badge color="gray">{retro.artifactType}</Badge>
+                  )}
+                  <span className="font-designer-12r text-text-subtlest">
+                    {retro.nickname} · member {retro.memberId} ·{' '}
+                    {formatDateTime(retro.createdAt)}
+                  </span>
+                </div>
+                {retro.artifactValue && (
+                  <p className="font-designer-13r text-text-brand mb-75 break-all underline">
+                    {retro.artifactValue}
+                  </p>
+                )}
+                <p className="font-designer-14r text-text-default whitespace-pre-wrap">
+                  {retro.content}
+                </p>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="border-border-default bg-background-default rounded-150 border p-200">
+        <h2 className="font-designer-18b text-text-default mb-100">
+          Builder Feed 운영
+        </h2>
+        {lessonBuilderFeedsQuery.isLoading ? (
+          <p className="font-designer-14r text-text-subtle">
+            Builder Feed 목록을 불러오는 중입니다.
+          </p>
+        ) : (lessonBuilderFeedsQuery.data?.feeds.length ?? 0) === 0 ? (
+          <p className="font-designer-14r text-text-subtle">
+            연결된 Builder Feed가 없습니다.
+          </p>
+        ) : (
+          <div className="grid gap-125">
+            {lessonBuilderFeedsQuery.data?.feeds.map((feed) => (
+              <article
+                key={feed.feedId}
+                className="border-border-default rounded-100 border p-150"
+              >
+                <div className="mb-100 flex flex-wrap items-center gap-75">
+                  <Badge color={feed.role === 'MANAGER' ? 'orange' : 'blue'}>
+                    {feed.role}
+                  </Badge>
+                  <Badge color={feed.operatorPick ? 'green' : 'gray'}>
+                    {feed.operatorPick
+                      ? 'Operator Pick ON'
+                      : 'Operator Pick OFF'}
+                  </Badge>
+                  <Badge color={feed.featured ? 'green' : 'gray'}>
+                    {feed.featured
+                      ? `Showcase ON #${feed.featuredOrder ?? '-'}`
+                      : 'Showcase OFF'}
+                  </Badge>
+                  <span className="font-designer-12r text-text-subtlest">
+                    {feed.nickname} · member {feed.memberId} · 좋아요{' '}
+                    {feed.likeCount} · 댓글 {feed.commentCount} ·{' '}
+                    {formatDateTime(feed.createdAt)}
+                  </span>
+                </div>
+                <p className="font-designer-14r text-text-default whitespace-pre-wrap">
+                  {feed.content}
+                </p>
+                {feed.imageUrls.length > 0 && (
+                  <div className="mt-100 flex flex-col gap-50">
+                    {feed.imageUrls.map((url) => (
+                      <a
+                        key={url}
+                        href={url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="font-designer-13m text-text-brand underline"
+                      >
+                        이미지 열기
+                      </a>
+                    ))}
+                  </div>
+                )}
+                <div className="mt-125 flex flex-wrap items-end gap-100">
+                  <Button
+                    color={feed.operatorPick ? 'secondary' : 'outlined'}
+                    size="xsmall"
+                    disabled={isAwaitingBuilderFeedRefresh}
+                    loading={isAwaitingBuilderFeedRefresh}
+                    onClick={() =>
+                      handleToggleBuilderFeedCuration({
+                        feedId: feed.feedId,
+                        currentOperatorPick: feed.operatorPick,
+                        currentFeatured: feed.featured,
+                        nextOperatorPick: !feed.operatorPick,
+                      })
+                    }
+                  >
+                    {feed.operatorPick
+                      ? 'operator pick 해제'
+                      : 'operator pick 지정'}
+                  </Button>
+                  <Button
+                    color={feed.featured ? 'secondary' : 'outlined'}
+                    size="xsmall"
+                    disabled={isAwaitingBuilderFeedRefresh}
+                    loading={isAwaitingBuilderFeedRefresh}
+                    onClick={() =>
+                      handleToggleBuilderFeedCuration({
+                        feedId: feed.feedId,
+                        currentOperatorPick: feed.operatorPick,
+                        currentFeatured: feed.featured,
+                        nextFeatured: !feed.featured,
+                      })
+                    }
+                  >
+                    {feed.featured ? 'showcase 해제' : 'showcase 지정'}
+                  </Button>
+                  <label className="flex items-center gap-75">
+                    <span className="font-designer-12r text-text-subtle">
+                      showcase 순서
+                    </span>
+                    <BaseInput
+                      size="m"
+                      type="number"
+                      min={1}
+                      disabled={isAwaitingBuilderFeedRefresh}
+                      value={builderFeedOrderDrafts[feed.feedId] ?? ''}
+                      onValueChange={(value) =>
+                        setBuilderFeedOrderDrafts((prev) => ({
+                          ...prev,
+                          [feed.feedId]: value,
+                        }))
+                      }
+                    />
+                  </label>
+                  <Button
+                    color="secondary"
+                    size="xsmall"
+                    disabled={!feed.featured || isAwaitingBuilderFeedRefresh}
+                    loading={isAwaitingBuilderFeedRefresh}
+                    onClick={() =>
+                      handleToggleBuilderFeedCuration({
+                        feedId: feed.feedId,
+                        currentOperatorPick: feed.operatorPick,
+                        currentFeatured: feed.featured,
+                        nextFeatured: true,
+                      })
+                    }
+                  >
+                    순서 저장
+                  </Button>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="border-border-default bg-background-default rounded-150 border p-200">
+        <h2 className="font-designer-18b text-text-default mb-100">
+          레슨 QnA 관리
+        </h2>
+        <div className="grid grid-cols-2 gap-200">
+          <div className="border-border-default rounded-100 overflow-hidden border">
+            <div className="border-border-default bg-background-alternative border-b px-150 py-100">
+              <p className="font-designer-13m text-text-subtle">
+                질문 목록 · {lessonQnasQuery.data?.totalCount ?? 0}개
+              </p>
+            </div>
+            <div className="max-h-modal flex flex-col overflow-y-auto">
+              {lessonQnasQuery.isLoading && (
+                <p className="font-designer-14r text-text-subtle p-150">
+                  질문을 불러오는 중입니다.
+                </p>
+              )}
+              {!lessonQnasQuery.isLoading &&
+                (lessonQnasQuery.data?.qnas.length ?? 0) === 0 && (
+                  <p className="font-designer-14r text-text-subtle p-150">
+                    등록된 질문이 없습니다.
+                  </p>
+                )}
+              {lessonQnasQuery.data?.qnas.map((qna: AdminLessonQnaListItem) => (
+                <button
+                  key={qna.qnaId}
+                  disabled={createLessonQnaAnswerMutation.isPending}
+                  type="button"
+                  onClick={() => setSelectedQnaId(qna.qnaId)}
+                  className={cn(
+                    'border-border-default flex flex-col items-start gap-50 border-b px-150 py-125 text-left',
+                    selectedQnaId === qna.qnaId &&
+                      'bg-fill-brand-subtle-default',
+                  )}
+                >
+                  <div className="flex w-full items-center justify-between gap-100">
+                    <span className="font-designer-14m text-text-default">
+                      {qna.title}
+                    </span>
+                    <Badge
+                      color={qna.author.role === 'MANAGER' ? 'orange' : 'blue'}
+                    >
+                      {qna.author.role}
+                    </Badge>
+                  </div>
+                  <p className="font-designer-12r text-text-subtlest">
+                    {qna.author.nickname} · 답변 {qna.answerCount}개 · 조회{' '}
+                    {qna.viewCount} · {formatDateTime(qna.createdAt)}
+                  </p>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="border-border-default rounded-100 border p-150">
+            {qnaDetailQuery.isLoading ? (
+              <p className="font-designer-14r text-text-subtle">
+                질문 상세를 불러오는 중입니다.
+              </p>
+            ) : !qnaDetailQuery.data ? (
+              <p className="font-designer-14r text-text-subtle">
+                왼쪽에서 질문을 선택하세요.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-150">
+                <div>
+                  <div className="flex items-center gap-75">
+                    <h3 className="font-designer-18b text-text-default">
+                      {qnaDetailQuery.data.title}
+                    </h3>
+                    <Badge
+                      color={
+                        qnaDetailQuery.data.author.role === 'MANAGER'
+                          ? 'orange'
+                          : 'blue'
+                      }
+                    >
+                      {qnaDetailQuery.data.author.role}
+                    </Badge>
+                  </div>
+                  <p className="font-designer-12r text-text-subtlest mt-50">
+                    작성자 {qnaDetailQuery.data.author.nickname} · 조회{' '}
+                    {qnaDetailQuery.data.viewCount} ·{' '}
+                    {formatDateTime(qnaDetailQuery.data.createdAt)}
+                  </p>
+                </div>
+                <div className="border-border-subtle rounded-100 border p-125">
+                  <p className="font-designer-14r text-text-default whitespace-pre-wrap">
+                    {qnaDetailQuery.data.content}
+                  </p>
+                  {qnaDetailQuery.data.imageUrls.length > 0 && (
+                    <div className="mt-125 flex flex-col gap-50">
+                      {qnaDetailQuery.data.imageUrls.map((url) => (
+                        <a
+                          key={url}
+                          href={url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="font-designer-13m text-text-brand underline"
+                        >
+                          첨부 이미지 열기
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-col gap-100">
+                  <h4 className="font-designer-16b text-text-default">
+                    답변 {qnaDetailQuery.data.answers.length}개
+                  </h4>
+                  {qnaDetailQuery.data.answers.length === 0 && (
+                    <p className="font-designer-14r text-text-subtle">
+                      아직 등록된 답변이 없습니다.
+                    </p>
+                  )}
+                  {qnaDetailQuery.data.answers.map((answer) => (
+                    <div
+                      key={answer.answerId}
+                      className="border-border-subtle rounded-100 border p-125"
+                    >
+                      <div className="mb-50 flex items-center gap-75">
+                        <Badge
+                          color={
+                            answer.author.role === 'MANAGER' ? 'orange' : 'blue'
+                          }
+                        >
+                          {answer.author.role}
+                        </Badge>
+                        <span className="font-designer-13m text-text-default">
+                          {answer.author.nickname}
+                        </span>
+                        <span className="font-designer-12r text-text-subtlest">
+                          {formatDateTime(answer.createdAt)}
+                        </span>
+                      </div>
+                      <p className="font-designer-14r text-text-default whitespace-pre-wrap">
+                        {answer.content}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+                <div className="flex flex-col gap-100">
+                  <AdminCourseField label="관리자 답변">
+                    <BorderedTextarea
+                      disabled={createLessonQnaAnswerMutation.isPending}
+                      value={qnaAnswerContent}
+                      placeholder="운영자/매니저 답변을 입력하세요."
+                      onChange={(event) =>
+                        setQnaAnswerContent(event.target.value)
+                      }
+                    />
+                  </AdminCourseField>
+                  <div className="flex justify-end">
+                    <Button
+                      size="small"
+                      disabled={createLessonQnaAnswerMutation.isPending}
+                      loading={createLessonQnaAnswerMutation.isPending}
+                      onClick={handleSubmitQnaAnswer}
+                    >
+                      답변 등록
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/admin/courses/admin-lesson-management-sections.tsx
+++ b/src/components/admin/courses/admin-lesson-management-sections.tsx
@@ -1,0 +1,1034 @@
+import Link from 'next/link';
+import type { Dispatch, SetStateAction } from 'react';
+import AdminCourseField from '@/components/admin/courses/admin-course-field';
+import AdminCourseMarkdownField from '@/components/admin/courses/admin-course-markdown-field';
+import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import Badge from '@/components/common/ui/badge';
+import Button from '@/components/common/ui/button';
+import { BaseInput, NativeSelect } from '@/components/common/ui/input';
+import BorderedTextarea from '@/components/common/ui/input/bordered-textarea';
+import type {
+  AdminLessonBuilderFeedsResponse,
+  AdminLessonQnaDetailResponse,
+  AdminLessonQnaListItem,
+  AdminLessonRetrospectiveResponse,
+  AdminLessonSummary,
+  AdminLessonUpsertRequest,
+  AdminRetrospectivePurpose,
+} from '@/features/admin/course-management/model/admin-course-management-contract';
+import {
+  ADMIN_RETROSPECTIVE_PURPOSE_OPTIONS,
+  getAdminRetrospectivePurposeMeta,
+} from '@/features/admin/course-management/model/admin-course-presentation';
+
+const RetrospectivePurposeBadge = ({
+  purpose,
+}: {
+  purpose: AdminRetrospectivePurpose;
+}) => {
+  const meta = getAdminRetrospectivePurposeMeta(purpose);
+
+  return <Badge color={meta.color}>{meta.label}</Badge>;
+};
+
+type FormatDateTime = (value: string) => string;
+
+interface AdminLessonManagementContentProps {
+  allFilteredLessonsSelected: boolean;
+  bulkUpdateLessonsMutationPending: boolean;
+  createLessonMutationPending: boolean;
+  deleteLessonMutationPending: boolean;
+  editingLessonId?: number;
+  effectiveCourseId?: number;
+  filteredLessons: AdminLessonSummary[];
+  handleBulkLessonUpdate: (
+    request: { isPublished?: boolean; isFree?: boolean },
+    confirmMessage: string,
+  ) => void;
+  handleDeleteLesson: (lesson: AdminLessonSummary) => void;
+  handleEditLesson: (lesson: AdminLessonSummary) => void;
+  handleMoveLesson: (lessonId: number, direction: -1 | 1) => void;
+  handleSubmitLesson: () => void;
+  handleToggleLessonSelection: (lessonId: number) => void;
+  handleToggleSelectAllLessons: () => void;
+  isLessonContextLocked: boolean;
+  isLessonDetailHydrating: boolean;
+  isLessonFormLocked: boolean;
+  isLessonListFiltered: boolean;
+  isLessonListInteractionLocked: boolean;
+  lessonAccessFilter: 'ALL' | 'FREE' | 'PAID';
+  lessonDetailQueryIsFetching: boolean;
+  lessonForm: AdminLessonUpsertRequest;
+  lessonFormMode: 'create' | 'edit';
+  lessonPublishedFilter: 'ALL' | 'PUBLISHED' | 'UNPUBLISHED';
+  lessonSearch: string;
+  lessonsQueryIsLoading: boolean;
+  lessonEditorStateKey: string;
+  reorderLessonsMutationPending: boolean;
+  selectedLessonIds: number[];
+  setLessonAccessFilter: (value: 'ALL' | 'FREE' | 'PAID') => void;
+  setLessonForm: Dispatch<SetStateAction<AdminLessonUpsertRequest>>;
+  setLessonPublishedFilter: (
+    value: 'ALL' | 'PUBLISHED' | 'UNPUBLISHED',
+  ) => void;
+  setLessonSearch: (value: string) => void;
+  resetLessonForm: () => void;
+  updateLessonMutationPending: boolean;
+  formatDateTime: FormatDateTime;
+}
+
+export function AdminLessonManagementContent({
+  allFilteredLessonsSelected,
+  bulkUpdateLessonsMutationPending,
+  createLessonMutationPending,
+  deleteLessonMutationPending,
+  editingLessonId,
+  effectiveCourseId,
+  filteredLessons,
+  handleBulkLessonUpdate,
+  handleDeleteLesson,
+  handleEditLesson,
+  handleMoveLesson,
+  handleSubmitLesson,
+  handleToggleLessonSelection,
+  handleToggleSelectAllLessons,
+  isLessonContextLocked,
+  isLessonDetailHydrating,
+  isLessonFormLocked,
+  isLessonListFiltered,
+  isLessonListInteractionLocked,
+  lessonAccessFilter,
+  lessonDetailQueryIsFetching,
+  lessonForm,
+  lessonFormMode,
+  lessonPublishedFilter,
+  lessonSearch,
+  lessonsQueryIsLoading,
+  lessonEditorStateKey,
+  reorderLessonsMutationPending,
+  selectedLessonIds,
+  setLessonAccessFilter,
+  setLessonForm,
+  setLessonPublishedFilter,
+  setLessonSearch,
+  resetLessonForm,
+  updateLessonMutationPending,
+  formatDateTime,
+}: AdminLessonManagementContentProps) {
+  return (
+    <>
+      <div className="mb-150 flex flex-wrap items-end justify-between gap-100">
+        <div className="flex flex-wrap items-end gap-100">
+          <AdminCourseField label="레슨 찾기">
+            <BaseInput
+              size="m"
+              disabled={isLessonListInteractionLocked}
+              value={lessonSearch}
+              placeholder="제목 또는 1-3 같은 순서"
+              onValueChange={setLessonSearch}
+            />
+          </AdminCourseField>
+          <AdminCourseField label="게시 필터">
+            <NativeSelect
+              disabled={isLessonListInteractionLocked}
+              value={lessonPublishedFilter}
+              onChange={(event) =>
+                setLessonPublishedFilter(
+                  event.target.value as 'ALL' | 'PUBLISHED' | 'UNPUBLISHED',
+                )
+              }
+            >
+              <option value="ALL">전체</option>
+              <option value="PUBLISHED">게시만</option>
+              <option value="UNPUBLISHED">비게시만</option>
+            </NativeSelect>
+          </AdminCourseField>
+          <AdminCourseField label="무료/유료 필터">
+            <NativeSelect
+              disabled={isLessonListInteractionLocked}
+              value={lessonAccessFilter}
+              onChange={(event) =>
+                setLessonAccessFilter(
+                  event.target.value as 'ALL' | 'FREE' | 'PAID',
+                )
+              }
+            >
+              <option value="ALL">전체</option>
+              <option value="FREE">무료만</option>
+              <option value="PAID">유료만</option>
+            </NativeSelect>
+          </AdminCourseField>
+        </div>
+        <div className="flex flex-wrap items-center gap-75">
+          <span className="font-designer-13r text-text-subtlest">
+            선택 {selectedLessonIds.length}개 / 필터 결과{' '}
+            {filteredLessons.length}개
+          </span>
+          {isLessonListFiltered && (
+            <span className="font-designer-12r text-text-subtlest">
+              필터 중에는 순서 변경을 잠시 막아둡니다.
+            </span>
+          )}
+          <Button
+            color="outlined"
+            size="xsmall"
+            disabled={
+              selectedLessonIds.length === 0 || isLessonListInteractionLocked
+            }
+            loading={bulkUpdateLessonsMutationPending}
+            onClick={() =>
+              handleBulkLessonUpdate(
+                { isPublished: true },
+                '선택한 레슨을 모두 게시 상태로 바꿀까요?',
+              )
+            }
+          >
+            일괄 게시
+          </Button>
+          <Button
+            color="outlined"
+            size="xsmall"
+            disabled={
+              selectedLessonIds.length === 0 || isLessonListInteractionLocked
+            }
+            loading={bulkUpdateLessonsMutationPending}
+            onClick={() =>
+              handleBulkLessonUpdate(
+                { isPublished: false },
+                '선택한 레슨을 모두 비게시 상태로 바꿀까요?',
+              )
+            }
+          >
+            일괄 비게시
+          </Button>
+          <Button
+            color="outlined"
+            size="xsmall"
+            disabled={
+              selectedLessonIds.length === 0 || isLessonListInteractionLocked
+            }
+            loading={bulkUpdateLessonsMutationPending}
+            onClick={() =>
+              handleBulkLessonUpdate(
+                { isFree: true },
+                '선택한 레슨을 모두 무료로 바꿀까요?',
+              )
+            }
+          >
+            일괄 무료
+          </Button>
+          <Button
+            color="outlined"
+            size="xsmall"
+            disabled={
+              selectedLessonIds.length === 0 || isLessonListInteractionLocked
+            }
+            loading={bulkUpdateLessonsMutationPending}
+            onClick={() =>
+              handleBulkLessonUpdate(
+                { isFree: false },
+                '선택한 레슨을 모두 유료로 바꿀까요?',
+              )
+            }
+          >
+            일괄 유료
+          </Button>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-200">
+        <div className="border-border-default rounded-100 overflow-hidden border">
+          <table className="w-full">
+            <thead className="bg-background-alternative border-border-default border-b">
+              <tr>
+                <th className="py-100 pl-150 text-left">
+                  <input
+                    checked={allFilteredLessonsSelected}
+                    disabled={isLessonListInteractionLocked}
+                    type="checkbox"
+                    onChange={handleToggleSelectAllLessons}
+                  />
+                </th>
+                <th className="font-designer-13m text-text-subtle py-100 pl-150 text-left">
+                  순서
+                </th>
+                <th className="font-designer-13m text-text-subtle py-100 pl-100 text-left">
+                  레슨
+                </th>
+                <th className="font-designer-13m text-text-subtle py-100 pl-100 text-left">
+                  상태
+                </th>
+                <th className="py-100 pr-150" />
+              </tr>
+            </thead>
+            <tbody>
+              {lessonsQueryIsLoading && (
+                <tr>
+                  <td
+                    className="font-designer-14r text-text-subtle py-300 text-center"
+                    colSpan={5}
+                  >
+                    레슨을 불러오는 중입니다.
+                  </td>
+                </tr>
+              )}
+              {!lessonsQueryIsLoading && filteredLessons.length === 0 && (
+                <tr>
+                  <td
+                    className="font-designer-14r text-text-subtle py-300 text-center"
+                    colSpan={5}
+                  >
+                    조건에 맞는 레슨이 없습니다.
+                  </td>
+                </tr>
+              )}
+              {filteredLessons.map((lesson, index) => (
+                <tr
+                  key={lesson.lessonId}
+                  className="border-border-default border-b"
+                >
+                  <td className="py-150 pl-150 align-top">
+                    <input
+                      checked={selectedLessonIds.includes(lesson.lessonId)}
+                      disabled={isLessonListInteractionLocked}
+                      type="checkbox"
+                      onChange={() =>
+                        handleToggleLessonSelection(lesson.lessonId)
+                      }
+                    />
+                  </td>
+                  <td className="font-designer-14r text-text-default py-150 pl-150 align-top">
+                    {lesson.chapterNumber}-{lesson.lessonNumber}
+                  </td>
+                  <td className="py-150 pl-100 align-top">
+                    <div className="flex flex-col gap-50">
+                      <span className="font-designer-14m text-text-default">
+                        {lesson.title}
+                      </span>
+                      <div className="flex flex-wrap gap-50">
+                        <RetrospectivePurposeBadge
+                          purpose={lesson.retrospectivePurpose}
+                        />
+                        <Badge color={lesson.isPublished ? 'green' : 'gray'}>
+                          {lesson.isPublished ? '게시' : '비게시'}
+                        </Badge>
+                        <Badge color={lesson.isFree ? 'blue' : 'gray'}>
+                          {lesson.isFree ? '무료' : '유료'}
+                        </Badge>
+                      </div>
+                      <span className="font-designer-13r text-text-subtlest">
+                        회고 {lesson.retrospectiveCount}개 · 수정{' '}
+                        {formatDateTime(lesson.updatedAt)}
+                      </span>
+                    </div>
+                  </td>
+                  <td className="py-150 pl-100 align-top">
+                    <p className="font-designer-12r text-text-subtlest">
+                      {
+                        getAdminRetrospectivePurposeMeta(
+                          lesson.retrospectivePurpose,
+                        ).helper
+                      }
+                    </p>
+                  </td>
+                  <td className="py-150 pr-150 align-top">
+                    <div className="flex justify-end gap-50">
+                      <Button
+                        color="secondary"
+                        size="xsmall"
+                        disabled={
+                          isLessonListFiltered ||
+                          index === 0 ||
+                          isLessonListInteractionLocked
+                        }
+                        loading={reorderLessonsMutationPending}
+                        onClick={() => handleMoveLesson(lesson.lessonId, -1)}
+                      >
+                        위
+                      </Button>
+                      <Button
+                        color="secondary"
+                        size="xsmall"
+                        disabled={
+                          isLessonListFiltered ||
+                          index === filteredLessons.length - 1 ||
+                          isLessonListInteractionLocked
+                        }
+                        loading={reorderLessonsMutationPending}
+                        onClick={() => handleMoveLesson(lesson.lessonId, 1)}
+                      >
+                        아래
+                      </Button>
+                      <Button
+                        color="secondary"
+                        size="xsmall"
+                        disabled={isLessonContextLocked}
+                        onClick={() => handleEditLesson(lesson)}
+                      >
+                        수정
+                      </Button>
+                      <Link
+                        className={cn(
+                          isLessonContextLocked &&
+                            'pointer-events-none opacity-60',
+                        )}
+                        href={`/admin/courses/lessons/${lesson.lessonId}`}
+                      >
+                        <Button
+                          color="secondary"
+                          size="xsmall"
+                          disabled={isLessonContextLocked}
+                        >
+                          상세
+                        </Button>
+                      </Link>
+                      <Button
+                        color="outlined"
+                        size="xsmall"
+                        disabled={isLessonListInteractionLocked}
+                        loading={deleteLessonMutationPending}
+                        onClick={() => handleDeleteLesson(lesson)}
+                      >
+                        삭제
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div>
+          <div className="mb-150 flex items-center justify-between gap-100">
+            <div>
+              <h3 className="font-designer-18b text-text-default">
+                {lessonFormMode === 'create' ? '레슨 생성' : '레슨 수정'}
+              </h3>
+              {lessonFormMode === 'edit' && editingLessonId && (
+                <p className="font-designer-12r text-text-subtlest mt-25">
+                  {isLessonDetailHydrating
+                    ? '레슨 상세를 불러오는 중이라 잠시 입력이 잠겨 있습니다.'
+                    : '레슨 상세를 불러와 본문/돌아보기 목적까지 함께 수정합니다.'}
+                </p>
+              )}
+            </div>
+            <Button
+              color="outlined"
+              size="xsmall"
+              disabled={isLessonContextLocked}
+              onClick={resetLessonForm}
+            >
+              새 레슨 입력
+            </Button>
+          </div>
+          <div className="grid grid-cols-3 gap-150">
+            <AdminCourseField label="챕터">
+              <BaseInput
+                size="m"
+                type="number"
+                min={1}
+                disabled={isLessonFormLocked}
+                value={String(lessonForm.chapterNumber)}
+                onValueChange={(chapterNumber) =>
+                  setLessonForm((prev) => ({
+                    ...prev,
+                    chapterNumber: Number(chapterNumber),
+                  }))
+                }
+              />
+            </AdminCourseField>
+            <AdminCourseField label="레슨">
+              <BaseInput
+                size="m"
+                type="number"
+                min={1}
+                disabled={isLessonFormLocked}
+                value={String(lessonForm.lessonNumber)}
+                onValueChange={(lessonNumber) =>
+                  setLessonForm((prev) => ({
+                    ...prev,
+                    lessonNumber: Number(lessonNumber),
+                  }))
+                }
+              />
+            </AdminCourseField>
+            <AdminCourseField label="예상 시간(분)">
+              <BaseInput
+                size="m"
+                type="number"
+                min={1}
+                disabled={isLessonFormLocked}
+                value={String(lessonForm.estimatedMinutes)}
+                onValueChange={(estimatedMinutes) =>
+                  setLessonForm((prev) => ({
+                    ...prev,
+                    estimatedMinutes: Number(estimatedMinutes),
+                  }))
+                }
+              />
+            </AdminCourseField>
+          </div>
+          <div className="mt-150 flex flex-col gap-150">
+            <AdminCourseField label="레슨 제목">
+              <BaseInput
+                size="m"
+                disabled={isLessonFormLocked}
+                value={lessonForm.title}
+                placeholder="1일차 오리엔테이션"
+                onValueChange={(title) =>
+                  setLessonForm((prev) => ({ ...prev, title }))
+                }
+              />
+            </AdminCourseField>
+            <AdminCourseField
+              label="돌아보기 목적"
+              helper={
+                getAdminRetrospectivePurposeMeta(
+                  lessonForm.retrospectivePurpose,
+                ).helper
+              }
+            >
+              <NativeSelect
+                disabled={isLessonFormLocked}
+                value={lessonForm.retrospectivePurpose}
+                onChange={(event) =>
+                  setLessonForm((prev) => ({
+                    ...prev,
+                    retrospectivePurpose: event.target
+                      .value as AdminRetrospectivePurpose,
+                  }))
+                }
+              >
+                {ADMIN_RETROSPECTIVE_PURPOSE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </NativeSelect>
+            </AdminCourseField>
+            <div className="grid grid-cols-2 gap-150">
+              <AdminCourseField label="무료 공개">
+                <NativeSelect
+                  disabled={isLessonFormLocked}
+                  value={lessonForm.isFree ? 'true' : 'false'}
+                  onChange={(event) =>
+                    setLessonForm((prev) => ({
+                      ...prev,
+                      isFree: event.target.value === 'true',
+                    }))
+                  }
+                >
+                  <option value="false">유료 레슨</option>
+                  <option value="true">무료 레슨</option>
+                </NativeSelect>
+              </AdminCourseField>
+              <AdminCourseField label="게시 상태">
+                <NativeSelect
+                  disabled={isLessonFormLocked}
+                  value={lessonForm.isPublished ? 'true' : 'false'}
+                  onChange={(event) =>
+                    setLessonForm((prev) => ({
+                      ...prev,
+                      isPublished: event.target.value === 'true',
+                    }))
+                  }
+                >
+                  <option value="false">비게시</option>
+                  <option value="true">게시</option>
+                </NativeSelect>
+              </AdminCourseField>
+            </div>
+            <AdminCourseMarkdownField
+              editorStateKey={lessonEditorStateKey}
+              value={lessonForm.content}
+              helper="긴 레슨 본문은 마크다운/리치 텍스트 에디터로 작성합니다. 저장 값은 그대로 public 레슨 상세에 노출됩니다."
+              isHydrating={isLessonFormLocked}
+              hydratingText={
+                createLessonMutationPending
+                  ? '레슨 저장 중입니다.'
+                  : '레슨 본문을 불러오는 중입니다.'
+              }
+              placeholder="레슨 본문을 작성하세요. 마크다운/이미지 붙여넣기, 드래그 앤 드롭, 코드블록, 제목을 사용할 수 있습니다."
+              onChange={(content) =>
+                setLessonForm((prev) => ({
+                  ...prev,
+                  content,
+                }))
+              }
+            />
+          </div>
+          <div className="mt-150 flex justify-end gap-75">
+            <Button
+              color="outlined"
+              size="small"
+              disabled={isLessonContextLocked}
+              onClick={resetLessonForm}
+            >
+              초기화
+            </Button>
+            <Button
+              size="small"
+              disabled={!effectiveCourseId || isLessonFormLocked}
+              loading={
+                lessonDetailQueryIsFetching ||
+                createLessonMutationPending ||
+                updateLessonMutationPending
+              }
+              onClick={handleSubmitLesson}
+            >
+              {lessonFormMode === 'create' ? '레슨 생성' : '레슨 저장'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+interface AdminLessonRetrospectivesContentProps {
+  editingLessonId?: number;
+  lessonRetrospectives?: AdminLessonRetrospectiveResponse['retrospectives'];
+  lessonRetrospectivesLoading: boolean;
+  formatDateTime: FormatDateTime;
+}
+
+export function AdminLessonRetrospectivesContent({
+  editingLessonId,
+  lessonRetrospectives,
+  lessonRetrospectivesLoading,
+  formatDateTime,
+}: AdminLessonRetrospectivesContentProps) {
+  if (!editingLessonId) {
+    return (
+      <p className="font-designer-14r text-text-subtle">
+        현재 선택된 레슨이 없습니다. 레슨 목록에서 수정 버튼을 눌러 제출 내역을
+        확인하세요.
+      </p>
+    );
+  }
+
+  if (lessonRetrospectivesLoading) {
+    return (
+      <p className="font-designer-14r text-text-subtle">
+        돌아보기 제출 목록을 불러오는 중입니다.
+      </p>
+    );
+  }
+
+  if ((lessonRetrospectives?.length ?? 0) === 0) {
+    return (
+      <p className="font-designer-14r text-text-subtle">
+        아직 제출된 돌아보기가 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid gap-125">
+      {lessonRetrospectives?.map((retro) => (
+        <article
+          key={retro.retrospectiveId}
+          className="border-border-default rounded-100 border p-150"
+        >
+          <div className="mb-75 flex flex-wrap items-center gap-75">
+            <Badge
+              color={retro.purpose === 'SUBJECTIVE_QUIZ' ? 'orange' : 'blue'}
+            >
+              {getAdminRetrospectivePurposeMeta(retro.purpose).label}
+            </Badge>
+            <Badge color="green">이해도 {retro.understandingScore}/5</Badge>
+            {retro.artifactType && (
+              <Badge color="gray">{retro.artifactType}</Badge>
+            )}
+            <span className="font-designer-12r text-text-subtlest">
+              {retro.nickname} · member {retro.memberId} ·{' '}
+              {formatDateTime(retro.createdAt)}
+            </span>
+          </div>
+          {retro.artifactValue && (
+            <p className="font-designer-13r text-text-brand mb-75 break-all underline">
+              {retro.artifactValue}
+            </p>
+          )}
+          <p className="font-designer-14r text-text-default whitespace-pre-wrap">
+            {retro.content}
+          </p>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+interface AdminLessonBuilderFeedContentProps {
+  editingLessonId?: number;
+  feeds?: AdminLessonBuilderFeedsResponse['feeds'];
+  isAwaitingBuilderFeedRefresh: boolean;
+  isLoading: boolean;
+  builderFeedOrderDrafts: Record<number, string>;
+  setBuilderFeedOrderDrafts: Dispatch<SetStateAction<Record<number, string>>>;
+  handleToggleBuilderFeedCuration: (args: {
+    feedId: number;
+    currentOperatorPick: boolean;
+    currentFeatured: boolean;
+    nextOperatorPick?: boolean;
+    nextFeatured?: boolean;
+  }) => void;
+  formatDateTime: FormatDateTime;
+}
+
+export function AdminLessonBuilderFeedContent({
+  editingLessonId,
+  feeds,
+  isAwaitingBuilderFeedRefresh,
+  isLoading,
+  builderFeedOrderDrafts,
+  setBuilderFeedOrderDrafts,
+  handleToggleBuilderFeedCuration,
+  formatDateTime,
+}: AdminLessonBuilderFeedContentProps) {
+  if (!editingLessonId) {
+    return (
+      <p className="font-designer-14r text-text-subtle">
+        현재 선택된 레슨이 없습니다. 레슨 목록에서 수정 버튼을 눌러 Builder Feed
+        운영 대상을 선택하세요.
+      </p>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <p className="font-designer-14r text-text-subtle">
+        Builder Feed 목록을 불러오는 중입니다.
+      </p>
+    );
+  }
+
+  if ((feeds?.length ?? 0) === 0) {
+    return (
+      <p className="font-designer-14r text-text-subtle">
+        아직 이 레슨에 연결된 Builder Feed가 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid gap-125">
+      {feeds?.map((feed) => (
+        <article
+          key={feed.feedId}
+          className="border-border-default rounded-100 border p-150"
+        >
+          <div className="mb-100 flex flex-wrap items-center gap-75">
+            <Badge color={feed.role === 'MANAGER' ? 'orange' : 'blue'}>
+              {feed.role}
+            </Badge>
+            <Badge color={feed.operatorPick ? 'green' : 'gray'}>
+              {feed.operatorPick ? 'Operator Pick ON' : 'Operator Pick OFF'}
+            </Badge>
+            <Badge color={feed.featured ? 'green' : 'gray'}>
+              {feed.featured
+                ? `Showcase ON #${feed.featuredOrder ?? '-'}`
+                : 'Showcase OFF'}
+            </Badge>
+            <span className="font-designer-12r text-text-subtlest">
+              {feed.nickname} · member {feed.memberId} · 좋아요 {feed.likeCount}{' '}
+              · 댓글 {feed.commentCount} · {formatDateTime(feed.createdAt)}
+            </span>
+          </div>
+
+          <p className="font-designer-14r text-text-default whitespace-pre-wrap">
+            {feed.content}
+          </p>
+
+          {feed.imageUrls.length > 0 && (
+            <div className="mt-100 flex flex-col gap-50">
+              {feed.imageUrls.map((url) => (
+                <a
+                  key={url}
+                  href={url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-designer-13m text-text-brand underline"
+                >
+                  이미지 열기
+                </a>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-125 flex flex-wrap items-end gap-100">
+            <Button
+              color={feed.operatorPick ? 'secondary' : 'outlined'}
+              size="xsmall"
+              disabled={isAwaitingBuilderFeedRefresh}
+              loading={isAwaitingBuilderFeedRefresh}
+              onClick={() =>
+                handleToggleBuilderFeedCuration({
+                  feedId: feed.feedId,
+                  currentOperatorPick: feed.operatorPick,
+                  currentFeatured: feed.featured,
+                  nextOperatorPick: !feed.operatorPick,
+                })
+              }
+            >
+              {feed.operatorPick ? 'operator pick 해제' : 'operator pick 지정'}
+            </Button>
+            <Button
+              color={feed.featured ? 'secondary' : 'outlined'}
+              size="xsmall"
+              disabled={isAwaitingBuilderFeedRefresh}
+              loading={isAwaitingBuilderFeedRefresh}
+              onClick={() =>
+                handleToggleBuilderFeedCuration({
+                  feedId: feed.feedId,
+                  currentOperatorPick: feed.operatorPick,
+                  currentFeatured: feed.featured,
+                  nextFeatured: !feed.featured,
+                })
+              }
+            >
+              {feed.featured ? 'showcase 해제' : 'showcase 지정'}
+            </Button>
+            <label className="flex items-center gap-75">
+              <span className="font-designer-12r text-text-subtle">
+                showcase 순서
+              </span>
+              <BaseInput
+                size="m"
+                type="number"
+                min={1}
+                disabled={isAwaitingBuilderFeedRefresh}
+                value={builderFeedOrderDrafts[feed.feedId] ?? ''}
+                onValueChange={(value) =>
+                  setBuilderFeedOrderDrafts((prev) => ({
+                    ...prev,
+                    [feed.feedId]: value,
+                  }))
+                }
+              />
+            </label>
+            <Button
+              color="secondary"
+              size="xsmall"
+              disabled={!feed.featured || isAwaitingBuilderFeedRefresh}
+              loading={isAwaitingBuilderFeedRefresh}
+              onClick={() =>
+                handleToggleBuilderFeedCuration({
+                  feedId: feed.feedId,
+                  currentOperatorPick: feed.operatorPick,
+                  currentFeatured: feed.featured,
+                  nextFeatured: true,
+                })
+              }
+            >
+              순서 저장
+            </Button>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+interface AdminLessonQnaContentProps {
+  qnaCount: number;
+  qnas?: AdminLessonQnaListItem[];
+  selectedQna?: AdminLessonQnaDetailResponse;
+  selectedQnaId?: number;
+  qnaAnswerContent: string;
+  qnaDetailLoading: boolean;
+  qnaListLoading: boolean;
+  answerMutationPending: boolean;
+  editingLessonId?: number;
+  setQnaAnswerContent: (value: string) => void;
+  setSelectedQnaId: (value: number) => void;
+  handleSubmitQnaAnswer: () => void;
+  formatDateTime: FormatDateTime;
+}
+
+export function AdminLessonQnaContent({
+  qnaCount,
+  qnas,
+  selectedQna,
+  selectedQnaId,
+  qnaAnswerContent,
+  qnaDetailLoading,
+  qnaListLoading,
+  answerMutationPending,
+  editingLessonId,
+  setQnaAnswerContent,
+  setSelectedQnaId,
+  handleSubmitQnaAnswer,
+  formatDateTime,
+}: AdminLessonQnaContentProps) {
+  if (!editingLessonId) {
+    return (
+      <p className="font-designer-14r text-text-subtle">
+        현재 선택된 레슨이 없습니다. 레슨 목록에서 수정 버튼을 눌러 QnA 관리
+        대상을 선택하세요.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-200">
+      <div className="border-border-default rounded-100 overflow-hidden border">
+        <div className="border-border-default bg-background-alternative border-b px-150 py-100">
+          <p className="font-designer-13m text-text-subtle">
+            질문 목록 · {qnaCount}개
+          </p>
+        </div>
+        <div className="max-h-modal flex flex-col overflow-y-auto">
+          {qnaListLoading && (
+            <p className="font-designer-14r text-text-subtle p-150">
+              질문을 불러오는 중입니다.
+            </p>
+          )}
+          {!qnaListLoading && (qnas?.length ?? 0) === 0 && (
+            <p className="font-designer-14r text-text-subtle p-150">
+              등록된 질문이 없습니다.
+            </p>
+          )}
+          {qnas?.map((qna) => (
+            <button
+              key={qna.qnaId}
+              disabled={answerMutationPending}
+              type="button"
+              onClick={() => setSelectedQnaId(qna.qnaId)}
+              className={cn(
+                'border-border-default flex flex-col items-start gap-50 border-b px-150 py-125 text-left',
+                selectedQnaId === qna.qnaId && 'bg-fill-brand-subtle-default',
+              )}
+            >
+              <div className="flex w-full items-center justify-between gap-100">
+                <span className="font-designer-14m text-text-default">
+                  {qna.title}
+                </span>
+                <Badge
+                  color={qna.author.role === 'MANAGER' ? 'orange' : 'blue'}
+                >
+                  {qna.author.role}
+                </Badge>
+              </div>
+              <p className="font-designer-12r text-text-subtlest">
+                {qna.author.nickname} · 답변 {qna.answerCount}개 · 조회{' '}
+                {qna.viewCount} · {formatDateTime(qna.createdAt)}
+              </p>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="border-border-default rounded-100 border p-150">
+        {qnaDetailLoading ? (
+          <p className="font-designer-14r text-text-subtle">
+            질문 상세를 불러오는 중입니다.
+          </p>
+        ) : !selectedQna ? (
+          <p className="font-designer-14r text-text-subtle">
+            왼쪽에서 질문을 선택하세요.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-150">
+            <div>
+              <div className="flex items-center gap-75">
+                <h3 className="font-designer-18b text-text-default">
+                  {selectedQna.title}
+                </h3>
+                <Badge
+                  color={
+                    selectedQna.author.role === 'MANAGER' ? 'orange' : 'blue'
+                  }
+                >
+                  {selectedQna.author.role}
+                </Badge>
+              </div>
+              <p className="font-designer-12r text-text-subtlest mt-50">
+                작성자 {selectedQna.author.nickname} · 조회{' '}
+                {selectedQna.viewCount} ·{' '}
+                {formatDateTime(selectedQna.createdAt)}
+              </p>
+            </div>
+            <div className="border-border-subtle rounded-100 border p-125">
+              <p className="font-designer-14r text-text-default whitespace-pre-wrap">
+                {selectedQna.content}
+              </p>
+              {selectedQna.imageUrls.length > 0 && (
+                <div className="mt-125 flex flex-col gap-50">
+                  {selectedQna.imageUrls.map((url) => (
+                    <a
+                      key={url}
+                      href={url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-designer-13m text-text-brand underline"
+                    >
+                      첨부 이미지 열기
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-100">
+              <h4 className="font-designer-16b text-text-default">
+                답변 {selectedQna.answers.length}개
+              </h4>
+              {selectedQna.answers.length === 0 && (
+                <p className="font-designer-14r text-text-subtle">
+                  아직 등록된 답변이 없습니다.
+                </p>
+              )}
+              {selectedQna.answers.map((answer) => (
+                <div
+                  key={answer.answerId}
+                  className="border-border-subtle rounded-100 border p-125"
+                >
+                  <div className="mb-50 flex items-center gap-75">
+                    <Badge
+                      color={
+                        answer.author.role === 'MANAGER' ? 'orange' : 'blue'
+                      }
+                    >
+                      {answer.author.role}
+                    </Badge>
+                    <span className="font-designer-13m text-text-default">
+                      {answer.author.nickname}
+                    </span>
+                    <span className="font-designer-12r text-text-subtlest">
+                      {formatDateTime(answer.createdAt)}
+                    </span>
+                  </div>
+                  <p className="font-designer-14r text-text-default whitespace-pre-wrap">
+                    {answer.content}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <div className="flex flex-col gap-100">
+              <AdminCourseField label="관리자 답변">
+                <BorderedTextarea
+                  disabled={answerMutationPending}
+                  value={qnaAnswerContent}
+                  placeholder="운영자/매니저 답변을 입력하세요."
+                  onChange={(event) => setQnaAnswerContent(event.target.value)}
+                />
+              </AdminCourseField>
+              <div className="flex justify-end">
+                <Button
+                  size="small"
+                  disabled={answerMutationPending}
+                  loading={answerMutationPending}
+                  onClick={handleSubmitQnaAnswer}
+                >
+                  답변 등록
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/layout/sidebar/admin-sidebar.tsx
+++ b/src/components/common/layout/sidebar/admin-sidebar.tsx
@@ -16,6 +16,7 @@ export default function AdminSideBar() {
   const isSalesManagementPath = pathname.startsWith('/admin/sales-management');
   const isMentoringManagementPath = pathname.startsWith('/admin/mentoring');
   const isMatchingManagementPath = pathname.startsWith('/admin/matching');
+  const isCourseManagementPath = pathname.startsWith('/admin/courses');
 
   return (
     <aside className="border-border-subtle h-screen w-fit border-r p-200">
@@ -30,7 +31,7 @@ export default function AdminSideBar() {
           />
         )}
 
-        <div className="w-[136px]">
+        <div className="min-w-0 flex-1">
           <p className="font-designer-14m text-text-default">
             {profile?.memberProfile.memberName}
           </p>
@@ -41,9 +42,13 @@ export default function AdminSideBar() {
         </Link>
       </div>
 
-      <nav className="mt-200 flex w-[188px] flex-col gap-100">
+      <nav className="mt-200 flex min-w-0 flex-col gap-100">
         <Link href="/admin">
           <TabMenu active={pathname === '/admin'}>사용자 관리</TabMenu>
+        </Link>
+
+        <Link href="/admin/courses">
+          <TabMenu active={isCourseManagementPath}>클래스 관리</TabMenu>
         </Link>
 
         <Link href="/admin/sales-management/payment-refund">

--- a/src/features/admin/course-management/api/admin-course-management-api.ts
+++ b/src/features/admin/course-management/api/admin-course-management-api.ts
@@ -1,0 +1,251 @@
+import { axiosInstance } from '@/api/client/axios';
+import type {
+  AdminBuilderFeedCurationRequest,
+  AdminCompletionMessageRequest,
+  AdminCompletionMessageResponse,
+  AdminCourseCreateResponse,
+  AdminCourseDeleteResponse,
+  AdminCourseListParams,
+  AdminCourseSummary,
+  AdminCourseUpdateRequest,
+  AdminCourseUpsertRequest,
+  AdminLessonBulkUpdateRequest,
+  AdminLessonCreateResponse,
+  AdminLessonDeleteResponse,
+  AdminLessonBuilderFeedsResponse,
+  AdminLessonQnaAnswerCreateResponse,
+  AdminLessonQnaDetailResponse,
+  AdminLessonQnaListResponse,
+  AdminLessonRetrospectiveResponse,
+  AdminLessonDetailResponse,
+  AdminLessonOrderRequest,
+  AdminLessonSummary,
+  AdminLessonUpdateRequest,
+  AdminLessonUpsertRequest,
+  ApiBaseResponse,
+  ApiPageResponse,
+} from '@/features/admin/course-management/model/admin-course-management-contract';
+
+const unwrap = <T>(response: { data: ApiBaseResponse<T> }) =>
+  response.data.content;
+
+export const getAdminCourses = async ({
+  status,
+  page,
+  size,
+}: AdminCourseListParams): Promise<ApiPageResponse<AdminCourseSummary>> => {
+  const response = await axiosInstance.get<
+    ApiBaseResponse<ApiPageResponse<AdminCourseSummary>>
+  >('/admin/courses', {
+    params: { status, page, size },
+  });
+
+  return unwrap(response);
+};
+
+export const createAdminCourse = async (
+  request: AdminCourseUpsertRequest,
+): Promise<AdminCourseCreateResponse> => {
+  const response = await axiosInstance.post<
+    ApiBaseResponse<AdminCourseCreateResponse>
+  >('/admin/courses', request);
+
+  return unwrap(response);
+};
+
+export const updateAdminCourse = async ({
+  courseId,
+  request,
+}: {
+  courseId: number;
+  request: AdminCourseUpdateRequest;
+}): Promise<void> => {
+  await axiosInstance.put<ApiBaseResponse<void>>(
+    `/admin/courses/${courseId}`,
+    request,
+  );
+};
+
+export const deleteAdminCourse = async (
+  courseId: number,
+): Promise<AdminCourseDeleteResponse> => {
+  const response = await axiosInstance.delete<
+    ApiBaseResponse<AdminCourseDeleteResponse>
+  >(`/admin/courses/${courseId}`);
+
+  return unwrap(response);
+};
+
+export const getAdminCourseLessons = async (
+  courseId: number,
+): Promise<AdminLessonSummary[]> => {
+  const response = await axiosInstance.get<
+    ApiBaseResponse<AdminLessonSummary[]>
+  >(`/admin/courses/${courseId}/lessons`);
+
+  return unwrap(response);
+};
+
+export const getAdminLessonDetail = async (
+  lessonId: number,
+): Promise<AdminLessonDetailResponse> => {
+  const response = await axiosInstance.get<
+    ApiBaseResponse<AdminLessonDetailResponse>
+  >(`/admin/lessons/${lessonId}`);
+
+  return unwrap(response);
+};
+
+export const createAdminLesson = async ({
+  courseId,
+  request,
+}: {
+  courseId: number;
+  request: AdminLessonUpsertRequest;
+}): Promise<AdminLessonCreateResponse> => {
+  const response = await axiosInstance.post<
+    ApiBaseResponse<AdminLessonCreateResponse>
+  >(`/admin/courses/${courseId}/lessons`, request);
+
+  return unwrap(response);
+};
+
+export const updateAdminLesson = async ({
+  lessonId,
+  request,
+}: {
+  lessonId: number;
+  request: AdminLessonUpdateRequest;
+}): Promise<void> => {
+  await axiosInstance.put<ApiBaseResponse<void>>(
+    `/admin/lessons/${lessonId}`,
+    request,
+  );
+};
+
+export const deleteAdminLesson = async (
+  lessonId: number,
+): Promise<AdminLessonDeleteResponse> => {
+  const response = await axiosInstance.delete<
+    ApiBaseResponse<AdminLessonDeleteResponse>
+  >(`/admin/lessons/${lessonId}`);
+
+  return unwrap(response);
+};
+
+export const bulkUpdateAdminLessons = async ({
+  courseId,
+  request,
+}: {
+  courseId: number;
+  request: AdminLessonBulkUpdateRequest;
+}): Promise<void> => {
+  await axiosInstance.patch<ApiBaseResponse<void>>(
+    `/admin/courses/${courseId}/lessons/bulk`,
+    request,
+  );
+};
+
+export const reorderAdminLessons = async ({
+  courseId,
+  request,
+}: {
+  courseId: number;
+  request: AdminLessonOrderRequest;
+}): Promise<void> => {
+  await axiosInstance.patch<ApiBaseResponse<void>>(
+    `/admin/courses/${courseId}/lessons/order`,
+    request,
+  );
+};
+
+export const getAdminCompletionMessage = async (
+  courseId: number,
+): Promise<AdminCompletionMessageResponse> => {
+  const response = await axiosInstance.get<
+    ApiBaseResponse<AdminCompletionMessageResponse>
+  >(`/admin/courses/${courseId}/completion-message`);
+
+  return unwrap(response);
+};
+
+export const upsertAdminCompletionMessage = async ({
+  courseId,
+  request,
+}: {
+  courseId: number;
+  request: AdminCompletionMessageRequest;
+}): Promise<AdminCompletionMessageResponse> => {
+  const response = await axiosInstance.put<
+    ApiBaseResponse<AdminCompletionMessageResponse>
+  >(`/admin/courses/${courseId}/completion-message`, request);
+
+  return unwrap(response);
+};
+
+export const getAdminLessonQnas = async (
+  lessonId: number,
+): Promise<AdminLessonQnaListResponse> => {
+  const response = await axiosInstance.get<
+    ApiBaseResponse<AdminLessonQnaListResponse>
+  >(`/admin/lessons/${lessonId}/qnas`);
+
+  return unwrap(response);
+};
+
+export const getAdminLessonQnaDetail = async (
+  qnaId: number,
+): Promise<AdminLessonQnaDetailResponse> => {
+  const response = await axiosInstance.get<
+    ApiBaseResponse<AdminLessonQnaDetailResponse>
+  >(`/admin/qnas/${qnaId}`);
+
+  return unwrap(response);
+};
+
+export const createAdminLessonQnaAnswer = async ({
+  qnaId,
+  content,
+}: {
+  qnaId: number;
+  content: string;
+}): Promise<AdminLessonQnaAnswerCreateResponse> => {
+  const response = await axiosInstance.post<
+    ApiBaseResponse<AdminLessonQnaAnswerCreateResponse>
+  >(`/admin/qnas/${qnaId}/answers`, { content });
+
+  return unwrap(response);
+};
+
+export const getAdminLessonRetrospectives = async (
+  lessonId: number,
+): Promise<AdminLessonRetrospectiveResponse> => {
+  const response = await axiosInstance.get<
+    ApiBaseResponse<AdminLessonRetrospectiveResponse>
+  >(`/admin/lessons/${lessonId}/retrospectives`);
+
+  return unwrap(response);
+};
+
+export const getAdminLessonBuilderFeeds = async (
+  lessonId: number,
+): Promise<AdminLessonBuilderFeedsResponse> => {
+  const response = await axiosInstance.get<
+    ApiBaseResponse<AdminLessonBuilderFeedsResponse>
+  >(`/admin/lessons/${lessonId}/builder-feeds`);
+
+  return unwrap(response);
+};
+
+export const updateAdminBuilderFeedCuration = async ({
+  feedId,
+  request,
+}: {
+  feedId: number;
+  request: AdminBuilderFeedCurationRequest;
+}): Promise<void> => {
+  await axiosInstance.patch<ApiBaseResponse<void>>(
+    `/admin/builder-feeds/${feedId}/curation`,
+    request,
+  );
+};

--- a/src/features/admin/course-management/model/admin-course-image-upload.ts
+++ b/src/features/admin/course-management/model/admin-course-image-upload.ts
@@ -1,0 +1,9 @@
+import { uploadCommunityMarkdownImage } from '@/features/community/model/community-markdown-image-upload';
+
+/**
+ * 클래스 어드민은 아직 전용 이미지 업로드 티켓 API가 없어
+ * 검증된 기존 업로드 인프라를 재사용한다.
+ */
+export const uploadAdminCourseImage = async (file: File): Promise<string> => {
+  return uploadCommunityMarkdownImage(file);
+};

--- a/src/features/admin/course-management/model/admin-course-management-contract.ts
+++ b/src/features/admin/course-management/model/admin-course-management-contract.ts
@@ -1,0 +1,239 @@
+export type AdminCourseStatus = 'OPEN' | 'COMING_SOON' | 'HIDDEN';
+export type AdminRetrospectivePurpose =
+  | 'PRACTICE_PROOF'
+  | 'ARTIFACT_SHARE'
+  | 'SUBJECTIVE_QUIZ';
+
+export interface ApiBaseResponse<T> {
+  statusCode: number;
+  timestamp: string;
+  content: T;
+  message: string;
+}
+
+export interface ApiPageResponse<T> {
+  content: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+}
+
+export interface AdminCourseSummary {
+  courseId: number;
+  slug: string;
+  title: string;
+  status: AdminCourseStatus;
+  lessonCount: number;
+  enrolledCount: number;
+  updatedAt: string | null;
+}
+
+export interface AdminCourseUpsertRequest {
+  slug: string;
+  title: string;
+  cardHeadline: string;
+  cardSummary: string;
+  cardTags: string[];
+  regularPrice?: number;
+  discountPrice?: number;
+  description: string;
+  thumbnailUrl: string;
+  status: AdminCourseStatus;
+  durationDays?: number;
+  earlyBirdEndsAt: string | null;
+}
+
+export type AdminCourseUpdateRequest = Partial<AdminCourseUpsertRequest>;
+
+export interface AdminCourseFormValues {
+  slug: string;
+  title: string;
+  cardHeadline: string;
+  cardSummary: string;
+  cardTags: string;
+  regularPrice: string;
+  discountPrice: string;
+  description: string;
+  thumbnailUrl: string;
+  status: AdminCourseStatus;
+  durationDays: string;
+  earlyBirdEndsAt: string | null;
+}
+
+export interface AdminCourseCreateResponse {
+  courseId: number;
+}
+
+export interface AdminCourseDeleteResponse {
+  deleted: boolean;
+  reason: string | null;
+  status: AdminCourseStatus | null;
+}
+
+export interface AdminLessonSummary {
+  lessonId: number;
+  chapterNumber: number;
+  lessonNumber: number;
+  title: string;
+  retrospectivePurpose: AdminRetrospectivePurpose;
+  isFree: boolean;
+  isPublished: boolean;
+  retrospectiveCount: number;
+  updatedAt: string | null;
+}
+
+export interface AdminLessonDetailResponse {
+  lessonId: number;
+  chapterNumber: number;
+  lessonNumber: number;
+  title: string;
+  content: string;
+  estimatedMinutes: number;
+  retrospectivePurpose: AdminRetrospectivePurpose;
+  isFree: boolean;
+  isPublished: boolean;
+}
+
+export interface AdminLessonUpsertRequest {
+  chapterNumber: number;
+  lessonNumber: number;
+  title: string;
+  content: string;
+  estimatedMinutes: number;
+  retrospectivePurpose: AdminRetrospectivePurpose;
+  isFree: boolean;
+  isPublished: boolean;
+}
+
+export type AdminLessonUpdateRequest = Partial<AdminLessonUpsertRequest>;
+
+export interface AdminLessonCreateResponse {
+  lessonId: number;
+}
+
+export interface AdminLessonDeleteResponse {
+  deleted: boolean;
+  reason: string | null;
+  isPublished: boolean | null;
+}
+
+export interface AdminLessonOrderRequest {
+  orderedLessonIds: number[];
+}
+
+export interface AdminCompletionMessageResponse {
+  courseId: number;
+  message: string | null;
+  updatedAt: string | null;
+}
+
+export interface AdminCompletionMessageRequest {
+  message: string;
+}
+
+export interface AdminCourseListParams {
+  status?: AdminCourseStatus;
+  page: number;
+  size: number;
+}
+
+export interface AdminLessonQnaListItem {
+  qnaId: number;
+  title: string;
+  author: {
+    memberId: number;
+    nickname: string;
+    role: 'BUILDER' | 'MANAGER';
+  };
+  viewCount: number;
+  answerCount: number;
+  isMyQuestion: boolean;
+  createdAt: string;
+}
+
+export interface AdminLessonQnaListResponse {
+  myQnas: Array<{
+    qnaId: number;
+    title: string;
+    answerCount: number;
+    createdAt: string;
+  }>;
+  qnas: AdminLessonQnaListItem[];
+  totalCount: number;
+}
+
+export interface AdminLessonQnaDetailResponse {
+  qnaId: number;
+  lessonId: number;
+  title: string;
+  content: string;
+  imageUrls: string[];
+  author: {
+    memberId: number;
+    nickname: string;
+    role: 'BUILDER' | 'MANAGER';
+  };
+  createdAt: string;
+  viewCount: number;
+  answers: Array<{
+    answerId: number;
+    content: string;
+    author: {
+      memberId: number;
+      nickname: string;
+      role: 'BUILDER' | 'MANAGER';
+    };
+    createdAt: string;
+  }>;
+}
+
+export interface AdminLessonQnaAnswerCreateResponse {
+  answerId: number;
+}
+
+export interface AdminLessonRetrospectiveResponse {
+  retrospectives: Array<{
+    retrospectiveId: number;
+    memberId: number;
+    nickname: string;
+    understandingScore: number;
+    purpose: AdminRetrospectivePurpose;
+    artifactType: 'SCREENSHOT' | 'LINK' | null;
+    artifactValue: string | null;
+    content: string;
+    createdAt: string;
+  }>;
+}
+
+export interface AdminLessonBuilderFeedsResponse {
+  feeds: Array<{
+    feedId: number;
+    lessonId: number | null;
+    memberId: number;
+    nickname: string;
+    role: 'BUILDER' | 'MANAGER';
+    content: string;
+    imageUrls: string[];
+    likeCount: number;
+    commentCount: number;
+    operatorPick: boolean;
+    featured: boolean;
+    featuredOrder: number | null;
+    createdAt: string;
+  }>;
+}
+
+export interface AdminBuilderFeedCurationRequest {
+  operatorPick: boolean;
+  featured: boolean;
+  featuredOrder: number | null;
+}
+
+export interface AdminLessonBulkUpdateRequest {
+  lessonIds: number[];
+  isFree?: boolean;
+  isPublished?: boolean;
+}

--- a/src/features/admin/course-management/model/admin-course-management-effects.ts
+++ b/src/features/admin/course-management/model/admin-course-management-effects.ts
@@ -1,0 +1,471 @@
+import {
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+  useEffect,
+} from 'react';
+import type { AdminLessonUpsertRequest } from '@/features/admin/course-management/model/admin-course-management-contract';
+import { normalizeAdminCourseMarkdownContent } from '@/features/admin/course-management/model/admin-course-markdown';
+
+const emptyLessonForm: AdminLessonUpsertRequest = {
+  chapterNumber: 1,
+  lessonNumber: 1,
+  title: '',
+  content: '',
+  estimatedMinutes: 30,
+  retrospectivePurpose: 'PRACTICE_PROOF',
+  isFree: false,
+  isPublished: false,
+};
+
+type StateSetter<T> = Dispatch<SetStateAction<T>>;
+
+export const useAdminPendingCourseSelectionSync = ({
+  coursesFetching,
+  pendingSelectedCourseId,
+  setPendingSelectedCourseId,
+  setSelectedCourseId,
+  showInfoToast,
+  suppressNextAutoCourseSelectionRef,
+  visibleCourseIds,
+}: {
+  coursesFetching: boolean;
+  pendingSelectedCourseId?: number;
+  setPendingSelectedCourseId: StateSetter<number | undefined>;
+  setSelectedCourseId: StateSetter<number | undefined>;
+  showInfoToast: (message: string) => void;
+  suppressNextAutoCourseSelectionRef: MutableRefObject<boolean>;
+  visibleCourseIds: number[];
+}) => {
+  useEffect(() => {
+    if (!pendingSelectedCourseId) {
+      return;
+    }
+
+    if (visibleCourseIds.includes(pendingSelectedCourseId)) {
+      setSelectedCourseId(pendingSelectedCourseId);
+      setPendingSelectedCourseId(undefined);
+      return;
+    }
+
+    if (coursesFetching) {
+      return;
+    }
+
+    suppressNextAutoCourseSelectionRef.current = true;
+    setSelectedCourseId(undefined);
+    showInfoToast(
+      '방금 생성한 코스를 현재 목록에서 찾지 못했습니다. 검색어나 페이지를 확인해주세요.',
+    );
+    setPendingSelectedCourseId(undefined);
+  }, [
+    coursesFetching,
+    pendingSelectedCourseId,
+    setPendingSelectedCourseId,
+    setSelectedCourseId,
+    showInfoToast,
+    suppressNextAutoCourseSelectionRef,
+    visibleCourseIds,
+  ]);
+};
+
+export const useAdminAutoCourseSelection = ({
+  coursesFetching,
+  pendingSelectedCourseId,
+  selectedCourseId,
+  setSelectedCourseId,
+  suppressNextAutoCourseSelectionRef,
+  visibleCourseIds,
+}: {
+  coursesFetching: boolean;
+  pendingSelectedCourseId?: number;
+  selectedCourseId?: number;
+  setSelectedCourseId: StateSetter<number | undefined>;
+  suppressNextAutoCourseSelectionRef: MutableRefObject<boolean>;
+  visibleCourseIds: number[];
+}) => {
+  useEffect(() => {
+    if (pendingSelectedCourseId) {
+      return;
+    }
+
+    if (suppressNextAutoCourseSelectionRef.current) {
+      suppressNextAutoCourseSelectionRef.current = false;
+      return;
+    }
+
+    if (coursesFetching && visibleCourseIds.length === 0) {
+      return;
+    }
+
+    if (visibleCourseIds.length === 0) {
+      setSelectedCourseId(undefined);
+      return;
+    }
+
+    if (selectedCourseId && visibleCourseIds.includes(selectedCourseId)) {
+      return;
+    }
+
+    setSelectedCourseId(visibleCourseIds[0]);
+  }, [
+    coursesFetching,
+    pendingSelectedCourseId,
+    selectedCourseId,
+    setSelectedCourseId,
+    suppressNextAutoCourseSelectionRef,
+    visibleCourseIds,
+  ]);
+};
+
+export const useAdminStatusFilterResetSync = ({
+  preserveCourseSelectionOnFilterResetRef,
+  setPage,
+  setSelectedCourseId,
+  statusFilter,
+}: {
+  preserveCourseSelectionOnFilterResetRef: MutableRefObject<boolean>;
+  setPage: StateSetter<number>;
+  setSelectedCourseId: StateSetter<number | undefined>;
+  statusFilter: string;
+}) => {
+  useEffect(() => {
+    if (preserveCourseSelectionOnFilterResetRef.current) {
+      preserveCourseSelectionOnFilterResetRef.current = false;
+      return;
+    }
+
+    setPage(1);
+    setSelectedCourseId(undefined);
+  }, [
+    preserveCourseSelectionOnFilterResetRef,
+    setPage,
+    setSelectedCourseId,
+    statusFilter,
+  ]);
+};
+
+export const useAdminLessonContextResetSync = ({
+  effectiveCourseId,
+  setBuilderFeedOrderDrafts,
+  setEditingLessonId,
+  setHydratedLessonId,
+  setHydratedLessonSnapshot,
+  setLessonEditorResetVersion,
+  setLessonForm,
+  setLessonFormMode,
+  setQnaAnswerContent,
+  setSelectedLessonIds,
+  setSelectedQnaId,
+}: {
+  effectiveCourseId?: number;
+  setBuilderFeedOrderDrafts: StateSetter<Record<number, string>>;
+  setEditingLessonId: StateSetter<number | undefined>;
+  setHydratedLessonId: StateSetter<number | undefined>;
+  setHydratedLessonSnapshot: StateSetter<string>;
+  setLessonEditorResetVersion: StateSetter<number>;
+  setLessonForm: StateSetter<AdminLessonUpsertRequest>;
+  setLessonFormMode: StateSetter<'create' | 'edit'>;
+  setQnaAnswerContent: StateSetter<string>;
+  setSelectedLessonIds: StateSetter<number[]>;
+  setSelectedQnaId: StateSetter<number | undefined>;
+}) => {
+  useEffect(() => {
+    setSelectedLessonIds([]);
+  }, [effectiveCourseId, setSelectedLessonIds]);
+
+  useEffect(() => {
+    setLessonFormMode('create');
+    setEditingLessonId(undefined);
+    setHydratedLessonId(undefined);
+    setHydratedLessonSnapshot('');
+    setSelectedQnaId(undefined);
+    setQnaAnswerContent('');
+    setBuilderFeedOrderDrafts({});
+    setLessonEditorResetVersion((prev) => prev + 1);
+    setLessonForm({
+      ...emptyLessonForm,
+      lessonNumber: 1,
+    });
+  }, [
+    effectiveCourseId,
+    setBuilderFeedOrderDrafts,
+    setEditingLessonId,
+    setHydratedLessonId,
+    setHydratedLessonSnapshot,
+    setLessonEditorResetVersion,
+    setLessonForm,
+    setLessonFormMode,
+    setQnaAnswerContent,
+    setSelectedQnaId,
+  ]);
+};
+
+export const useAdminCompletionMessageSync = ({
+  completionMessage,
+  completionMessageData,
+  completionMessageSourceRef,
+  currentCompletionMessageRef,
+  currentEffectiveCourseIdRef,
+  effectiveCourseId,
+  hydratedCompletionMessageCourseId,
+  setCompletionMessage,
+  setHydratedCompletionMessageCourseId,
+}: {
+  completionMessage: string;
+  completionMessageData?: { message?: string };
+  completionMessageSourceRef: MutableRefObject<{
+    courseId?: number;
+    message: string;
+  }>;
+  currentCompletionMessageRef: MutableRefObject<string>;
+  currentEffectiveCourseIdRef: MutableRefObject<number | undefined>;
+  effectiveCourseId?: number;
+  hydratedCompletionMessageCourseId?: number;
+  setCompletionMessage: StateSetter<string>;
+  setHydratedCompletionMessageCourseId: StateSetter<number | undefined>;
+}) => {
+  useEffect(() => {
+    currentEffectiveCourseIdRef.current = effectiveCourseId;
+  }, [currentEffectiveCourseIdRef, effectiveCourseId]);
+
+  useEffect(() => {
+    currentCompletionMessageRef.current = completionMessage;
+  }, [completionMessage, currentCompletionMessageRef]);
+
+  useEffect(() => {
+    if (effectiveCourseId) {
+      setCompletionMessage('');
+    }
+    setHydratedCompletionMessageCourseId(undefined);
+    completionMessageSourceRef.current = {
+      courseId: effectiveCourseId,
+      message: '',
+    };
+  }, [
+    completionMessageSourceRef,
+    effectiveCourseId,
+    setCompletionMessage,
+    setHydratedCompletionMessageCourseId,
+  ]);
+
+  useEffect(() => {
+    if (!effectiveCourseId) {
+      setCompletionMessage('');
+      setHydratedCompletionMessageCourseId(undefined);
+      completionMessageSourceRef.current = { courseId: undefined, message: '' };
+      return;
+    }
+
+    if (!completionMessageData) {
+      return;
+    }
+
+    const serverMessage = completionMessageData.message ?? '';
+    const previousSource = completionMessageSourceRef.current;
+    const shouldSyncLocalValue =
+      hydratedCompletionMessageCourseId !== effectiveCourseId ||
+      (previousSource.courseId === effectiveCourseId &&
+        completionMessage === previousSource.message);
+
+    if (shouldSyncLocalValue) {
+      setCompletionMessage(serverMessage);
+    }
+
+    completionMessageSourceRef.current = {
+      courseId: effectiveCourseId,
+      message: serverMessage,
+    };
+    setHydratedCompletionMessageCourseId(effectiveCourseId);
+  }, [
+    completionMessage,
+    completionMessageData,
+    completionMessageSourceRef,
+    effectiveCourseId,
+    hydratedCompletionMessageCourseId,
+    setCompletionMessage,
+    setHydratedCompletionMessageCourseId,
+  ]);
+};
+
+export const useAdminLessonHydrationSync = ({
+  hydratedLessonSnapshot,
+  lessonDetail,
+  lessonDetailSnapshot,
+  lessonFormMode,
+  setHydratedLessonId,
+  setHydratedLessonSnapshot,
+  setLessonForm,
+}: {
+  hydratedLessonSnapshot: string;
+  lessonDetail?: AdminLessonUpsertRequest & { lessonId: number };
+  lessonDetailSnapshot: string;
+  lessonFormMode: 'create' | 'edit';
+  setHydratedLessonId: StateSetter<number | undefined>;
+  setHydratedLessonSnapshot: StateSetter<string>;
+  setLessonForm: StateSetter<AdminLessonUpsertRequest>;
+}) => {
+  useEffect(() => {
+    if (!lessonDetail || lessonFormMode !== 'edit') {
+      return;
+    }
+
+    if (hydratedLessonSnapshot === lessonDetailSnapshot) {
+      return;
+    }
+
+    setLessonForm({
+      chapterNumber: lessonDetail.chapterNumber,
+      lessonNumber: lessonDetail.lessonNumber,
+      title: lessonDetail.title,
+      content: normalizeAdminCourseMarkdownContent(lessonDetail.content),
+      estimatedMinutes: lessonDetail.estimatedMinutes,
+      retrospectivePurpose: lessonDetail.retrospectivePurpose,
+      isFree: lessonDetail.isFree,
+      isPublished: lessonDetail.isPublished,
+    });
+    setHydratedLessonId(lessonDetail.lessonId);
+    setHydratedLessonSnapshot(lessonDetailSnapshot);
+  }, [
+    hydratedLessonSnapshot,
+    lessonDetail,
+    lessonDetailSnapshot,
+    lessonFormMode,
+    setHydratedLessonId,
+    setHydratedLessonSnapshot,
+    setLessonForm,
+  ]);
+};
+
+export const useAdminQnaSelectionSync = ({
+  currentQnaAnswerContentRef,
+  currentSelectedQnaIdRef,
+  qnaAnswerContent,
+  qnas,
+  qnasFetching,
+  selectedQnaId,
+  setQnaAnswerContent,
+  setSelectedQnaId,
+}: {
+  currentQnaAnswerContentRef: MutableRefObject<string>;
+  currentSelectedQnaIdRef: MutableRefObject<number | undefined>;
+  qnaAnswerContent: string;
+  qnas: Array<{
+    qnaId: number;
+  }>;
+  qnasFetching: boolean;
+  selectedQnaId?: number;
+  setQnaAnswerContent: StateSetter<string>;
+  setSelectedQnaId: StateSetter<number | undefined>;
+}) => {
+  useEffect(() => {
+    currentSelectedQnaIdRef.current = selectedQnaId;
+  }, [currentSelectedQnaIdRef, selectedQnaId]);
+
+  useEffect(() => {
+    currentQnaAnswerContentRef.current = qnaAnswerContent;
+  }, [currentQnaAnswerContentRef, qnaAnswerContent]);
+
+  useEffect(() => {
+    if (qnasFetching && qnas.length === 0) {
+      return;
+    }
+
+    if (qnas.length === 0) {
+      setSelectedQnaId(undefined);
+      return;
+    }
+
+    if (selectedQnaId && qnas.some((qna) => qna.qnaId === selectedQnaId)) {
+      return;
+    }
+
+    setSelectedQnaId(qnas[0].qnaId);
+  }, [qnas, qnasFetching, selectedQnaId, setSelectedQnaId]);
+
+  useEffect(() => {
+    setQnaAnswerContent('');
+  }, [selectedQnaId, setQnaAnswerContent]);
+};
+
+export const useAdminBuilderFeedDraftSync = ({
+  builderFeedOrderSourceValuesRef,
+  editingLessonId,
+  feeds,
+  isAwaitingBuilderFeedRefresh,
+  lessonBuilderFeedsFetching,
+  setBuilderFeedOrderDrafts,
+  setIsAwaitingBuilderFeedRefresh,
+  updateBuilderFeedCurationPending,
+}: {
+  builderFeedOrderSourceValuesRef: MutableRefObject<Record<number, string>>;
+  editingLessonId?: number;
+  feeds: Array<{
+    feedId: number;
+    featuredOrder?: number;
+  }>;
+  isAwaitingBuilderFeedRefresh: boolean;
+  lessonBuilderFeedsFetching: boolean;
+  setBuilderFeedOrderDrafts: StateSetter<Record<number, string>>;
+  setIsAwaitingBuilderFeedRefresh: StateSetter<boolean>;
+  updateBuilderFeedCurationPending: boolean;
+}) => {
+  useEffect(() => {
+    if (!editingLessonId || feeds.length === 0) {
+      setBuilderFeedOrderDrafts({});
+      builderFeedOrderSourceValuesRef.current = {};
+      setIsAwaitingBuilderFeedRefresh(false);
+      return;
+    }
+
+    const nextSourceValues = Object.fromEntries(
+      feeds.map((feed) => [
+        feed.feedId,
+        feed.featuredOrder ? String(feed.featuredOrder) : '',
+      ]),
+    );
+
+    setBuilderFeedOrderDrafts((prevDrafts) => {
+      const nextDrafts: Record<number, string> = {};
+
+      feeds.forEach((feed) => {
+        const serverValue = nextSourceValues[feed.feedId] ?? '';
+        const previousSourceValue =
+          builderFeedOrderSourceValuesRef.current[feed.feedId];
+        const previousDraftValue = prevDrafts[feed.feedId];
+
+        nextDrafts[feed.feedId] =
+          previousDraftValue !== undefined &&
+          previousDraftValue !== previousSourceValue
+            ? previousDraftValue
+            : serverValue;
+      });
+
+      return nextDrafts;
+    });
+    builderFeedOrderSourceValuesRef.current = nextSourceValues;
+  }, [
+    builderFeedOrderSourceValuesRef,
+    editingLessonId,
+    feeds,
+    setBuilderFeedOrderDrafts,
+    setIsAwaitingBuilderFeedRefresh,
+  ]);
+
+  useEffect(() => {
+    if (
+      !isAwaitingBuilderFeedRefresh ||
+      updateBuilderFeedCurationPending ||
+      lessonBuilderFeedsFetching
+    ) {
+      return;
+    }
+
+    setIsAwaitingBuilderFeedRefresh(false);
+  }, [
+    isAwaitingBuilderFeedRefresh,
+    lessonBuilderFeedsFetching,
+    setIsAwaitingBuilderFeedRefresh,
+    updateBuilderFeedCurationPending,
+  ]);
+};

--- a/src/features/admin/course-management/model/admin-course-management-locks.ts
+++ b/src/features/admin/course-management/model/admin-course-management-locks.ts
@@ -1,0 +1,103 @@
+interface AdminCourseManagementLockInputs {
+  courseFormMode: 'create' | 'edit';
+  createCoursePending: boolean;
+  createLessonPending: boolean;
+  createLessonQnaAnswerPending: boolean;
+  deleteLessonPending: boolean;
+  editingCourseId?: number;
+  editingLessonId?: number;
+  effectiveCourseId?: number;
+  hydratedCompletionMessageCourseId?: number;
+  hydratedLessonId?: number;
+  isAwaitingBuilderFeedRefresh: boolean;
+  isUploadingCourseThumbnail: boolean;
+  reorderLessonsPending: boolean;
+  selectedCourseId?: number;
+  upsertCompletionMessagePending: boolean;
+  updateBuilderFeedCurationPending: boolean;
+  updateCoursePending: boolean;
+  updateLessonPending: boolean;
+  bulkUpdateLessonsPending: boolean;
+  hasSelectedCourse: boolean;
+  lessonFormMode: 'create' | 'edit';
+}
+
+export interface AdminCourseManagementLocks {
+  isCompletionMessageHydrating: boolean;
+  isCourseFormLocked: boolean;
+  isCourseSelectionLocked: boolean;
+  isLessonContextLocked: boolean;
+  isLessonDetailHydrating: boolean;
+  isLessonFormLocked: boolean;
+  isLessonListInteractionLocked: boolean;
+  isLessonMutationPending: boolean;
+  isQuickCourseStatusChangeEnabled: boolean;
+}
+
+export const getAdminCourseManagementLocks = ({
+  bulkUpdateLessonsPending,
+  courseFormMode,
+  createCoursePending,
+  createLessonPending,
+  createLessonQnaAnswerPending,
+  deleteLessonPending,
+  editingCourseId,
+  editingLessonId,
+  effectiveCourseId,
+  hasSelectedCourse,
+  hydratedCompletionMessageCourseId,
+  hydratedLessonId,
+  isAwaitingBuilderFeedRefresh,
+  isUploadingCourseThumbnail,
+  lessonFormMode,
+  reorderLessonsPending,
+  selectedCourseId,
+  upsertCompletionMessagePending,
+  updateBuilderFeedCurationPending,
+  updateCoursePending,
+  updateLessonPending,
+}: AdminCourseManagementLockInputs): AdminCourseManagementLocks => {
+  const isCourseFormLocked =
+    isUploadingCourseThumbnail || createCoursePending || updateCoursePending;
+  const isLessonMutationPending = createLessonPending || updateLessonPending;
+  const isLessonDetailHydrating =
+    lessonFormMode === 'edit' &&
+    typeof editingLessonId === 'number' &&
+    hydratedLessonId !== editingLessonId;
+  const isLessonFormLocked = isLessonDetailHydrating || isLessonMutationPending;
+  const isLessonContextLocked =
+    isLessonFormLocked ||
+    updateBuilderFeedCurationPending ||
+    createLessonQnaAnswerPending ||
+    isAwaitingBuilderFeedRefresh;
+  const isLessonListInteractionLocked =
+    isLessonContextLocked ||
+    deleteLessonPending ||
+    bulkUpdateLessonsPending ||
+    reorderLessonsPending;
+
+  return {
+    isCompletionMessageHydrating:
+      typeof effectiveCourseId === 'number' &&
+      hydratedCompletionMessageCourseId !== effectiveCourseId,
+    isCourseFormLocked,
+    isCourseSelectionLocked:
+      isCourseFormLocked ||
+      isLessonMutationPending ||
+      deleteLessonPending ||
+      bulkUpdateLessonsPending ||
+      reorderLessonsPending ||
+      updateBuilderFeedCurationPending ||
+      createLessonQnaAnswerPending ||
+      upsertCompletionMessagePending,
+    isLessonContextLocked,
+    isLessonDetailHydrating,
+    isLessonFormLocked,
+    isLessonListInteractionLocked,
+    isLessonMutationPending,
+    isQuickCourseStatusChangeEnabled:
+      courseFormMode === 'edit' &&
+      hasSelectedCourse &&
+      editingCourseId === selectedCourseId,
+  };
+};

--- a/src/features/admin/course-management/model/admin-course-markdown.ts
+++ b/src/features/admin/course-management/model/admin-course-markdown.ts
@@ -1,0 +1,86 @@
+import {
+  COMMUNITY_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS,
+  COMMUNITY_MARKDOWN_MAX_IMAGE_COUNT,
+  COMMUNITY_MARKDOWN_MAX_IMAGE_FILE_SIZE,
+} from '@/types/community/markdown';
+import { normalizeMarkdownContent } from '@/utils/markdown-content-normalize';
+import { isHtmlContent } from '@/utils/markdown-content-shared';
+
+export const ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS =
+  COMMUNITY_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS;
+export const ADMIN_COURSE_MARKDOWN_MAX_IMAGE_COUNT =
+  COMMUNITY_MARKDOWN_MAX_IMAGE_COUNT;
+export const ADMIN_COURSE_MARKDOWN_MAX_IMAGE_FILE_SIZE =
+  COMMUNITY_MARKDOWN_MAX_IMAGE_FILE_SIZE;
+
+const GLOBAL_DISALLOWED_ATTRIBUTES = new Set(['class', 'style', 'id']);
+const ATTRIBUTE_ALLOWLIST_BY_TAG: Record<string, Set<string>> = {
+  a: new Set(['href', 'title', 'target', 'rel']),
+  blockquote: new Set(),
+  br: new Set(),
+  code: new Set(),
+  del: new Set(),
+  em: new Set(),
+  h1: new Set(),
+  h2: new Set(),
+  h3: new Set(),
+  hr: new Set(),
+  iframe: new Set([
+    'allow',
+    'allowfullscreen',
+    'frameborder',
+    'height',
+    'referrerpolicy',
+    'src',
+    'title',
+    'width',
+  ]),
+  img: new Set(['alt', 'height', 'loading', 'src', 'title', 'width']),
+  li: new Set(),
+  ol: new Set(),
+  p: new Set(),
+  pre: new Set(),
+  s: new Set(),
+  span: new Set(),
+  strong: new Set(),
+  u: new Set(),
+  ul: new Set(),
+};
+
+const stripEditorBreakingAttributes = (html: string) => {
+  if (typeof window === 'undefined') {
+    return html;
+  }
+
+  const document = new window.DOMParser().parseFromString(html, 'text/html');
+
+  document.body.querySelectorAll('*').forEach((element) => {
+    const tagName = element.tagName.toLowerCase();
+    const allowedAttributes = ATTRIBUTE_ALLOWLIST_BY_TAG[tagName] ?? new Set();
+
+    Array.from(element.attributes).forEach((attribute) => {
+      const attributeName = attribute.name.toLowerCase();
+
+      if (
+        GLOBAL_DISALLOWED_ATTRIBUTES.has(attributeName) ||
+        attributeName.startsWith('data-') ||
+        attributeName.startsWith('on') ||
+        !allowedAttributes.has(attributeName)
+      ) {
+        element.removeAttribute(attribute.name);
+      }
+    });
+  });
+
+  return document.body.innerHTML.trim();
+};
+
+export const normalizeAdminCourseMarkdownContent = (content: unknown) => {
+  const normalizedContent = normalizeMarkdownContent(content);
+
+  if (!normalizedContent || !isHtmlContent(normalizedContent)) {
+    return normalizedContent;
+  }
+
+  return stripEditorBreakingAttributes(normalizedContent);
+};

--- a/src/features/admin/course-management/model/admin-course-presentation.ts
+++ b/src/features/admin/course-management/model/admin-course-presentation.ts
@@ -1,0 +1,34 @@
+import type { AdminRetrospectivePurpose } from '@/features/admin/course-management/model/admin-course-management-contract';
+
+export const ADMIN_RETROSPECTIVE_PURPOSE_OPTIONS: Array<{
+  value: AdminRetrospectivePurpose;
+  label: string;
+  helper: string;
+  color: 'blue' | 'green' | 'orange';
+}> = [
+  {
+    value: 'PRACTICE_PROOF',
+    label: '실습 인증',
+    helper: '링크 또는 스크린샷 제출이 필수입니다.',
+    color: 'blue',
+  },
+  {
+    value: 'ARTIFACT_SHARE',
+    label: '결과물 자랑',
+    helper: '링크 또는 스크린샷 제출이 필수입니다.',
+    color: 'green',
+  },
+  {
+    value: 'SUBJECTIVE_QUIZ',
+    label: '주관식 퀴즈',
+    helper: '텍스트 답변만 제출하고 링크/스크린샷 입력은 숨깁니다.',
+    color: 'orange',
+  },
+];
+
+export const getAdminRetrospectivePurposeMeta = (
+  purpose: AdminRetrospectivePurpose,
+) =>
+  ADMIN_RETROSPECTIVE_PURPOSE_OPTIONS.find(
+    (option) => option.value === purpose,
+  ) ?? ADMIN_RETROSPECTIVE_PURPOSE_OPTIONS[0];

--- a/src/features/admin/course-management/model/use-admin-course-management-query.ts
+++ b/src/features/admin/course-management/model/use-admin-course-management-query.ts
@@ -1,0 +1,510 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createAdminCourse,
+  bulkUpdateAdminLessons,
+  createAdminLesson,
+  deleteAdminCourse,
+  deleteAdminLesson,
+  getAdminCompletionMessage,
+  getAdminCourseLessons,
+  getAdminCourses,
+  getAdminLessonDetail,
+  getAdminLessonQnaDetail,
+  getAdminLessonQnas,
+  getAdminLessonRetrospectives,
+  updateAdminBuilderFeedCuration,
+  createAdminLessonQnaAnswer,
+  getAdminLessonBuilderFeeds,
+  reorderAdminLessons,
+  updateAdminCourse,
+  updateAdminLesson,
+  upsertAdminCompletionMessage,
+} from '@/features/admin/course-management/api/admin-course-management-api';
+import type {
+  AdminBuilderFeedCurationRequest,
+  AdminCourseFormValues,
+  AdminCourseListParams,
+  AdminCourseUpdateRequest,
+  AdminCourseUpsertRequest,
+  AdminLessonUpsertRequest,
+} from '@/features/admin/course-management/model/admin-course-management-contract';
+import { useToastStore } from '@/stores/use-toast-store';
+import { analyzeError } from '@/utils/error-handler';
+
+export const adminCourseManagementQueryKeys = {
+  all: ['admin-course-management'] as const,
+  courses: (params: AdminCourseListParams) =>
+    [...adminCourseManagementQueryKeys.all, 'courses', params] as const,
+  lessons: (courseId?: number) =>
+    [...adminCourseManagementQueryKeys.all, 'lessons', courseId] as const,
+  lessonDetail: (lessonId?: number) =>
+    [...adminCourseManagementQueryKeys.all, 'lesson-detail', lessonId] as const,
+  completionMessage: (courseId?: number) =>
+    [
+      ...adminCourseManagementQueryKeys.all,
+      'completion-message',
+      courseId,
+    ] as const,
+  lessonQnas: (lessonId?: number) =>
+    [...adminCourseManagementQueryKeys.all, 'lesson-qnas', lessonId] as const,
+  lessonQnaDetail: (qnaId?: number) =>
+    [
+      ...adminCourseManagementQueryKeys.all,
+      'lesson-qna-detail',
+      qnaId,
+    ] as const,
+  lessonRetrospectives: (lessonId?: number) =>
+    [
+      ...adminCourseManagementQueryKeys.all,
+      'lesson-retrospectives',
+      lessonId,
+    ] as const,
+  lessonBuilderFeeds: (lessonId?: number) =>
+    [
+      ...adminCourseManagementQueryKeys.all,
+      'lesson-builder-feeds',
+      lessonId,
+    ] as const,
+};
+
+const showMutationError = (error: unknown) => {
+  const { userMessage } = analyzeError(error);
+  useToastStore
+    .getState()
+    .showToast(userMessage || '요청 처리 중 오류가 발생했습니다.', 'error');
+};
+
+export const useAdminCoursesQuery = (params: AdminCourseListParams) =>
+  useQuery({
+    queryKey: adminCourseManagementQueryKeys.courses(params),
+    queryFn: () => getAdminCourses(params),
+    staleTime: 60_000,
+  });
+
+export const useAdminCourseLessonsQuery = (courseId?: number) =>
+  useQuery({
+    queryKey: adminCourseManagementQueryKeys.lessons(courseId),
+    queryFn: () => getAdminCourseLessons(courseId ?? 0),
+    enabled: typeof courseId === 'number',
+    staleTime: 30_000,
+  });
+
+export const useAdminLessonDetailQuery = (lessonId?: number) =>
+  useQuery({
+    queryKey: adminCourseManagementQueryKeys.lessonDetail(lessonId),
+    queryFn: () => getAdminLessonDetail(lessonId ?? 0),
+    enabled: typeof lessonId === 'number',
+    staleTime: 30_000,
+  });
+
+export const useAdminLessonQnasQuery = (lessonId?: number) =>
+  useQuery({
+    queryKey: adminCourseManagementQueryKeys.lessonQnas(lessonId),
+    queryFn: () => getAdminLessonQnas(lessonId ?? 0),
+    enabled: typeof lessonId === 'number',
+    staleTime: 30_000,
+  });
+
+export const useAdminLessonRetrospectivesQuery = (lessonId?: number) =>
+  useQuery({
+    queryKey: adminCourseManagementQueryKeys.lessonRetrospectives(lessonId),
+    queryFn: () => getAdminLessonRetrospectives(lessonId ?? 0),
+    enabled: typeof lessonId === 'number',
+    staleTime: 30_000,
+  });
+
+export const useAdminLessonBuilderFeedsQuery = (lessonId?: number) =>
+  useQuery({
+    queryKey: adminCourseManagementQueryKeys.lessonBuilderFeeds(lessonId),
+    queryFn: () => getAdminLessonBuilderFeeds(lessonId ?? 0),
+    enabled: typeof lessonId === 'number',
+    staleTime: 30_000,
+  });
+
+export const useAdminLessonQnaDetailQuery = (qnaId?: number) =>
+  useQuery({
+    queryKey: adminCourseManagementQueryKeys.lessonQnaDetail(qnaId),
+    queryFn: () => getAdminLessonQnaDetail(qnaId ?? 0),
+    enabled: typeof qnaId === 'number',
+    staleTime: 30_000,
+  });
+
+export const useAdminCompletionMessageQuery = (courseId?: number) =>
+  useQuery({
+    queryKey: adminCourseManagementQueryKeys.completionMessage(courseId),
+    queryFn: () => getAdminCompletionMessage(courseId ?? 0),
+    enabled: typeof courseId === 'number',
+    staleTime: 30_000,
+  });
+
+export const useCreateAdminCourseMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createAdminCourse,
+    onSuccess: async () => {
+      useToastStore.getState().showToast('코스를 생성했습니다.', 'success');
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useUpdateAdminCourseMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateAdminCourse,
+    onSuccess: async () => {
+      useToastStore.getState().showToast('코스를 저장했습니다.', 'success');
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useDeleteAdminCourseMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteAdminCourse,
+    onSuccess: async (response) => {
+      useToastStore
+        .getState()
+        .showToast(
+          response.deleted
+            ? '코스를 삭제했습니다.'
+            : '수강 이력이 있어 코스를 삭제하지 않고 비공개 처리했습니다.',
+          'success',
+        );
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useCreateAdminLessonMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createAdminLesson,
+    onSuccess: async (_, variables) => {
+      useToastStore.getState().showToast('레슨을 생성했습니다.', 'success');
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.lessons(variables.courseId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useUpdateAdminLessonMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      lessonId,
+      request,
+    }: {
+      courseId?: number;
+      lessonId: number;
+      request: AdminLessonUpsertRequest;
+    }) => updateAdminLesson({ lessonId, request }),
+    onSuccess: async (_, variables) => {
+      useToastStore.getState().showToast('레슨을 저장했습니다.', 'success');
+      if (variables.courseId) {
+        await queryClient.invalidateQueries({
+          queryKey: adminCourseManagementQueryKeys.lessons(variables.courseId),
+        });
+      }
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.lessonDetail(
+          variables.lessonId,
+        ),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useDeleteAdminLessonMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ lessonId }: { courseId: number; lessonId: number }) =>
+      deleteAdminLesson(lessonId),
+    onSuccess: async (response, variables) => {
+      useToastStore
+        .getState()
+        .showToast(
+          response.deleted
+            ? '레슨을 삭제했습니다.'
+            : '수강 이력이 있어 레슨을 삭제하지 않고 비게시 처리했습니다.',
+          'success',
+        );
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.lessons(variables.courseId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.lessonDetail(
+          variables.lessonId,
+        ),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useReorderAdminLessonsMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: reorderAdminLessons,
+    onSuccess: async (_, variables) => {
+      useToastStore
+        .getState()
+        .showToast('레슨 순서를 저장했습니다.', 'success');
+      await queryClient.invalidateQueries({
+        predicate: (query) =>
+          Array.isArray(query.queryKey) &&
+          query.queryKey.includes('lesson-detail'),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.lessons(variables.courseId),
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useUpsertAdminCompletionMessageMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: upsertAdminCompletionMessage,
+    onSuccess: async (_, variables) => {
+      useToastStore
+        .getState()
+        .showToast('완주 메시지를 저장했습니다.', 'success');
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.completionMessage(
+          variables.courseId,
+        ),
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const toAdminCoursePayload = (
+  form: AdminCourseFormValues,
+): AdminCourseUpsertRequest => {
+  const toOptionalNumber = (value: string) => {
+    const normalizedValue = value.trim();
+    if (!normalizedValue) {
+      return undefined;
+    }
+
+    const parsedValue = Number(normalizedValue);
+
+    return Number.isFinite(parsedValue) ? parsedValue : undefined;
+  };
+
+  const cardTags = Array.from(
+    new Set(
+      form.cardTags
+        .split(/[\n,]/)
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+    ),
+  );
+
+  return {
+    slug: form.slug.trim(),
+    title: form.title.trim(),
+    cardHeadline: form.cardHeadline.trim(),
+    cardSummary: form.cardSummary.trim(),
+    cardTags,
+    regularPrice: toOptionalNumber(form.regularPrice),
+    discountPrice: toOptionalNumber(form.discountPrice),
+    description: form.description.trim(),
+    thumbnailUrl: form.thumbnailUrl.trim(),
+    status: form.status,
+    durationDays: toOptionalNumber(form.durationDays),
+    earlyBirdEndsAt: form.earlyBirdEndsAt || null,
+  };
+};
+
+export const toAdminCourseUpdateRequest = ({
+  basePayload,
+  touchedFields,
+}: {
+  basePayload: AdminCourseUpsertRequest;
+  touchedFields: Partial<Record<keyof AdminCourseFormValues, boolean>>;
+}): AdminCourseUpdateRequest => {
+  const request: AdminCourseUpdateRequest = {};
+
+  if (touchedFields.slug) {
+    request.slug = basePayload.slug || undefined;
+  }
+  if (touchedFields.title) {
+    request.title = basePayload.title || undefined;
+  }
+  if (touchedFields.cardHeadline) {
+    request.cardHeadline = basePayload.cardHeadline || undefined;
+  }
+  if (touchedFields.cardSummary) {
+    request.cardSummary = basePayload.cardSummary || undefined;
+  }
+  if (touchedFields.cardTags) {
+    request.cardTags = basePayload.cardTags;
+  }
+  if (touchedFields.regularPrice) {
+    request.regularPrice = basePayload.regularPrice;
+  }
+  if (touchedFields.discountPrice) {
+    request.discountPrice = basePayload.discountPrice;
+  }
+  if (touchedFields.description) {
+    request.description = basePayload.description;
+  }
+  if (touchedFields.thumbnailUrl) {
+    request.thumbnailUrl = basePayload.thumbnailUrl;
+  }
+  if (touchedFields.status) {
+    request.status = basePayload.status;
+  }
+  if (touchedFields.durationDays) {
+    request.durationDays = basePayload.durationDays;
+  }
+  if (touchedFields.earlyBirdEndsAt) {
+    request.earlyBirdEndsAt = basePayload.earlyBirdEndsAt;
+  }
+
+  return request;
+};
+
+export const toAdminLessonPayload = (
+  form: AdminLessonUpsertRequest,
+): AdminLessonUpsertRequest => ({
+  ...form,
+  chapterNumber: Number(form.chapterNumber),
+  lessonNumber: Number(form.lessonNumber),
+  estimatedMinutes: Number(form.estimatedMinutes),
+});
+
+export const getAdminLessonPayloadValidationError = (
+  payload: AdminLessonUpsertRequest,
+) => {
+  if (!Number.isInteger(payload.chapterNumber) || payload.chapterNumber < 1) {
+    return '챕터 번호는 1 이상의 숫자여야 합니다.';
+  }
+
+  if (!Number.isInteger(payload.lessonNumber) || payload.lessonNumber < 1) {
+    return '레슨 번호는 1 이상의 숫자여야 합니다.';
+  }
+
+  if (
+    !Number.isInteger(payload.estimatedMinutes) ||
+    payload.estimatedMinutes < 1
+  ) {
+    return '예상 시간은 1분 이상이어야 합니다.';
+  }
+
+  if (!payload.title.trim()) {
+    return '레슨 제목을 입력해주세요.';
+  }
+
+  return null;
+};
+
+export const useCreateAdminLessonQnaAnswerMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createAdminLessonQnaAnswer,
+    onSuccess: async (_, variables) => {
+      useToastStore.getState().showToast('QnA 답변을 등록했습니다.', 'success');
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.lessonQnaDetail(
+          variables.qnaId,
+        ),
+      });
+      await queryClient.invalidateQueries({
+        predicate: (query) =>
+          Array.isArray(query.queryKey) &&
+          query.queryKey.includes('lesson-qnas'),
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useUpdateAdminBuilderFeedCurationMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      feedId,
+      lessonId,
+      request,
+    }: {
+      feedId: number;
+      lessonId: number;
+      request: AdminBuilderFeedCurationRequest;
+    }) => updateAdminBuilderFeedCuration({ feedId, request }),
+    onSuccess: async (_, variables) => {
+      useToastStore
+        .getState()
+        .showToast('Builder Feed 운영 상태를 저장했습니다.', 'success');
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.lessonBuilderFeeds(
+          variables.lessonId,
+        ),
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useBulkUpdateAdminLessonsMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: bulkUpdateAdminLessons,
+    onSuccess: async (_, variables) => {
+      useToastStore
+        .getState()
+        .showToast('선택한 레슨 상태를 일괄 저장했습니다.', 'success');
+      await Promise.all(
+        variables.request.lessonIds.map((lessonId) =>
+          queryClient.invalidateQueries({
+            queryKey: adminCourseManagementQueryKeys.lessonDetail(lessonId),
+          }),
+        ),
+      );
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.lessons(variables.courseId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: showMutationError,
+  });
+};


### PR DESCRIPTION
## 변경 내용
- 관리자 `/admin/courses` 코스/레슨 관리 화면 추가 및 안정화
- 클래스 관리자 마크다운/썸네일/레슨/QnA/Builder Feed 운영 플로우 정리
- 관리자 코스 UI를 `components/admin/courses`로 이동해 레이어드 구조 방향에 맞춤

## 검증
- `yarn lint:fix`
- `yarn prettier:fix`
- `yarn typecheck`
- `next build` (pre-push hook)

## 참고
- public 클래스 화면은 건드리지 않고 admin 범위 중심으로 작업했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 강사용 코스 관리 시스템 추가: 코스 생성, 수정, 삭제 및 상태 관리 기능 지원
  * 강의(레슨) 관리 기능: 강의 추가, 수정, 삭제, 순서 변경
  * 강의 완주 메시지 관리
  * 강의별 Q&A 및 돌아보기 제출 관리
  * Builder Feed 운영 및 큐레이션 기능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->