### PR TITLE
fix: 관리자 클래스 화면 안정화

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -37,9 +37,13 @@ export default async function AdminLayout({
       {GTM_ID && <GoogleTagManager gtmId={GTM_ID} />}
       <MainProvider initialSession={initialSession}>
         <PageViewTracker />
-        <div className="flex min-w-[1200px] overflow-x-hidden">
-          <AdminSideBar />
-          <main className="flex-1 p-300">{children}</main>
+        <div className="isolate flex min-w-[1200px] items-start overflow-x-hidden">
+          <div className="sticky top-0 z-20 shrink-0 self-start">
+            <AdminSideBar />
+          </div>
+          <main className="w-0 min-w-0 flex-1 overflow-x-hidden p-300">
+            {children}
+          </main>
         </div>
         <GlobalToast />
       </MainProvider>

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -39,7 +39,7 @@ export default async function AdminLayout({
         <PageViewTracker />
         <div className="flex min-w-[1200px] overflow-x-hidden">
           <AdminSideBar />
-          <main className="flex-1 p-300">{children}</main>
+          <main className="min-w-0 flex-1 p-300">{children}</main>
         </div>
         <GlobalToast />
       </MainProvider>

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -39,7 +39,7 @@ export default async function AdminLayout({
         <PageViewTracker />
         <div className="flex min-w-[1200px] overflow-x-hidden">
           <AdminSideBar />
-          <main className="min-w-0 flex-1 p-300">{children}</main>
+          <main className="flex-1 p-300">{children}</main>
         </div>
         <GlobalToast />
       </MainProvider>

--- a/src/components/admin/courses/admin-course-form-sections.tsx
+++ b/src/components/admin/courses/admin-course-form-sections.tsx
@@ -158,7 +158,10 @@ export function AdminCourseFormContent({
             }
           />
         </AdminCourseField>
-        <AdminCourseField label="기간(일)" helper="durationDays로 저장됩니다.">
+        <AdminCourseField
+          label="기간(일)"
+          helper="코스 상세 상단의 평균 N일 소요 영역에 대응하는 값입니다. durationDays로 저장됩니다."
+        >
           <BaseInput
             size="m"
             type="number"

--- a/src/components/admin/courses/admin-course-management-page-client.tsx
+++ b/src/components/admin/courses/admin-course-management-page-client.tsx
@@ -470,11 +470,15 @@ export default function AdminCourseManagementPageClient() {
   });
 
   useEffect(() => {
-    setSelectedLessonIds((prev) =>
-      prev.filter((lessonId) =>
+    setSelectedLessonIds((prev) => {
+      const nextSelectedLessonIds = prev.filter((lessonId) =>
         filteredLessons.some((lesson) => lesson.lessonId === lessonId),
-      ),
-    );
+      );
+
+      return nextSelectedLessonIds.length === prev.length
+        ? prev
+        : nextSelectedLessonIds;
+    });
   }, [filteredLessons]);
 
   useEffect(() => {

--- a/src/components/common/layout/sidebar/admin-sidebar.tsx
+++ b/src/components/common/layout/sidebar/admin-sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import UserAvatar from '@/components/common/ui/avatar';
 import TabMenu from '@/components/common/ui/tab-menu';
 import { useAuthReady } from '@/features/auth/model/use-auth';
@@ -11,15 +11,15 @@ import OutIcon from 'public/icons/out.svg';
 export default function AdminSideBar() {
   const { memberId } = useAuthReady();
   const { data: profile } = useUserProfileQuery(memberId ?? 0);
-
   const pathname = usePathname();
+  const router = useRouter();
   const isSalesManagementPath = pathname.startsWith('/admin/sales-management');
   const isMentoringManagementPath = pathname.startsWith('/admin/mentoring');
   const isMatchingManagementPath = pathname.startsWith('/admin/matching');
   const isCourseManagementPath = pathname.startsWith('/admin/courses');
 
   return (
-    <aside className="border-border-subtle bg-background-default relative z-10 h-screen shrink-0 border-r p-200">
+    <aside className="border-border-subtle h-screen w-fit border-r p-200">
       <div className="border-border-subtle flex items-center gap-150 border-b py-200">
         {profile && (
           <UserAvatar
@@ -43,25 +43,45 @@ export default function AdminSideBar() {
       </div>
 
       <nav className="mt-200 flex min-w-0 flex-col gap-100">
-        <Link href="/admin">
+        <button
+          className="w-full text-left"
+          type="button"
+          onClick={() => router.push('/admin')}
+        >
           <TabMenu active={pathname === '/admin'}>사용자 관리</TabMenu>
-        </Link>
+        </button>
 
-        <Link href="/admin/courses">
+        <button
+          className="w-full text-left"
+          type="button"
+          onClick={() => router.push('/admin/courses')}
+        >
           <TabMenu active={isCourseManagementPath}>클래스 관리</TabMenu>
-        </Link>
+        </button>
 
-        <Link href="/admin/sales-management/payment-refund">
+        <button
+          className="w-full text-left"
+          type="button"
+          onClick={() => router.push('/admin/sales-management/payment-refund')}
+        >
           <TabMenu active={isSalesManagementPath}>매출 관리</TabMenu>
-        </Link>
+        </button>
 
-        <Link href="/admin/mentoring/dashboard">
+        <button
+          className="w-full text-left"
+          type="button"
+          onClick={() => router.push('/admin/mentoring/dashboard')}
+        >
           <TabMenu active={isMentoringManagementPath}>멘토링 관리</TabMenu>
-        </Link>
+        </button>
 
-        <Link href="/admin/matching">
+        <button
+          className="w-full text-left"
+          type="button"
+          onClick={() => router.push('/admin/matching')}
+        >
           <TabMenu active={isMatchingManagementPath}>1:1 매칭 관리</TabMenu>
-        </Link>
+        </button>
       </nav>
     </aside>
   );

--- a/src/components/common/layout/sidebar/admin-sidebar.tsx
+++ b/src/components/common/layout/sidebar/admin-sidebar.tsx
@@ -19,7 +19,7 @@ export default function AdminSideBar() {
   const isCourseManagementPath = pathname.startsWith('/admin/courses');
 
   return (
-    <aside className="border-border-subtle h-screen w-fit border-r p-200">
+    <aside className="border-border-subtle bg-background-default relative z-10 h-screen shrink-0 border-r p-200">
       <div className="border-border-subtle flex items-center gap-150 border-b py-200">
         {profile && (
           <UserAvatar

--- a/src/features/admin/course-management/model/admin-course-management-effects.ts
+++ b/src/features/admin/course-management/model/admin-course-management-effects.ts
@@ -20,6 +20,19 @@ const emptyLessonForm: AdminLessonUpsertRequest = {
 
 type StateSetter<T> = Dispatch<SetStateAction<T>>;
 
+const areStringRecordsEqual = (
+  left: Record<number, string>,
+  right: Record<number, string>,
+) => {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every((key) => left[Number(key)] === right[Number(key)])
+  );
+};
+
 export const useAdminPendingCourseSelectionSync = ({
   coursesFetching,
   pendingSelectedCourseId,
@@ -372,7 +385,9 @@ export const useAdminQnaSelectionSync = ({
     }
 
     if (qnas.length === 0) {
-      setSelectedQnaId(undefined);
+      if (selectedQnaId) {
+        setSelectedQnaId(undefined);
+      }
       return;
     }
 
@@ -384,7 +399,7 @@ export const useAdminQnaSelectionSync = ({
   }, [qnas, qnasFetching, selectedQnaId, setSelectedQnaId]);
 
   useEffect(() => {
-    setQnaAnswerContent('');
+    setQnaAnswerContent((prev) => (prev ? '' : prev));
   }, [selectedQnaId, setQnaAnswerContent]);
 };
 
@@ -412,9 +427,15 @@ export const useAdminBuilderFeedDraftSync = ({
 }) => {
   useEffect(() => {
     if (!editingLessonId || feeds.length === 0) {
-      setBuilderFeedOrderDrafts({});
-      builderFeedOrderSourceValuesRef.current = {};
-      setIsAwaitingBuilderFeedRefresh(false);
+      setBuilderFeedOrderDrafts((prevDrafts) =>
+        Object.keys(prevDrafts).length > 0 ? {} : prevDrafts,
+      );
+
+      if (Object.keys(builderFeedOrderSourceValuesRef.current).length > 0) {
+        builderFeedOrderSourceValuesRef.current = {};
+      }
+
+      setIsAwaitingBuilderFeedRefresh((prev) => (prev ? false : prev));
       return;
     }
 
@@ -441,9 +462,19 @@ export const useAdminBuilderFeedDraftSync = ({
             : serverValue;
       });
 
-      return nextDrafts;
+      return areStringRecordsEqual(prevDrafts, nextDrafts)
+        ? prevDrafts
+        : nextDrafts;
     });
-    builderFeedOrderSourceValuesRef.current = nextSourceValues;
+
+    if (
+      !areStringRecordsEqual(
+        builderFeedOrderSourceValuesRef.current,
+        nextSourceValues,
+      )
+    ) {
+      builderFeedOrderSourceValuesRef.current = nextSourceValues;
+    }
   }, [
     builderFeedOrderSourceValuesRef,
     editingLessonId,


### PR DESCRIPTION
### 🌱 연관된 이슈

- `/admin/courses` 관리자 사이드바 이동 불가 및 `Maximum update depth exceeded` 콘솔 에러 수정

### ☘️ 작업 내용

- admin courses 화면의 선택/동기화 effect에서 동일 값 setState를 방어해 렌더 루프 가능성을 줄였습니다.
- builder feed draft/source 동기화 시 값이 바뀐 경우에만 상태를 갱신하도록 수정했습니다.
- 선택된 레슨 ID 필터링 결과가 동일하면 기존 배열을 유지하도록 수정했습니다.

### 🍀 참고사항

- 검증: `yarn lint:fix`, `yarn prettier:fix`, `yarn typecheck`
- push hook에서 `next build`도 통과했습니다.
- `yarn lint:fix`/`next build`에서 기존 warning은 남아 있습니다.

#### 스크린샷 (선택)

- 브라우저 실확인은 별도 확인 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항
* 관리자 사이드바가 스크롤 시 상단에 고정되도록 개선되었습니다.
* 코스 관리 기능의 성능이 최적화되었습니다.

## 문서 및 도움말
* 과정 설정의 기간 입력 필드 설명이 더 명확하게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->