### PR TITLE
feat: vibe-intro 레슨 본문/메타 DB 값 렌더

### DIFF
--- a/src/app/(landing)/class/vibe-intro/(learning)/home/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/(learning)/home/page.tsx
@@ -302,7 +302,7 @@ export default function JourneyMapPage() {
         {/* Course badge */}
         <div className="flex justify-center">
           <span className="rounded-full bg-rose-300 px-250 py-125 font-designer-20b text-white">
-            바이브 코딩 입문자 코스
+            {course?.title ?? ''}
           </span>
         </div>
 
@@ -345,14 +345,17 @@ export default function JourneyMapPage() {
         </div>
 
         {/* Free trial callout */}
-        <div className="mt-300 flex flex-col gap-75 rounded-200 border border-border-default bg-gray-100 px-350 py-300">
-          <p className="font-designer-20b text-gray-800">
-            Lesson 03까지 무료로 온보딩을 하실 수 있어요! 무료로 즐겨보세요!
-          </p>
-          <p className="font-designer-16m text-gray-800">
-            이후 결제는 무료 온보딩을 하시고 결정하셔도 늦지 않습니다.
-          </p>
-        </div>
+        {course?.freeLessonCount && course.freeLessonCount > 0 ? (
+          <div className="mt-300 flex flex-col gap-75 rounded-200 border border-border-default bg-gray-100 px-350 py-300">
+            <p className="font-designer-20b text-gray-800">
+              Lesson {String(course.freeLessonCount).padStart(2, '0')}까지
+              무료로 온보딩을 하실 수 있어요! 무료로 즐겨보세요!
+            </p>
+            <p className="font-designer-16m text-gray-800">
+              이후 결제는 무료 온보딩을 하시고 결정하셔도 늦지 않습니다.
+            </p>
+          </div>
+        ) : null}
 
         {/* Journey map */}
         <div className="mt-500 flex flex-col items-center">

--- a/src/app/(landing)/class/vibe-intro/lesson/[id]/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/lesson/[id]/page.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { use, useEffect, useMemo, useState } from 'react';
+import MarkdownContentCore from '@/components/common/ui/rich-text/markdown-content-core';
 import {
   useGetBuilderFeeds,
   useGetCourseDrawer,
@@ -258,14 +259,26 @@ export default function LessonPage({
                   {lesson?.title ?? 'AI 처음 만나는 날'}
                 </h1>
               </div>
-              <p className="font-designer-16m text-gray-500">약 18분 소요</p>
+              <p className="font-designer-16m text-gray-500">
+                {lesson?.estimatedMinutes
+                  ? `약 ${lesson.estimatedMinutes}분 소요`
+                  : ''}
+              </p>
             </div>
 
             <div className="mt-[24px]">
               <LessonTabs value={tab} onChange={setTab} />
             </div>
 
-            <div className="mt-[24px] min-h-[964px] rounded-150 bg-background-default" />
+            <div className="mt-[24px] min-h-[964px] rounded-150 bg-background-default p-[40px]">
+              {lesson?.contentMarkdown ? (
+                <MarkdownContentCore content={lesson.contentMarkdown} />
+              ) : (
+                <p className="font-designer-16r text-gray-500">
+                  본문이 준비 중입니다.
+                </p>
+              )}
+            </div>
 
             <hr className="my-[40px] border-gray-300" />
 

--- a/src/types/api/course.types.ts
+++ b/src/types/api/course.types.ts
@@ -68,6 +68,7 @@ export interface LessonDetailResponse {
   courseTitle: string;
   title: string;
   isFree: boolean;
+  estimatedMinutes: number | null;
   videoUrl: string | null;
   lessonViewCount: number;
   retrospectivePurpose: string;


### PR DESCRIPTION
## Summary
- 레슨 상세 페이지의 빈 본문 영역에 `MarkdownContentCore`를 추가해 `lesson.contentMarkdown`(DB 저장된 마크다운 본문)을 화면에 그리도록 수정
- 소요시간을 하드코딩("약 18분 소요") → `lesson.estimatedMinutes` 동적 값으로 전환 (`LessonDetailResponse` 타입에 필드 누락분 추가)
- 학습 홈의 코스 제목 뱃지를 하드코딩("바이브 코딩 입문자 코스") → `course.title`로 전환
- 학습 홈 무료 온보딩 callout을 `course.freeLessonCount` 기반 동적 표시 (값 없을 시 숨김)

## 배경
test-api dev 백엔드에 `vibe-intro` 코스 + 8 챕터 + 30 레슨 본문이 admin API로 입력됨. 그러나 프론트가 응답 필드를 화면에 그리는 코드를 일부 가지고 있지 않아 본문/소요시간/코스 제목/무료 callout이 DB와 무관하게 하드코딩 표시되고 있었음. 본 PR은 그 격차를 해소.

## 화면 영향
- `/class/vibe-intro/home`: 코스 제목 뱃지·무료 callout이 DB 값 따라감
- `/class/vibe-intro/lesson/[id]`: 본문 마크다운 렌더링 + 소요시간 정확 표시

## Test plan
- [ ] dev 배포 후 `/class/vibe-intro/home` 접속 → 코스 제목 뱃지가 "바이브 코딩 입문자 코스 For Designer"로 표시 확인
- [ ] 무료 온보딩 callout 동작 확인 (등록 사용자: 표시 / 미등록: 숨김)
- [ ] L01 클릭 → 레슨 상세 진입 → 제목·"약 10분 소요"·본문 마크다운 정상 렌더 확인 (헤딩/blockquote/list/strong)
- [ ] L02, L03 동일 검증
- [ ] L04+ 진입 시 enrollment 미완료라면 LESSON_ACCESS_DENIED는 별도 UX, 본 PR 범위 밖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 강의 제목이 동적으로 표시됩니다.
  * 무료 수강 범위가 조건부로 표시되어 사용자에게 정확한 수강 한계를 안내합니다.
  * 레슨 페이지에서 예상 수강 시간 정보가 추가되었습니다.
  * 레슨 콘텐츠가 마크다운 형식으로 렌더링됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->