### PR TITLE
비회원 클래스 액션에 로그인 모달 추가

### DIFF
--- a/src/app/(landing)/class/[id]/page.tsx
+++ b/src/app/(landing)/class/[id]/page.tsx
@@ -12,12 +12,18 @@ import {
   MessageSquare,
   Share2,
 } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
 import { use, useMemo, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import { useAuth } from '@/features/auth/model/use-auth';
 import { useGetCourseCurriculum } from '@/hooks/queries/course/course-api';
 import { useToastStore } from '@/stores/use-toast-store';
+
+const LoginModal = dynamic(
+  () => import('@/components/auth/modals/login-modal'),
+);
 
 type Tab = 'roadmap' | 'builder-feed' | 'curriculum' | 'benefits' | 'faq';
 
@@ -106,6 +112,7 @@ export default function ClassDetailPage({
     new Set([0]),
   );
   const showToast = useToastStore((state) => state.showToast);
+  const { isAuthenticated } = useAuth();
 
   // 커리큘럼은 DB에서 가져오되, 코스가 없으면 하드코딩된 CHAPTERS로 fallback.
   const { data: curriculum } = useGetCourseCurriculum(slug);
@@ -532,12 +539,25 @@ export default function ClassDetailPage({
                   >
                     공유하기
                   </button>
-                  <Link
-                    href="/class/vibe-intro/home"
-                    className="flex h-700 w-full items-center justify-center rounded-100 bg-background-brand-default font-designer-14b text-text-inverse"
-                  >
-                    무료 코스 시작하기
-                  </Link>
+                  {isAuthenticated ? (
+                    <Link
+                      href="/class/vibe-intro/home"
+                      className="flex h-700 w-full items-center justify-center rounded-100 bg-background-brand-default font-designer-14b text-text-inverse"
+                    >
+                      무료 코스 시작하기
+                    </Link>
+                  ) : (
+                    <LoginModal
+                      openTrigger={
+                        <button
+                          type="button"
+                          className="flex h-700 w-full items-center justify-center rounded-100 bg-background-brand-default font-designer-14b text-text-inverse"
+                        >
+                          무료 코스 시작하기
+                        </button>
+                      }
+                    />
+                  )}
                 </div>
 
                 {/* Study With Me */}

--- a/src/app/(landing)/class/vibe-intro/(learning)/feed/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/(learning)/feed/page.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import { Heart, MessageCircle, Share2, ChevronDown } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import { useAuth } from '@/features/auth/model/use-auth';
 import {
   useGetBuilderFeeds,
   useGetCourseDetail,
 } from '@/hooks/queries/course/course-api';
+
+const LoginModal = dynamic(
+  () => import('@/components/auth/modals/login-modal'),
+);
 
 type SortOption = '최신순' | '좋아요 많은 순' | '댓글 많은 순' | '오래된 순';
 type LessonFilter =
@@ -89,6 +95,7 @@ const SORT_API_MAP: Record<SortOption, string> = {
 };
 
 export default function BuilderFeedPage() {
+  const { isAuthenticated } = useAuth();
   const [courseFilter, setCourseFilter] = useState<CourseFilter>('전체');
   const [sort, setSort] = useState<SortOption>('최신순');
   const [lessonFilter, setLessonFilter] = useState<LessonFilter>('전체');
@@ -209,12 +216,25 @@ export default function BuilderFeedPage() {
             </div>
 
             {/* Write CTA */}
-            <Link
-              href="/class/vibe-intro/feed/write"
-              className="rounded-100 bg-background-brand-default px-250 py-125 font-designer-16m text-text-inverse"
-            >
-              피드 올리기
-            </Link>
+            {isAuthenticated ? (
+              <Link
+                href="/class/vibe-intro/feed/write"
+                className="rounded-100 bg-background-brand-default px-250 py-125 font-designer-16m text-text-inverse"
+              >
+                피드 올리기
+              </Link>
+            ) : (
+              <LoginModal
+                openTrigger={
+                  <button
+                    type="button"
+                    className="rounded-100 bg-background-brand-default px-250 py-125 font-designer-16m text-text-inverse"
+                  >
+                    피드 올리기
+                  </button>
+                }
+              />
+            )}
           </div>
         </div>
 

--- a/src/app/(landing)/class/vibe-intro/(learning)/home/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/(learning)/home/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { BookOpen } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import { useAuth } from '@/features/auth/model/use-auth';
 import {
   useGetCourseCurriculum,
   useGetCourseDetail,
@@ -15,6 +17,10 @@ import type {
   CourseJourneyMapLessonResponse,
   LessonProgressStatus,
 } from '@/types/api/course.types';
+
+const LoginModal = dynamic(
+  () => import('@/components/auth/modals/login-modal'),
+);
 
 const COURSE_SLUG = 'vibe-intro';
 
@@ -187,7 +193,13 @@ function mergeLessons(
   });
 }
 
-function LessonStamp({ lesson }: { lesson: LessonDisplayInfo }) {
+function LessonStamp({
+  lesson,
+  isAuthenticated,
+}: {
+  lesson: LessonDisplayInfo;
+  isAuthenticated: boolean;
+}) {
   const isCompleted = lesson.status === 'COMPLETED';
   const isInProgress = lesson.status === 'IN_PROGRESS';
 
@@ -242,6 +254,11 @@ function LessonStamp({ lesson }: { lesson: LessonDisplayInfo }) {
   );
 
   if (lesson.accessible) {
+    if (!isAuthenticated) {
+      return (
+        <LoginModal openTrigger={<button type="button">{content}</button>} />
+      );
+    }
     return (
       <Link href={`/class/vibe-intro/lesson/${lesson.lessonId}`}>
         {content}
@@ -272,6 +289,7 @@ function ChapterHeader({ chapterNumber }: { chapterNumber: number }) {
 }
 
 export default function JourneyMapPage() {
+  const { isAuthenticated } = useAuth();
   const { data: course } = useGetCourseDetail(COURSE_SLUG);
   const courseId = course?.courseId ?? 0;
 
@@ -359,16 +377,29 @@ export default function JourneyMapPage() {
 
         {/* Journey map */}
         <div className="mt-500 flex flex-col items-center">
-          <Link
-            href={
-              chapters[0]?.lessons[0]
-                ? `/class/vibe-intro/lesson/${chapters[0].lessons[0].lessonId}`
-                : '#'
-            }
-            className="flex h-[44px] w-[100px] items-center justify-center rounded-100 bg-background-brand-default font-designer-24b text-white"
-          >
-            Start
-          </Link>
+          {isAuthenticated ? (
+            <Link
+              href={
+                chapters[0]?.lessons[0]
+                  ? `/class/vibe-intro/lesson/${chapters[0].lessons[0].lessonId}`
+                  : '#'
+              }
+              className="flex h-[44px] w-[100px] items-center justify-center rounded-100 bg-background-brand-default font-designer-24b text-white"
+            >
+              Start
+            </Link>
+          ) : (
+            <LoginModal
+              openTrigger={
+                <button
+                  type="button"
+                  className="flex h-[44px] w-[100px] items-center justify-center rounded-100 bg-background-brand-default font-designer-24b text-white"
+                >
+                  Start
+                </button>
+              }
+            />
+          )}
 
           {chapters.map((chapter, ci) => {
             const lessons = mergeLessons(chapter, lessonStatusMap);
@@ -427,7 +458,11 @@ export default function JourneyMapPage() {
                       )}
                     >
                       {row.map((lesson) => (
-                        <LessonStamp key={lesson.lessonId} lesson={lesson} />
+                        <LessonStamp
+                          key={lesson.lessonId}
+                          lesson={lesson}
+                          isAuthenticated={isAuthenticated}
+                        />
                       ))}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary

- 비회원 유저가 클래스 액션 클릭 시 기존 LoginModal 컴포넌트 사용
- 인증 방법: useAuth().isAuthenticated 을 확인해 조건부 렌더링
- 대상 버튼: 무료 코스 시작하기, Start, 레슨 스탬프, 피드 올리기

## Test plan

- [ ] 비로그인 상태에서 /class/basic 방문 → "무료 코스 시작하기" 클릭 → 로그인 모달 표시 확인
- [ ] /class/vibe-intro/home 방문 → Start 버튼 클릭 → 로그인 모달 로그인 모달 표시 확인
- [ ] /class/vibe-intro/feed 방문 → "피드 올리기" 클릭 → 로그인 모달 표시 확인

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 주요 사용자 액션(코스 시작, 피드 작성, 레슨 진행)이 인증 상태에 따라 보호됩니다. 로그인하지 않은 사용자가 이러한 기능을 사용하려 할 때 로그인 모달이 표시되어 인증을 유도합니다. 로그인한 사용자의 경험은 변하지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->