### PR TITLE
클래스/레슨 페이지 기능 추가

### DIFF
--- a/.claude/rules/no-img-no-eslint-disable.md
+++ b/.claude/rules/no-img-no-eslint-disable.md
@@ -1,0 +1,32 @@
+# No `<img>` Tag, No eslint-disable Comments
+
+## `<img>` tag is banned
+
+Always use `<Image>` from `next/image`. No exceptions.
+
+For blob URLs (`URL.createObjectURL`), use `<Image unoptimized>` — that prop exists exactly for this case:
+
+```tsx
+// ❌ Never
+<img src={blobUrl} />
+// eslint-disable-next-line @next/next/no-img-element
+<img src={blobUrl} />
+
+// ✅ Always
+<Image src={blobUrl} width={100} height={100} unoptimized alt="..." />
+```
+
+## eslint-disable comments are banned
+
+Treat inline `eslint-disable` comments the same as `--no-verify`. Both are explicitly banned.
+
+When lint blocks a pattern, fix the root cause — use the correct API or component. Never silence the linter.
+
+```tsx
+// ❌ Never silence lint
+// eslint-disable-next-line @next/next/no-img-element
+<img src={url} />
+
+// ✅ Fix the root cause
+<Image src={url} unoptimized ... />
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ yarn typecheck      # No type errors
 - No Tailwind arbitrary values (`p-[4px]`, `w-[320px]`). Use project custom tokens.
 - No hardcoded colors/spacing. Use only `@theme inline` tokens from `global.css`.
 
+@.claude/rules/no-img-no-eslint-disable.md
+
 ---
 
 ## Project Overview

--- a/src/api/client/axios.ts
+++ b/src/api/client/axios.ts
@@ -46,3 +46,22 @@ axiosInstanceForMultipart.interceptors.response.use(
     axiosInstanceForMultipart(requestConfig),
   ),
 );
+
+// v5 Class API 전용 인스턴스
+export const axiosInstanceV5 = axios.create({
+  baseURL: `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v5/`,
+  timeout: 60000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  withCredentials: true,
+});
+
+attachApiLogger(axiosInstanceV5, 'client-v5-json');
+axiosInstanceV5.interceptors.request.use(attachAccessTokenToRequest);
+axiosInstanceV5.interceptors.response.use(
+  (config) => config,
+  createClientAuthResponseRejectedHandler((requestConfig) =>
+    axiosInstanceV5(requestConfig),
+  ),
+);

--- a/src/app/(landing)/class/[id]/page.tsx
+++ b/src/app/(landing)/class/[id]/page.tsx
@@ -84,14 +84,6 @@ const TEAM_MESSAGES = [
   },
 ];
 
-const FAQ_ITEMS = [
-  '코딩 한 번도 안 해봤는데 따라갈 수 있나요?',
-  '어떤 준비물이 필요한가요?',
-  '하루에 얼마나 시간을 써야 하나요?',
-  'Claude Pro를 이미 구독 중이에요!',
-  '환불이 가능한가요?',
-];
-
 const CHAPTERS = [
   {
     num: '01',
@@ -123,12 +115,14 @@ export default function ClassDetailPage({
   const [expandedChapters, setExpandedChapters] = useState<Set<number>>(
     new Set([0]),
   );
+  const [expandedFaq, setExpandedFaq] = useState<number | null>(null);
   const showToast = useToastStore((state) => state.showToast);
   const { isAuthenticated } = useAuth();
 
   // 커리큘럼은 DB에서 가져오되, 코스가 없으면 하드코딩된 CHAPTERS로 fallback.
   const { data: curriculum } = useGetCourseCurriculum(slug);
   const { data: courseDetail } = useGetCourseDetail(slug);
+
   const { data: allCourses } = useGetCourseList();
   const courseSummary = allCourses?.find((c) => c.slug === slug);
   const chaptersForRoadmap = useMemo(() => {
@@ -659,26 +653,91 @@ export default function ClassDetailPage({
               </div>
             </section>
 
+            {/* SECTION: 강사진 */}
+            {courseDetail?.instructors &&
+              courseDetail.instructors.length > 0 && (
+                <section>
+                  <h2 className="font-designer-24b text-gray-800">
+                    강사진 소개
+                  </h2>
+                  <div className="mt-400 space-y-300">
+                    {courseDetail.instructors.map((instructor) => (
+                      <div
+                        key={instructor.name}
+                        className="flex items-start gap-300 rounded-200 border border-border-default bg-gray-100 p-350"
+                      >
+                        {instructor.profileImageUrl && (
+                          <Image
+                            src={instructor.profileImageUrl}
+                            alt={instructor.name}
+                            width={64}
+                            height={64}
+                            className="shrink-0 rounded-full object-cover"
+                          />
+                        )}
+                        <div>
+                          <p className="font-designer-20b text-gray-800">
+                            {instructor.name}
+                          </p>
+                          {instructor.role && (
+                            <p className="mt-75 font-designer-16m text-text-brand">
+                              {instructor.role}
+                            </p>
+                          )}
+                          {instructor.bio && (
+                            <p className="mt-150 font-designer-16r text-gray-800">
+                              {instructor.bio}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+
             {/* SECTION: FAQ */}
             <section id="faq">
               <h2 className="font-designer-24b text-gray-800">
                 궁금한 점 있으세요?
               </h2>
               <div className="mt-400 space-y-125">
-                {FAQ_ITEMS.map((question) => (
+                {(courseDetail?.faqs ?? []).map((faq, idx) => (
                   <div
-                    key={question}
-                    className="flex h-800 items-center justify-between rounded-200 border border-border-default bg-gray-100 px-350"
+                    key={faq.question}
+                    className="overflow-hidden rounded-200 border border-border-default bg-gray-100"
                   >
-                    <div className="flex items-center">
-                      <span className="mr-250 font-designer-16m text-text-brand">
-                        Q
-                      </span>
-                      <span className="font-designer-16m text-gray-800">
-                        {question}
-                      </span>
-                    </div>
-                    <ChevronDown className="h-300 w-300 shrink-0 text-gray-800" />
+                    <button
+                      type="button"
+                      className="flex h-800 w-full items-center justify-between px-350"
+                      onClick={() =>
+                        setExpandedFaq(expandedFaq === idx ? null : idx)
+                      }
+                    >
+                      <div className="flex items-center">
+                        <span className="mr-250 font-designer-16m text-text-brand">
+                          Q
+                        </span>
+                        <span className="font-designer-16m text-gray-800">
+                          {faq.question}
+                        </span>
+                      </div>
+                      {expandedFaq === idx ? (
+                        <ChevronUp className="h-300 w-300 shrink-0 text-gray-800" />
+                      ) : (
+                        <ChevronDown className="h-300 w-300 shrink-0 text-gray-800" />
+                      )}
+                    </button>
+                    {expandedFaq === idx && (
+                      <div className="flex items-start gap-250 border-t border-border-default px-350 py-300">
+                        <span className="font-designer-16m text-gray-500">
+                          A
+                        </span>
+                        <span className="font-designer-16r text-gray-800">
+                          {faq.answer}
+                        </span>
+                      </div>
+                    )}
                   </div>
                 ))}
               </div>
@@ -686,7 +745,7 @@ export default function ClassDetailPage({
           </div>
 
           {/* RIGHT: sticky sidebar */}
-          <div className="sticky top-[57px]">
+          <div className="sticky top-550">
             <div className="overflow-hidden rounded-150 border border-border-subtle">
               <div className="p-300">
                 <h3 className="font-designer-28b text-gray-800">

--- a/src/app/(landing)/class/vibe-intro/(learning)/home/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/(learning)/home/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { BookOpen } from 'lucide-react';
+import { BookOpen, Lock, LockOpen, Timer, Users } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import { useAuth } from '@/features/auth/model/use-auth';
 import {
@@ -24,7 +25,6 @@ const LoginModal = dynamic(
 
 const COURSE_SLUG = 'vibe-intro';
 
-// Fallback chapter structure used when backend has no data yet (404).
 const FALLBACK_CHAPTERS: CourseCurriculumChapterResponse[] = [
   {
     chapterId: -1,
@@ -166,6 +166,7 @@ interface LessonDisplayInfo {
   isFree: boolean;
   status: LessonProgressStatus;
   accessible: boolean;
+  estimatedMinutes: number;
 }
 
 function buildLessonMap(
@@ -189,6 +190,7 @@ function mergeLessons(
       isFree: l.isFree,
       status: journeyLesson?.status ?? (l.locked ? 'LOCKED' : 'IN_PROGRESS'),
       accessible: journeyLesson?.accessible ?? !l.locked,
+      estimatedMinutes: l.estimatedMinutes,
     };
   });
 }
@@ -200,42 +202,40 @@ function LessonStamp({
   lesson: LessonDisplayInfo;
   isAuthenticated: boolean;
 }) {
+  const [showTooltip, setShowTooltip] = useState(false);
   const isCompleted = lesson.status === 'COMPLETED';
-  const isInProgress = lesson.status === 'IN_PROGRESS';
+  const isLocked = lesson.status === 'LOCKED';
+  const isCurrent = lesson.status === 'IN_PROGRESS' && lesson.accessible;
 
-  const content = (
-    <div className="relative flex h-[172px] w-[172px] shrink-0 flex-col items-center justify-center">
+  const stampContent = (
+    <div
+      className="relative flex size-1650 shrink-0 flex-col items-center justify-center"
+      onMouseEnter={() => !isCompleted && setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+    >
       <Image
         src="/class/vibe-intro/lesson-stamp.svg"
         alt=""
         aria-hidden="true"
-        width={172}
-        height={172}
+        width={132}
+        height={132}
         className={cn(
           'absolute inset-0',
           isCompleted && 'brightness-110 saturate-150',
-          isInProgress && 'animate-pulse',
+          isCurrent && 'animate-pulse',
         )}
       />
       <div className="relative z-10 flex flex-col items-center">
-        {lesson.isFree && !isCompleted && (
+        {lesson.isFree && !isCompleted && !isLocked && (
           <p className="mb-25 font-designer-16m text-gray-500">무료 온보딩</p>
         )}
-        {!lesson.isFree && lesson.status === 'LOCKED' && (
-          <Image
-            src="/class/vibe-intro/lesson-lock.svg"
-            alt="잠금"
-            width={24}
-            height={24}
-            className="mb-25"
-          />
-        )}
+        {isLocked && <Lock className="mb-25 size-300 text-gray-500" />}
         {isCompleted && (
           <p className="mb-25 font-designer-12b text-text-brand">완료</p>
         )}
         <p
           className={cn(
-            'font-designer-24b',
+            'font-designer-18b',
             isCompleted ? 'text-text-brand' : 'text-gray-500',
           )}
         >
@@ -243,47 +243,64 @@ function LessonStamp({
         </p>
         <p
           className={cn(
-            'font-designer-24b',
+            'font-designer-18b',
             isCompleted ? 'text-text-brand' : 'text-gray-500',
           )}
         >
           {String(lesson.order).padStart(2, '0')}
         </p>
       </div>
+      {showTooltip && (
+        <div className="absolute -top-400 left-1/2 flex -translate-x-1/2 items-center gap-75 rounded-100 bg-gray-900 px-150 py-75">
+          <Users className="size-200 text-gray-0" />
+          <span className="font-designer-12r text-gray-0">학습 중</span>
+        </div>
+      )}
     </div>
   );
 
   if (lesson.accessible) {
     if (!isAuthenticated) {
       return (
-        <LoginModal openTrigger={<button type="button">{content}</button>} />
+        <LoginModal
+          openTrigger={<button type="button">{stampContent}</button>}
+        />
       );
     }
     return (
       <Link href={`/class/vibe-intro/lesson/${lesson.lessonId}`}>
-        {content}
+        {stampContent}
       </Link>
     );
   }
 
   return (
     <div aria-disabled="true" className="cursor-not-allowed">
-      {content}
+      {stampContent}
     </div>
   );
 }
 
-function ChapterHeader({ chapterNumber }: { chapterNumber: number }) {
+function ChapterHeader({
+  chapterNumber,
+  title,
+}: {
+  chapterNumber: number;
+  title: string;
+}) {
   return (
-    <div className="relative flex w-full items-center">
-      <div className="h-px flex-1 bg-rose-500" />
-      <div className="mx-0 flex items-center gap-125 rounded-full border border-rose-500 bg-background-default px-250 py-125">
-        <BookOpen className="h-300 w-300 text-text-brand" />
-        <p className="font-designer-24b text-text-brand">
-          Chapter {String(chapterNumber).padStart(2, '0')}
-        </p>
+    <div className="flex w-full flex-col items-center gap-250">
+      <div className="relative flex w-full items-center">
+        <div className="h-px flex-1 bg-rose-500" />
+        <div className="mx-0 flex items-center gap-125 rounded-full border border-rose-500 bg-background-default px-250 py-125">
+          <BookOpen className="h-300 w-300 text-text-brand" />
+          <p className="font-designer-24b text-text-brand">
+            Chapter {String(chapterNumber).padStart(2, '0')}
+          </p>
+        </div>
+        <div className="h-px flex-1 bg-rose-500" />
       </div>
-      <div className="h-px flex-1 bg-rose-500" />
+      <p className="font-designer-20b text-text-brand">{title}</p>
     </div>
   );
 }
@@ -296,19 +313,24 @@ export default function JourneyMapPage() {
   const { data: curriculum, isLoading } = useGetCourseCurriculum(COURSE_SLUG);
   const { data: journeyMap } = useGetCourseJourneyMap(courseId);
   const { data: progress } = useGetCourseProgress(courseId);
+  const [visibleChapterCount, setVisibleChapterCount] = useState(2);
 
   const lessonStatusMap = buildLessonMap(journeyMap?.lessons ?? []);
   const chapters =
     curriculum?.chapters && curriculum.chapters.length > 0
       ? curriculum.chapters
       : FALLBACK_CHAPTERS;
+
   const completedLessons = progress?.completedLessons ?? 0;
   const totalLessons = progress?.totalLessons ?? 0;
   const progressRate = progress?.progressRate ?? 0;
 
+  const visibleChapters = chapters.slice(0, visibleChapterCount);
+  const hasMoreChapters = visibleChapterCount < chapters.length;
+
   if (isLoading) {
     return (
-      <div className="flex min-h-[400px] items-center justify-center">
+      <div className="flex min-h-5000 items-center justify-center">
         <p className="font-designer-16r text-gray-500">로딩 중...</p>
       </div>
     );
@@ -343,14 +365,14 @@ export default function JourneyMapPage() {
               width={173}
               height={61}
             />
-            <p className="absolute left-1/2 top-1/3 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap font-designer-20b text-center text-text-brand">
+            <p className="absolute left-1/2 top-1/3 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap text-center font-designer-20b text-text-brand">
               {completedLessons === 0
                 ? `Chapter 01  시작!`
                 : `${completedLessons}개 완료!`}
             </p>
           </div>
           <div className="flex-1">
-            <div className="relative h-[20px] overflow-hidden rounded-full bg-gray-200">
+            <div className="relative h-250 overflow-hidden rounded-full bg-gray-200">
               <div
                 className="absolute left-0 top-0 h-full rounded-full bg-background-brand-default transition-all"
                 style={{ width: `${progressRate}%` }}
@@ -366,8 +388,7 @@ export default function JourneyMapPage() {
         {course?.freeLessonCount && course.freeLessonCount > 0 ? (
           <div className="mt-300 flex flex-col gap-75 rounded-200 border border-border-default bg-gray-100 px-350 py-300">
             <p className="font-designer-20b text-gray-800">
-              Lesson {String(course.freeLessonCount).padStart(2, '0')}까지
-              무료로 온보딩을 하실 수 있어요! 무료로 즐겨보세요!
+              Chapter3까지 무료 코스! 마음껏 학습하세요.
             </p>
             <p className="font-designer-16m text-gray-800">
               이후 결제는 무료 온보딩을 하시고 결정하셔도 늦지 않습니다.
@@ -377,32 +398,9 @@ export default function JourneyMapPage() {
 
         {/* Journey map */}
         <div className="mt-500 flex flex-col items-center">
-          {isAuthenticated ? (
-            <Link
-              href={
-                chapters[0]?.lessons[0]
-                  ? `/class/vibe-intro/lesson/${chapters[0].lessons[0].lessonId}`
-                  : '#'
-              }
-              className="flex h-[44px] w-[100px] items-center justify-center rounded-100 bg-background-brand-default font-designer-24b text-white"
-            >
-              Start
-            </Link>
-          ) : (
-            <LoginModal
-              openTrigger={
-                <button
-                  type="button"
-                  className="flex h-[44px] w-[100px] items-center justify-center rounded-100 bg-background-brand-default font-designer-24b text-white"
-                >
-                  Start
-                </button>
-              }
-            />
-          )}
-
-          {chapters.map((chapter, ci) => {
+          {visibleChapters.map((chapter, ci) => {
             const lessons = mergeLessons(chapter, lessonStatusMap);
+
             const rows: LessonDisplayInfo[][] = [];
             for (let i = 0; i < lessons.length; i += 3) {
               rows.push(lessons.slice(i, i + 3));
@@ -410,16 +408,90 @@ export default function JourneyMapPage() {
 
             return (
               <div
-                key={chapter.chapterId}
+                key={chapter.order}
                 className="flex w-full flex-col items-center"
               >
-                <div className="mt-400 w-full max-w-[1060px]">
-                  <ChapterHeader chapterNumber={chapter.chapterNumber} />
+                <div className="mt-400 w-full">
+                  <ChapterHeader
+                    chapterNumber={chapter.chapterNumber}
+                    title={chapter.title}
+                  />
                 </div>
 
                 {rows.map((row, ri) => (
                   <div key={ri} className="flex w-full flex-col items-center">
-                    {(ci > 0 || ri > 0) && (
+                    <div
+                      className={cn(
+                        'relative flex items-center justify-center',
+                        ci === 0 && ri === 0 ? 'mt-800' : 'mt-300',
+                      )}
+                    >
+                      {ci === 0 && ri === 0 && (
+                        <div className="absolute inset-0 flex items-center justify-center">
+                          <Image
+                            src="/class/vibe-intro/journey-1st-load.svg"
+                            alt=""
+                            aria-hidden="true"
+                            width={795}
+                            height={10}
+                          />
+                        </div>
+                      )}
+                      <div
+                        className={cn(
+                          'relative z-10 flex items-center justify-center gap-2500',
+                          ri % 2 === 1 && 'flex-row-reverse',
+                        )}
+                      >
+                        {row.map((lesson, li) => (
+                          <div key={lesson.lessonId} className="relative">
+                            {ci === 0 && ri === 0 && li === 0 && (
+                              <div className="absolute bottom-full left-1/2 flex -translate-x-1/2 flex-col items-center">
+                                {isAuthenticated ? (
+                                  <Link
+                                    href={
+                                      chapters[0]?.lessons[0]
+                                        ? `/class/vibe-intro/lesson/${chapters[0].lessons[0].lessonId}`
+                                        : '#'
+                                    }
+                                    className="flex h-450 w-1250 items-center justify-center rounded-100 bg-background-brand-default font-designer-24b text-gray-0"
+                                  >
+                                    Start
+                                  </Link>
+                                ) : (
+                                  <LoginModal
+                                    openTrigger={
+                                      <button
+                                        type="button"
+                                        className="flex h-450 w-1250 items-center justify-center rounded-100 bg-background-brand-default font-designer-24b text-gray-0"
+                                      >
+                                        Start
+                                      </button>
+                                    }
+                                  />
+                                )}
+                                <svg
+                                  aria-hidden="true"
+                                  width="21"
+                                  height="24"
+                                  viewBox="0 0 21 24"
+                                >
+                                  <polygon
+                                    points="0,0 21,0 10.5,13"
+                                    className="fill-background-brand-default"
+                                  />
+                                </svg>
+                              </div>
+                            )}
+                            <LessonStamp
+                              lesson={lesson}
+                              isAuthenticated={isAuthenticated}
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                    {ri < rows.length - 1 && (
                       <div className="flex justify-center">
                         {ri % 2 === 0 ? (
                           <Image
@@ -440,35 +512,10 @@ export default function JourneyMapPage() {
                         )}
                       </div>
                     )}
-                    {ci === 0 && ri === 0 && (
-                      <div className="mt-300 flex justify-center">
-                        <Image
-                          src="/class/vibe-intro/journey-1st-load.svg"
-                          alt=""
-                          aria-hidden="true"
-                          width={795}
-                          height={10}
-                        />
-                      </div>
-                    )}
-                    <div
-                      className={cn(
-                        'mt-300 flex items-center justify-center gap-[200px]',
-                        ri % 2 === 1 && 'flex-row-reverse',
-                      )}
-                    >
-                      {row.map((lesson) => (
-                        <LessonStamp
-                          key={lesson.lessonId}
-                          lesson={lesson}
-                          isAuthenticated={isAuthenticated}
-                        />
-                      ))}
-                    </div>
                   </div>
                 ))}
 
-                {ci < chapters.length - 1 && (
+                {ci < visibleChapters.length - 1 && (
                   <div className="flex justify-center">
                     <Image
                       src="/class/vibe-intro/journey-load.svg"
@@ -483,25 +530,41 @@ export default function JourneyMapPage() {
             );
           })}
 
-          <div className="mt-400">
-            <button
-              type="button"
-              disabled={!progress?.isCourseCompleted}
-              className={cn(
-                'flex h-[44px] w-[100px] items-center justify-center rounded-100 font-designer-24b text-white',
-                progress?.isCourseCompleted
-                  ? 'bg-background-brand-default'
-                  : 'cursor-not-allowed bg-gray-300',
-              )}
-            >
-              Finish
-            </button>
-          </div>
+          {hasMoreChapters ? (
+            <div className="mt-500">
+              <button
+                type="button"
+                onClick={() =>
+                  setVisibleChapterCount((prev) =>
+                    Math.min(prev + 2, chapters.length),
+                  )
+                }
+                className="rounded-100 border border-gray-400 px-400 py-200 font-designer-16r text-gray-800"
+              >
+                더보기
+              </button>
+            </div>
+          ) : (
+            <div className="mt-400">
+              <button
+                type="button"
+                disabled={!progress?.isCourseCompleted}
+                className={cn(
+                  'flex h-450 w-1250 items-center justify-center rounded-100 font-designer-24b text-white',
+                  progress?.isCourseCompleted
+                    ? 'bg-background-brand-default'
+                    : 'cursor-not-allowed bg-gray-300',
+                )}
+              >
+                Finish
+              </button>
+            </div>
+          )}
         </div>
 
         {/* Lesson card list */}
         <div className="mt-800">
-          <h2 className="font-designer-28b text-gray-800">전체 레슨 목록</h2>
+          <h2 className="font-designer-28b text-gray-800">레슨 목록</h2>
           <div className="mt-400 flex flex-col gap-200">
             {chapters.flatMap((chapter) =>
               chapter.lessons.map((l) => {
@@ -512,18 +575,18 @@ export default function JourneyMapPage() {
                 const card = (
                   <div
                     className={cn(
-                      'flex items-center gap-300 rounded-200 border bg-background-default p-300 transition-colors',
+                      'flex h-1250 items-center gap-300 rounded-200 border px-500 transition-colors',
                       isAccessible
-                        ? 'cursor-pointer border-border-default hover:border-border-brand'
-                        : 'cursor-not-allowed border-border-subtle opacity-60',
+                        ? 'cursor-pointer border-gray-300 bg-gray-50 hover:border-border-brand'
+                        : 'cursor-not-allowed border-gray-300 bg-gray-50 opacity-60',
                     )}
                   >
                     <div
                       className={cn(
-                        'flex h-[48px] w-[48px] shrink-0 items-center justify-center rounded-full font-designer-16b',
+                        'flex size-550 shrink-0 items-center justify-center rounded-50 font-designer-16b text-gray-0',
                         isCompleted
-                          ? 'bg-background-brand-default text-white'
-                          : 'bg-gray-200 text-gray-500',
+                          ? 'bg-background-brand-default'
+                          : 'bg-gray-400',
                       )}
                     >
                       {String(l.order).padStart(2, '0')}
@@ -537,29 +600,24 @@ export default function JourneyMapPage() {
                       >
                         {l.title}
                       </p>
-                      <div className="flex items-center gap-200">
+                      <div className="flex items-center gap-150">
                         {l.isFree && (
-                          <span className="rounded-full bg-rose-100 px-150 py-25 font-designer-12b text-text-brand">
+                          <span className="rounded-50 bg-rose-100 px-150 py-25 font-designer-12b text-text-brand">
                             무료
                           </span>
                         )}
-                        <span className="font-designer-14r text-gray-500">
-                          약 {l.estimatedMinutes}분
+                        <span className="flex items-center gap-50 font-designer-12r text-gray-500">
+                          <Timer className="size-200" />
+                          {l.estimatedMinutes}분
                         </span>
-                        {isCompleted && (
-                          <span className="font-designer-14b text-text-brand">
-                            완료
-                          </span>
-                        )}
-                        {!isAccessible && (
-                          <span className="font-designer-14r text-gray-400">
-                            잠김
-                          </span>
-                        )}
                       </div>
                     </div>
-                    {isAccessible && (
-                      <BookOpen className="h-300 w-300 shrink-0 text-gray-400" />
+                    {isCompleted ? (
+                      <LockOpen className="size-300 shrink-0 text-text-brand" />
+                    ) : isAccessible ? (
+                      <LockOpen className="size-300 shrink-0 text-gray-400" />
+                    ) : (
+                      <Lock className="size-300 shrink-0 text-gray-400" />
                     )}
                   </div>
                 );

--- a/src/app/(landing)/class/vibe-intro/lesson/[id]/_components/lesson-builder-feed-card.tsx
+++ b/src/app/(landing)/class/vibe-intro/lesson/[id]/_components/lesson-builder-feed-card.tsx
@@ -7,15 +7,17 @@ import {
   MessageCircle,
   Share2,
 } from 'lucide-react';
+import Image from 'next/image';
 import { useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import type { BuilderFeedPreviewItemResponse } from '@/types/api/course.types';
 
 interface Props {
   feeds: BuilderFeedPreviewItemResponse[];
+  onSelectFeed?: (feedId: number) => void;
 }
 
-export function LessonBuilderFeedCard({ feeds }: Props) {
+export function LessonBuilderFeedCard({ feeds, onSelectFeed }: Props) {
   const [page, setPage] = useState(0);
   const total = feeds.length;
   const hasFeed = total > 0;
@@ -26,16 +28,23 @@ export function LessonBuilderFeedCard({ feeds }: Props) {
       <p className="font-designer-16b text-gray-1000">지금 HOT한 빌더 피드</p>
 
       <div className="relative">
-        <div className="h-2325 overflow-hidden rounded-150 bg-gray-600">
+        <button
+          type="button"
+          onClick={() => current && onSelectFeed?.(current.feedId)}
+          className="h-2325 w-full overflow-hidden rounded-150 bg-gray-600"
+          disabled={!onSelectFeed}
+        >
           {current?.thumbnailUrl && (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
+            <Image
               src={current.thumbnailUrl}
               alt=""
+              width={314}
+              height={186}
+              unoptimized
               className="h-full w-full object-cover"
             />
           )}
-        </div>
+        </button>
 
         {hasFeed && total > 1 && (
           <>

--- a/src/app/(landing)/class/vibe-intro/lesson/[id]/_components/lesson-builder-feed-detail-modal.tsx
+++ b/src/app/(landing)/class/vibe-intro/lesson/[id]/_components/lesson-builder-feed-detail-modal.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { Heart, MessageCircle, X } from 'lucide-react';
+import Image from 'next/image';
+import { useGetBuilderFeedDetail } from '@/hooks/queries/course/course-api';
+
+interface Props {
+  feedId: number | null;
+  onClose: () => void;
+}
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr)
+    .toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    .replace(/\. /g, '.')
+    .replace(/\.$/, '');
+}
+
+export function LessonBuilderFeedDetailModal({ feedId, onClose }: Props) {
+  const { data: feed, isLoading } = useGetBuilderFeedDetail(feedId ?? 0);
+
+  if (feedId === null) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-gray-1000/40" onClick={onClose} />
+      <div className="relative z-10 mx-400 flex max-h-modal w-full max-w-[800px] flex-col rounded-200 bg-background-default shadow-3">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border-subtle px-400 py-300">
+          <p className="font-designer-16b text-gray-800">빌더 피드</p>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-800"
+          >
+            <X className="h-300 w-300" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="overflow-y-auto px-400 py-350">
+          {isLoading ? (
+            <div className="flex h-2500 items-center justify-center">
+              <p className="font-designer-16r text-gray-400">불러오는 중...</p>
+            </div>
+          ) : !feed ? (
+            <div className="flex h-2500 items-center justify-center">
+              <p className="font-designer-16r text-gray-400">
+                피드를 불러올 수 없어요.
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-300">
+              {/* Author row */}
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-150">
+                  <div className="flex h-400 w-400 shrink-0 items-center justify-center rounded-full bg-gray-200">
+                    <p className="font-designer-14b text-gray-600">
+                      {feed.author.nickname.charAt(0)}
+                    </p>
+                  </div>
+                  <p className="font-designer-14b text-gray-800">
+                    {feed.author.nickname}
+                  </p>
+                </div>
+                <p className="font-designer-13m text-gray-400">
+                  {formatDate(feed.createdAt)}
+                </p>
+              </div>
+
+              {/* Content */}
+              <p className="whitespace-pre-wrap font-designer-16r leading-relaxed text-gray-800">
+                {feed.content}
+              </p>
+
+              {/* Images */}
+              {feed.imageUrls.length > 0 && (
+                <div className="flex flex-wrap gap-200">
+                  {feed.imageUrls.map((url, i) => (
+                    <Image
+                      key={i}
+                      src={url}
+                      alt={`피드 이미지 ${i + 1}`}
+                      width={400}
+                      height={300}
+                      unoptimized
+                      className="max-h-[300px] rounded-100 object-cover"
+                    />
+                  ))}
+                </div>
+              )}
+
+              {/* Stats */}
+              <div className="flex items-center gap-200 border-t border-border-subtle pt-250">
+                <div className="flex items-center gap-50">
+                  <Heart className="h-250 w-250 text-gray-800" />
+                  <p className="font-designer-14r text-gray-800">
+                    {feed.likeCount}
+                  </p>
+                </div>
+                <div className="flex items-center gap-50">
+                  <MessageCircle className="h-250 w-250 text-gray-800" />
+                  <p className="font-designer-14r text-gray-800">
+                    {feed.commentCount}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(landing)/class/vibe-intro/lesson/[id]/_components/lesson-qna-card.tsx
+++ b/src/app/(landing)/class/vibe-intro/lesson/[id]/_components/lesson-qna-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, MessageSquare } from 'lucide-react';
 import { useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import type { LessonQnaMyItem } from '@/types/api/course.types';
@@ -31,9 +31,7 @@ export function LessonQnaCard({ myQnas, onAskClick, onSelectQna }: Props) {
         <p className="text-center font-designer-14r text-gray-1000">
           30분 이상 막히면 바로 질문하기!
           <br />
-          운영자들이 대기 중입니다.
-          <br />
-          질문을 남겨주시면 누구보다 빠르게 대답해드릴게요.
+          질문을 남겨주시면 빠르게 답변드립니다.
         </p>
       </div>
 
@@ -62,6 +60,10 @@ export function LessonQnaCard({ myQnas, onAskClick, onSelectQna }: Props) {
             <p className="flex-1 truncate font-designer-14b text-gray-800">
               {current.title}
             </p>
+            <div className="flex shrink-0 items-center gap-50 font-designer-13m text-gray-400">
+              <MessageSquare className="h-225 w-225" />
+              <span>{current.answerCount}</span>
+            </div>
             <p className="shrink-0 font-designer-13m text-gray-400">
               {formatDate(current.createdAt)}
             </p>

--- a/src/app/(landing)/class/vibe-intro/lesson/[id]/_components/lesson-qna-submission-modal.tsx
+++ b/src/app/(landing)/class/vibe-intro/lesson/[id]/_components/lesson-qna-submission-modal.tsx
@@ -1,46 +1,117 @@
 'use client';
 
-import { ChevronDown, ImageIcon, X } from 'lucide-react';
-import { useState } from 'react';
+import { ImageIcon, Info, X } from 'lucide-react';
+import Image from 'next/image';
+import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import MarkdownEditor from '@/components/common/ui/editor/markdown-editor';
+import { uploadCommunityMarkdownImage } from '@/features/community/model/community-markdown-image-upload';
 import { useCreateLessonQna } from '@/hooks/queries/course/course-api';
 import { useToastStore } from '@/stores/use-toast-store';
 import { analyzeError } from '@/utils/error-handler';
 
 interface Props {
   lessonId: number;
+  courseId: number;
   open: boolean;
   onClose: () => void;
 }
 
-export function LessonQnaSubmissionModal({ lessonId, open, onClose }: Props) {
+interface AttachedImage {
+  previewUrl: string;
+  key: string;
+}
+
+export function LessonQnaSubmissionModal({
+  lessonId,
+  courseId,
+  open,
+  onClose,
+}: Props) {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [cautionOpen, setCautionOpen] = useState(false);
+  const [images, setImages] = useState<AttachedImage[]>([]);
+  const [noticeVisible, setNoticeVisible] = useState(true);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const showToast = useToastStore((s) => s.showToast);
   const createQna = useCreateLessonQna();
 
+  useEffect(() => {
+    if (!open) return;
+    const draft = localStorage.getItem(`lesson-qna-draft-${lessonId}`);
+    if (!draft) return;
+    try {
+      const { title: t, content: c } = JSON.parse(draft);
+      setTitle(t ?? '');
+      setContent(c ?? '');
+    } catch {
+      // malformed draft — ignore
+    }
+  }, [open, lessonId]);
+
   if (!open) return null;
 
+  async function handleImageAdd(file: File) {
+    if (images.length >= 10) {
+      showToast('최대 10장까지 첨부 가능합니다.', 'error');
+      return;
+    }
+    setIsUploadingImage(true);
+    try {
+      const publicUrl = await uploadCommunityMarkdownImage(file);
+      const previewUrl = URL.createObjectURL(file);
+      setImages((prev) => [...prev, { previewUrl, key: publicUrl }]);
+    } catch {
+      showToast('이미지 업로드에 실패했습니다.', 'error');
+    } finally {
+      setIsUploadingImage(false);
+    }
+  }
+
+  function handleImageRemove(index: number) {
+    setImages((prev) => {
+      const next = [...prev];
+      URL.revokeObjectURL(next[index].previewUrl);
+      next.splice(index, 1);
+      return next;
+    });
+  }
+
+  function handleDraftSave() {
+    localStorage.setItem(
+      `lesson-qna-draft-${lessonId}`,
+      JSON.stringify({ title, content }),
+    );
+    showToast('임시저장되었습니다.');
+  }
+
   function handleSubmit() {
-    if (!title.trim() || !content.trim()) {
-      showToast('제목과 내용을 입력해주세요.', 'error');
+    if (!title.trim()) {
+      showToast('제목을 입력해주세요.', 'error');
+      return;
+    }
+    if (!content.trim() || content.trim() === '<p></p>') {
+      showToast('내용을 입력해주세요.', 'error');
       return;
     }
     createQna.mutate(
       {
-        lessonId,
+        courseId,
         request: {
+          lessonId,
           title: title.trim(),
           content: content.trim(),
-          imageUrls: [], // TODO: wire file upload API
+          imageKeys: images.map((img) => img.key),
         },
       },
       {
         onSuccess: () => {
           showToast('질문이 등록되었어요!');
+          localStorage.removeItem(`lesson-qna-draft-${lessonId}`);
           setTitle('');
           setContent('');
+          setImages([]);
           onClose();
         },
         onError: (error) => {
@@ -54,101 +125,152 @@ export function LessonQnaSubmissionModal({ lessonId, open, onClose }: Props) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-gray-1000/40" onClick={onClose} />
-      <div className="relative z-10 flex w-full max-w-[800px] flex-col rounded-200 bg-background-default shadow-3 mx-400">
+      <div className="relative z-10 mx-400 flex max-h-[90vh] w-full max-w-[800px] flex-col overflow-hidden rounded-200 bg-background-default shadow-3">
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-border-subtle px-400 py-350">
-          <h2 className="font-designer-28b text-gray-800">궁금한 게 있어요!</h2>
+        <div className="relative flex shrink-0 items-center px-750 py-500">
+          <div className="flex items-center gap-150">
+            <h2 className="font-designer-28b text-gray-800">
+              궁금한 게 있어요!
+            </h2>
+            <button
+              type="button"
+              aria-label="유의사항 보기"
+              onClick={() => setNoticeVisible((v) => !v)}
+              className="text-gray-400 hover:text-gray-600"
+            >
+              <Info className="h-250 w-250" />
+            </button>
+          </div>
           <button
             type="button"
+            aria-label="닫기"
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-800"
+            className="absolute right-350 top-350 text-gray-400 hover:text-gray-800"
           >
             <X className="h-300 w-300" />
           </button>
         </div>
 
         {/* Body */}
-        <div className="flex flex-col gap-300 overflow-y-auto px-400 py-350">
-          {/* Title input */}
+        <div className="flex flex-1 flex-col gap-300 overflow-y-auto px-750 pb-500">
+          {/* Notice box */}
+          {noticeVisible && (
+            <div className="relative rounded-150 border border-border-subtle px-300 py-250 pr-500">
+              <button
+                type="button"
+                aria-label="유의사항 닫기"
+                onClick={() => setNoticeVisible(false)}
+                className="absolute right-200 top-200 text-gray-400 hover:text-gray-600"
+              >
+                <X className="h-200 w-200" />
+              </button>
+              <p className="mb-150 font-designer-14b text-gray-800">
+                질문시 유의사항
+              </p>
+              <ul className="list-disc space-y-75 pl-300 font-designer-14r text-gray-600">
+                <li>
+                  질문 후 답변이 달리기 전까지는 수정 및 삭제가 자유롭습니다.
+                </li>
+                <li>
+                  답변이 달린 후에는 수정 및 삭제가 어려우니 유의해주시기
+                  바랍니다.
+                </li>
+              </ul>
+            </div>
+          )}
+
+          {/* Title */}
           <div>
-            <p className="mb-150 font-designer-16b text-gray-800">질문 제목</p>
+            <p className="mb-150 font-designer-16b text-gray-800">
+              제목 <span className="text-rose-500">*</span>
+            </p>
             <input
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="질문 제목을 입력해 주세요."
-              className="w-full rounded-100 border border-border-default px-300 py-200 font-designer-16m text-gray-800 outline-none placeholder:text-gray-400 focus:border-border-brand"
+              placeholder="질문 제목을 입력해주세요."
+              className="w-full rounded-150 border border-border-default px-300 py-200 font-designer-16m text-gray-800 outline-none placeholder:text-gray-400 focus:border-rose-400"
             />
           </div>
 
-          {/* Content textarea */}
+          {/* Content */}
           <div>
-            <p className="mb-150 font-designer-16b text-gray-800">질문 내용</p>
-            <textarea
+            <p className="mb-150 font-designer-16b text-gray-800">내용</p>
+            <MarkdownEditor
               value={content}
-              onChange={(e) => setContent(e.target.value)}
+              onChange={setContent}
               placeholder="어떤 부분에서 막히셨나요? 자세히 적어주실수록 빠르게 도움드릴 수 있어요."
-              className="h-[200px] w-full resize-none rounded-100 border border-border-default px-300 py-200 font-designer-16m text-gray-800 outline-none placeholder:text-gray-400 focus:border-border-brand"
+              uploadImage={uploadCommunityMarkdownImage}
             />
           </div>
 
-          {/* Image upload */}
+          {/* Image attachment */}
           <div>
-            <div className="mb-150 flex items-center justify-between">
+            <div className="mb-150 flex items-center gap-150">
               <p className="font-designer-16b text-gray-800">이미지 첨부</p>
-              <p className="font-designer-14r text-gray-400">최대 10장</p>
+              <p className="font-designer-14r text-gray-400">
+                최대 10장 첨부 가능합니다.
+              </p>
             </div>
-            <div className="flex gap-200">
-              {[0, 1, 2].map((i) => (
-                <div
-                  key={i}
-                  className="flex h-[100px] w-[100px] items-center justify-center rounded-100 border border-dashed border-border-default bg-gray-100 text-gray-400"
-                >
-                  <ImageIcon className="h-300 w-300" />
+            <div className="flex items-center gap-200 overflow-x-auto">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isUploadingImage || images.length >= 10}
+                className={cn(
+                  'flex h-1250 w-1250 shrink-0 flex-col items-center justify-center gap-75 rounded-150 border border-dashed border-border-default font-designer-12r text-gray-400',
+                  isUploadingImage || images.length >= 10
+                    ? 'cursor-not-allowed opacity-50'
+                    : 'cursor-pointer hover:border-rose-400 hover:text-rose-400',
+                )}
+              >
+                <ImageIcon className="h-300 w-300" />
+                <span>{images.length}/10</span>
+              </button>
+              {images.map((img, i) => (
+                <div key={img.key} className="relative shrink-0">
+                  <Image
+                    src={img.previewUrl}
+                    alt={`첨부 이미지 ${i + 1}`}
+                    width={100}
+                    height={100}
+                    unoptimized
+                    className="h-1250 w-1250 rounded-150 object-cover"
+                  />
+                  <button
+                    type="button"
+                    aria-label={`이미지 ${i + 1} 삭제`}
+                    onClick={() => handleImageRemove(i)}
+                    className="absolute -right-75 -top-75 flex h-200 w-200 items-center justify-center rounded-full bg-gray-800 text-background-default"
+                  >
+                    <X className="h-125 w-125" />
+                  </button>
                 </div>
               ))}
             </div>
-            {/* TODO: wire file upload API */}
-          </div>
-
-          {/* Caution accordion */}
-          <div className="rounded-100 border border-border-subtle">
-            <button
-              type="button"
-              onClick={() => setCautionOpen((v) => !v)}
-              className="flex w-full items-center justify-between px-300 py-200"
-            >
-              <p className="font-designer-14b text-gray-800">질문시 유의사항</p>
-              <ChevronDown
-                className={cn(
-                  'h-250 w-250 text-gray-500 transition-transform',
-                  cautionOpen && 'rotate-180',
-                )}
-              />
-            </button>
-            {cautionOpen && (
-              <div className="border-t border-border-subtle px-300 py-200">
-                <ul className="list-disc pl-300 font-designer-14r text-gray-600 space-y-75">
-                  <li>
-                    욕설, 비방, 개인정보가 포함된 질문은 삭제될 수 있어요.
-                  </li>
-                  <li>비슷한 질문이 있다면 먼저 검색해 보세요.</li>
-                  <li>질문 내용이 구체적일수록 빠른 답변을 받을 수 있어요.</li>
-                </ul>
-              </div>
-            )}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={async (e) => {
+                const target = e.target;
+                const file = target.files?.[0];
+                if (file) await handleImageAdd(file);
+                target.value = '';
+              }}
+            />
           </div>
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-200 border-t border-border-subtle px-400 py-300">
+        <div className="flex shrink-0 items-center justify-end gap-200 border-t border-border-subtle px-750 py-300">
           <button
             type="button"
-            onClick={onClose}
-            className="rounded-100 border border-border-default px-400 py-200 font-designer-16b text-gray-800 hover:bg-gray-100"
+            onClick={handleDraftSave}
+            className="rounded-100 border border-rose-400 px-400 py-200 font-designer-16b text-rose-500 hover:opacity-80"
           >
             임시저장
-            {/* TODO: localStorage draft save */}
           </button>
           <button
             type="button"

--- a/src/app/(landing)/class/vibe-intro/lesson/[id]/_components/lesson-review-form.tsx
+++ b/src/app/(landing)/class/vibe-intro/lesson/[id]/_components/lesson-review-form.tsx
@@ -3,6 +3,7 @@
 import { Image as ImageIcon, Link as LinkIcon } from 'lucide-react';
 import Image from 'next/image';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import MarkdownEditor from '@/components/common/ui/editor/markdown-editor';
 import { RatingBox } from './lesson-rating-box';
 
 export const POSITIVE_CHIPS = [
@@ -58,15 +59,20 @@ function QuestionBlock({
         </div>
         <p className="font-designer-16r text-gray-800">{helper}</p>
       </div>
-      <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-        className={cn(
-          'w-full resize-none rounded-200 border border-gray-300 bg-background-default px-300 py-250 font-designer-16m text-gray-800 outline-none placeholder:text-gray-400 focus:border-border-brand',
-          tall ? 'h-5600' : 'h-1625',
-        )}
-      />
+      {tall ? (
+        <MarkdownEditor
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+        />
+      ) : (
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="h-1625 w-full resize-none rounded-200 border border-gray-300 bg-background-default px-300 py-250 font-designer-16m text-gray-800 outline-none placeholder:text-gray-400 focus:border-border-brand"
+        />
+      )}
     </div>
   );
 }

--- a/src/app/(landing)/class/vibe-intro/lesson/[id]/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/lesson/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
 import { useToastStore } from '@/stores/use-toast-store';
 import { CurriculumDrawer } from './_components/curriculum-drawer';
 import { LessonBuilderFeedCard } from './_components/lesson-builder-feed-card';
+import { LessonBuilderFeedDetailModal } from './_components/lesson-builder-feed-detail-modal';
 import { LessonQnaCard } from './_components/lesson-qna-card';
 import { LessonQnaDetailModal } from './_components/lesson-qna-detail-modal';
 import { LessonQnaSubmissionModal } from './_components/lesson-qna-submission-modal';
@@ -58,6 +59,7 @@ export default function LessonPage({
   );
   const [submissionModalOpen, setSubmissionModalOpen] = useState(false);
   const [selectedQnaId, setSelectedQnaId] = useState<number | null>(null);
+  const [selectedFeedId, setSelectedFeedId] = useState<number | null>(null);
 
   const { data: lesson } = useGetLessonDetail(lessonId);
   const courseId = lesson?.courseId ?? 0;
@@ -233,7 +235,10 @@ export default function LessonPage({
               onAskClick={() => setSubmissionModalOpen(true)}
               onSelectQna={setSelectedQnaId}
             />
-            <LessonBuilderFeedCard feeds={feedPreview?.feeds ?? []} />
+            <LessonBuilderFeedCard
+              feeds={feedPreview?.feeds ?? []}
+              onSelectFeed={setSelectedFeedId}
+            />
           </div>
         </div>
       </div>
@@ -247,6 +252,10 @@ export default function LessonPage({
       <LessonQnaDetailModal
         qnaId={selectedQnaId}
         onClose={() => setSelectedQnaId(null)}
+      />
+      <LessonBuilderFeedDetailModal
+        feedId={selectedFeedId}
+        onClose={() => setSelectedFeedId(null)}
       />
     </div>
   );

--- a/src/app/(landing)/class/vibe-intro/lesson/[id]/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/lesson/[id]/page.tsx
@@ -240,6 +240,7 @@ export default function LessonPage({
 
       <LessonQnaSubmissionModal
         lessonId={lessonId}
+        courseId={lesson?.courseId ?? 0}
         open={submissionModalOpen}
         onClose={() => setSubmissionModalOpen(false)}
       />

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -409,7 +409,9 @@ https://velog.io/@oneook/tailwindcss-4.0-%EB%AC%B4%EC%97%87%EC%9D%B4-%EB%8B%AC%E
   --spacing-1250: 100px;
   --spacing-1400: 112px;
   --spacing-1625: 130px;
+  --spacing-1650: 132px;
   --spacing-2125: 170px;
+  --spacing-2500: 200px;
   --spacing-2325: 186px;
   --spacing-3875: 310px;
   --spacing-3888: 311px;

--- a/src/features/admin/course-management/api/admin-course-management-api.ts
+++ b/src/features/admin/course-management/api/admin-course-management-api.ts
@@ -1,4 +1,4 @@
-import { axiosInstance } from '@/api/client/axios';
+import { axiosInstanceV5 } from '@/api/client/axios';
 import type {
   AdminBuilderFeedCurationRequest,
   AdminCompletionMessageRequest,
@@ -35,9 +35,9 @@ export const getAdminCourses = async ({
   page,
   size,
 }: AdminCourseListParams): Promise<ApiPageResponse<AdminCourseSummary>> => {
-  const response = await axiosInstance.get<
+  const response = await axiosInstanceV5.get<
     ApiBaseResponse<ApiPageResponse<AdminCourseSummary>>
-  >('/admin/courses', {
+  >('admin/courses', {
     params: { status, page, size },
   });
 
@@ -47,9 +47,9 @@ export const getAdminCourses = async ({
 export const createAdminCourse = async (
   request: AdminCourseUpsertRequest,
 ): Promise<AdminCourseCreateResponse> => {
-  const response = await axiosInstance.post<
+  const response = await axiosInstanceV5.post<
     ApiBaseResponse<AdminCourseCreateResponse>
-  >('/admin/courses', request);
+  >('admin/courses', request);
 
   return unwrap(response);
 };
@@ -57,9 +57,9 @@ export const createAdminCourse = async (
 export const getAdminCourseDetail = async (
   courseId: number,
 ): Promise<AdminCourseDetailResponse> => {
-  const response = await axiosInstance.get<
+  const response = await axiosInstanceV5.get<
     ApiBaseResponse<AdminCourseDetailResponse>
-  >(`/admin/courses/${courseId}`);
+  >(`admin/courses/${courseId}`);
 
   return unwrap(response);
 };
@@ -71,8 +71,8 @@ export const updateAdminCourse = async ({
   courseId: number;
   request: AdminCourseUpdateRequest;
 }): Promise<void> => {
-  await axiosInstance.put<ApiBaseResponse<void>>(
-    `/admin/courses/${courseId}`,
+  await axiosInstanceV5.put<ApiBaseResponse<void>>(
+    `admin/courses/${courseId}`,
     request,
   );
 };
@@ -80,9 +80,9 @@ export const updateAdminCourse = async ({
 export const deleteAdminCourse = async (
   courseId: number,
 ): Promise<AdminCourseDeleteResponse> => {
-  const response = await axiosInstance.delete<
+  const response = await axiosInstanceV5.delete<
     ApiBaseResponse<AdminCourseDeleteResponse>
-  >(`/admin/courses/${courseId}`);
+  >(`admin/courses/${courseId}`);
 
   return unwrap(response);
 };
@@ -90,9 +90,9 @@ export const deleteAdminCourse = async (
 export const getAdminCourseLessons = async (
   courseId: number,
 ): Promise<AdminLessonSummary[]> => {
-  const response = await axiosInstance.get<
+  const response = await axiosInstanceV5.get<
     ApiBaseResponse<AdminLessonSummary[]>
-  >(`/admin/courses/${courseId}/lessons`);
+  >(`admin/courses/${courseId}/lessons`);
 
   return unwrap(response);
 };
@@ -100,9 +100,9 @@ export const getAdminCourseLessons = async (
 export const getAdminLessonDetail = async (
   lessonId: number,
 ): Promise<AdminLessonDetailResponse> => {
-  const response = await axiosInstance.get<
+  const response = await axiosInstanceV5.get<
     ApiBaseResponse<AdminLessonDetailResponse>
-  >(`/admin/lessons/${lessonId}`);
+  >(`admin/lessons/${lessonId}`);
 
   return unwrap(response);
 };
@@ -114,9 +114,9 @@ export const createAdminLesson = async ({
   courseId: number;
   request: AdminLessonUpsertRequest;
 }): Promise<AdminLessonCreateResponse> => {
-  const response = await axiosInstance.post<
+  const response = await axiosInstanceV5.post<
     ApiBaseResponse<AdminLessonCreateResponse>
-  >(`/admin/courses/${courseId}/lessons`, request);
+  >(`admin/courses/${courseId}/lessons`, request);
 
   return unwrap(response);
 };
@@ -128,8 +128,8 @@ export const updateAdminLesson = async ({
   lessonId: number;
   request: AdminLessonUpdateRequest;
 }): Promise<void> => {
-  await axiosInstance.put<ApiBaseResponse<void>>(
-    `/admin/lessons/${lessonId}`,
+  await axiosInstanceV5.put<ApiBaseResponse<void>>(
+    `admin/lessons/${lessonId}`,
     request,
   );
 };
@@ -137,9 +137,9 @@ export const updateAdminLesson = async ({
 export const deleteAdminLesson = async (
   lessonId: number,
 ): Promise<AdminLessonDeleteResponse> => {
-  const response = await axiosInstance.delete<
+  const response = await axiosInstanceV5.delete<
     ApiBaseResponse<AdminLessonDeleteResponse>
-  >(`/admin/lessons/${lessonId}`);
+  >(`admin/lessons/${lessonId}`);
 
   return unwrap(response);
 };
@@ -151,8 +151,8 @@ export const bulkUpdateAdminLessons = async ({
   courseId: number;
   request: AdminLessonBulkUpdateRequest;
 }): Promise<void> => {
-  await axiosInstance.patch<ApiBaseResponse<void>>(
-    `/admin/courses/${courseId}/lessons/bulk`,
+  await axiosInstanceV5.patch<ApiBaseResponse<void>>(
+    `admin/courses/${courseId}/lessons/bulk`,
     request,
   );
 };
@@ -164,8 +164,8 @@ export const reorderAdminLessons = async ({
   courseId: number;
   request: AdminLessonOrderRequest;
 }): Promise<void> => {
-  await axiosInstance.patch<ApiBaseResponse<void>>(
-    `/admin/courses/${courseId}/lessons/order`,
+  await axiosInstanceV5.patch<ApiBaseResponse<void>>(
+    `admin/courses/${courseId}/lessons/order`,
     request,
   );
 };
@@ -173,9 +173,9 @@ export const reorderAdminLessons = async ({
 export const getAdminCompletionMessage = async (
   courseId: number,
 ): Promise<AdminCompletionMessageResponse> => {
-  const response = await axiosInstance.get<
+  const response = await axiosInstanceV5.get<
     ApiBaseResponse<AdminCompletionMessageResponse>
-  >(`/admin/courses/${courseId}/completion-message`);
+  >(`admin/courses/${courseId}/completion-message`);
 
   return unwrap(response);
 };
@@ -187,9 +187,9 @@ export const upsertAdminCompletionMessage = async ({
   courseId: number;
   request: AdminCompletionMessageRequest;
 }): Promise<AdminCompletionMessageResponse> => {
-  const response = await axiosInstance.put<
+  const response = await axiosInstanceV5.put<
     ApiBaseResponse<AdminCompletionMessageResponse>
-  >(`/admin/courses/${courseId}/completion-message`, request);
+  >(`admin/courses/${courseId}/completion-message`, request);
 
   return unwrap(response);
 };
@@ -197,9 +197,9 @@ export const upsertAdminCompletionMessage = async ({
 export const getAdminLessonQnas = async (
   lessonId: number,
 ): Promise<AdminLessonQnaListResponse> => {
-  const response = await axiosInstance.get<
+  const response = await axiosInstanceV5.get<
     ApiBaseResponse<AdminLessonQnaListResponse>
-  >(`/admin/lessons/${lessonId}/qnas`);
+  >(`admin/lessons/${lessonId}/qnas`);
 
   return unwrap(response);
 };
@@ -207,9 +207,9 @@ export const getAdminLessonQnas = async (
 export const getAdminLessonQnaDetail = async (
   qnaId: number,
 ): Promise<AdminLessonQnaDetailResponse> => {
-  const response = await axiosInstance.get<
+  const response = await axiosInstanceV5.get<
     ApiBaseResponse<AdminLessonQnaDetailResponse>
-  >(`/admin/qnas/${qnaId}`);
+  >(`admin/qnas/${qnaId}`);
 
   return unwrap(response);
 };
@@ -221,9 +221,9 @@ export const createAdminLessonQnaAnswer = async ({
   qnaId: number;
   content: string;
 }): Promise<AdminLessonQnaAnswerCreateResponse> => {
-  const response = await axiosInstance.post<
+  const response = await axiosInstanceV5.post<
     ApiBaseResponse<AdminLessonQnaAnswerCreateResponse>
-  >(`/admin/qnas/${qnaId}/answers`, { content });
+  >(`admin/qnas/${qnaId}/answers`, { content });
 
   return unwrap(response);
 };
@@ -231,9 +231,9 @@ export const createAdminLessonQnaAnswer = async ({
 export const getAdminLessonRetrospectives = async (
   lessonId: number,
 ): Promise<AdminLessonRetrospectiveResponse> => {
-  const response = await axiosInstance.get<
+  const response = await axiosInstanceV5.get<
     ApiBaseResponse<AdminLessonRetrospectiveResponse>
-  >(`/admin/lessons/${lessonId}/retrospectives`);
+  >(`admin/lessons/${lessonId}/retrospectives`);
 
   return unwrap(response);
 };
@@ -241,9 +241,9 @@ export const getAdminLessonRetrospectives = async (
 export const getAdminLessonBuilderFeeds = async (
   lessonId: number,
 ): Promise<AdminLessonBuilderFeedsResponse> => {
-  const response = await axiosInstance.get<
+  const response = await axiosInstanceV5.get<
     ApiBaseResponse<AdminLessonBuilderFeedsResponse>
-  >(`/admin/lessons/${lessonId}/builder-feeds`);
+  >(`admin/lessons/${lessonId}/builder-feeds`);
 
   return unwrap(response);
 };
@@ -255,8 +255,8 @@ export const updateAdminBuilderFeedCuration = async ({
   feedId: number;
   request: AdminBuilderFeedCurationRequest;
 }): Promise<void> => {
-  await axiosInstance.patch<ApiBaseResponse<void>>(
-    `/admin/builder-feeds/${feedId}/curation`,
+  await axiosInstanceV5.patch<ApiBaseResponse<void>>(
+    `admin/builder-feeds/${feedId}/curation`,
     request,
   );
 };

--- a/src/hooks/queries/course/course-api.ts
+++ b/src/hooks/queries/course/course-api.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { axiosInstance } from '@/api/client/axios';
+import { axiosInstanceV5 } from '@/api/client/axios';
 import type {
   BuilderFeedCommentCreateRequest,
   BuilderFeedCommentsResponse,
@@ -32,7 +32,7 @@ export const useGetCourseList = () => {
   return useQuery({
     queryKey: ['courses'],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: { content: CourseSummaryResponse[] };
       }>('courses');
       return data.content.content;
@@ -46,7 +46,7 @@ export const useGetCourseDetail = (slug: string) => {
   return useQuery({
     queryKey: ['courseDetail', slug],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: CourseDetailResponse;
       }>(`courses/${slug}`);
       return data.content;
@@ -59,7 +59,7 @@ export const useGetCourseCurriculum = (slug: string) => {
   return useQuery({
     queryKey: ['courseCurriculum', slug],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: CourseCurriculumResponse;
       }>(`courses/${slug}/curriculum`);
       return data.content;
@@ -72,7 +72,7 @@ export const useGetCourseDrawer = (courseId: number) => {
   return useQuery({
     queryKey: ['courseDrawer', courseId],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: CourseDrawerResponse;
       }>(`courses/${courseId}/drawer`);
       return data.content;
@@ -87,7 +87,7 @@ export const useGetCourseJourneyMap = (courseId: number) => {
   return useQuery({
     queryKey: ['courseJourneyMap', courseId],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: CourseJourneyMapResponse;
       }>(`courses/${courseId}/journey-map`);
       return data.content;
@@ -102,7 +102,7 @@ export const useGetCourseProgress = (courseId: number) => {
   return useQuery({
     queryKey: ['courseProgress', courseId],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: CourseProgressResponse;
       }>(`courses/${courseId}/progress`);
       return data.content;
@@ -117,7 +117,7 @@ export const useGetCourseCompletionRecap = (courseId: number) => {
   return useQuery({
     queryKey: ['courseCompletionRecap', courseId],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: CourseCompletionRecapResponse;
       }>(`courses/${courseId}/completion-recap`);
       return data.content;
@@ -135,7 +135,7 @@ export const useSubmitNextPlan = () => {
       courseId: number;
       nextPlan: string;
     }) => {
-      const { data } = await axiosInstance.post<{ content: unknown }>(
+      const { data } = await axiosInstanceV5.post<{ content: unknown }>(
         `courses/${courseId}/next-plan`,
         { nextPlan },
       );
@@ -150,7 +150,7 @@ export const useGetLessonDetail = (lessonId: number) => {
   return useQuery({
     queryKey: ['lessonDetail', lessonId],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: LessonDetailResponse;
       }>(`lessons/${lessonId}`);
       return data.content;
@@ -165,7 +165,7 @@ export const useGetLessonRetrospective = (lessonId: number) => {
   return useQuery({
     queryKey: ['lessonRetrospective', lessonId],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: LessonRetrospectiveResponse;
       }>(`lessons/${lessonId}/retrospective`);
       return data.content;
@@ -185,7 +185,7 @@ export const useSubmitLessonRetrospective = () => {
       request: LessonRetrospectiveCreateRequest;
     }) => {
       try {
-        const { data } = await axiosInstance.post<{
+        const { data } = await axiosInstanceV5.post<{
           content: { lessonRetrospectiveId: number };
         }>(`lessons/${lessonId}/retrospective`, request);
         return { ...data.content, mocked: false as const };
@@ -230,16 +230,16 @@ export const useSubmitLessonRetrospective = () => {
 
 // ─── Q&A ──────────────────────────────────────────────────────────────────────
 
-export const useGetLessonQnas = (lessonId: number) => {
+export const useGetCourseQnas = (courseId: number) => {
   return useQuery({
-    queryKey: ['lessonQnas', lessonId],
+    queryKey: ['courseQnas', courseId],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: LessonQnaListResponse;
-      }>(`lessons/${lessonId}/qnas`);
+      }>(`courses/${courseId}/qnas`);
       return data.content;
     },
-    enabled: !!lessonId,
+    enabled: !!courseId,
   });
 };
 
@@ -247,21 +247,20 @@ export const useCreateLessonQna = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({
-      lessonId,
+      courseId,
       request,
     }: {
-      lessonId: number;
+      courseId: number;
       request: LessonQnaCreateRequest;
     }) => {
-      const { data } = await axiosInstance.post<{ content: { qnaId: number } }>(
-        `lessons/${lessonId}/qnas`,
-        request,
-      );
+      const { data } = await axiosInstanceV5.post<{
+        content: { qnaId: number };
+      }>(`courses/${courseId}/qnas`, request);
       return data.content;
     },
     onSuccess: async (_, variables) => {
       await queryClient.invalidateQueries({
-        queryKey: ['lessonQnas', variables.lessonId],
+        queryKey: ['courseQnas', variables.courseId],
       });
     },
   });
@@ -271,7 +270,7 @@ export const useGetLessonQnaDetail = (qnaId: number | null) => {
   return useQuery({
     queryKey: ['lessonQnaDetail', qnaId],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: LessonQnaDetailResponse;
       }>(`qnas/${qnaId}`);
       return data.content;
@@ -311,7 +310,7 @@ export const useGetBuilderFeeds = ({
       size,
     ],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: BuilderFeedListResponse;
       }>(`courses/${courseId}/builder-feeds`, {
         params: { sort, filter, lessonId, memberId, page, size },
@@ -332,7 +331,7 @@ export const useCreateBuilderFeed = () => {
       courseId: number;
       request: BuilderFeedCreateRequest;
     }) => {
-      const { data } = await axiosInstance.post<{
+      const { data } = await axiosInstanceV5.post<{
         content: { feedId: number };
       }>(`courses/${courseId}/builder-feeds`, request);
       return data.content;
@@ -349,7 +348,7 @@ export const useGetBuilderFeedDetail = (feedId: number) => {
   return useQuery({
     queryKey: ['builderFeedDetail', feedId],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: BuilderFeedDetailResponse;
       }>(`builder-feeds/${feedId}`);
       return data.content;
@@ -362,7 +361,7 @@ export const useToggleFeedLike = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (feedId: number) => {
-      const { data } = await axiosInstance.post<{
+      const { data } = await axiosInstanceV5.post<{
         content: { isLiked: boolean; likeCount: number };
       }>(`builder-feeds/${feedId}/like`);
       return data.content;
@@ -379,7 +378,7 @@ export const useGetFeedComments = (feedId: number) => {
   return useQuery({
     queryKey: ['feedComments', feedId],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: BuilderFeedCommentsResponse;
       }>(`builder-feeds/${feedId}/comments`);
       return data.content;
@@ -398,7 +397,7 @@ export const useCreateFeedComment = () => {
       feedId: number;
       request: BuilderFeedCommentCreateRequest;
     }) => {
-      const { data } = await axiosInstance.post<{
+      const { data } = await axiosInstanceV5.post<{
         content: { commentId: number };
       }>(`builder-feeds/${feedId}/comments`, request);
       return data.content;
@@ -420,7 +419,7 @@ export const useReportBuilderFeed = () => {
       feedId: number;
       request: BuilderFeedReportCreateRequest;
     }) => {
-      const { data } = await axiosInstance.post<{
+      const { data } = await axiosInstanceV5.post<{
         content: { reportId: number };
       }>(`builder-feeds/${feedId}/report`, request);
       return data.content;
@@ -434,7 +433,7 @@ export const useGetLessonBuilderFeedPreview = (lessonId: number) => {
   return useQuery({
     queryKey: ['lessonBuilderFeedPreview', lessonId],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: BuilderFeedPreviewResponse;
       }>(`lessons/${lessonId}/builder-feeds/preview`);
       return data.content;
@@ -449,7 +448,7 @@ export const useGetMyBuilderFeedStats = () => {
   return useQuery({
     queryKey: ['myBuilderFeedStats'],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: BuilderFeedStatsResponse;
       }>('members/me/builder-feed-stats');
       return data.content;
@@ -461,7 +460,7 @@ export const useGetMyBuilderFeeds = () => {
   return useQuery({
     queryKey: ['myBuilderFeeds'],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: MyBuilderFeedsResponse;
       }>('members/me/builder-feeds');
       return data.content;
@@ -475,7 +474,7 @@ export const useGetLessonQnaSidebar = (lessonId: number) => {
   return useQuery({
     queryKey: ['lessonQnaSidebar', lessonId],
     queryFn: async () => {
-      const { data } = await axiosInstance.get<{
+      const { data } = await axiosInstanceV5.get<{
         content: LessonQnaSidebarResponse;
       }>(`lessons/${lessonId}/qnas/sidebar`);
       return data.content;

--- a/src/types/api/course.types.ts
+++ b/src/types/api/course.types.ts
@@ -1,5 +1,17 @@
 // ─── Course Detail ────────────────────────────────────────────────────────────
 
+export interface CourseFaqItem {
+  question: string;
+  answer: string;
+}
+
+export interface CourseInstructor {
+  name: string;
+  role?: string;
+  bio?: string;
+  profileImageUrl?: string;
+}
+
 export interface CourseDetailResponse {
   courseId: number;
   slug: string;
@@ -14,6 +26,8 @@ export interface CourseDetailResponse {
   fullAccess: boolean | null;
   isEnrolled: boolean | null;
   purchaseAvailable: boolean | null;
+  faqs?: CourseFaqItem[];
+  instructors?: CourseInstructor[];
 }
 
 // ─── Enums ────────────────────────────────────────────────────────────────────
@@ -198,9 +212,10 @@ export interface LessonQnaItem {
 }
 
 export interface LessonQnaCreateRequest {
+  lessonId: number;
   title: string;
   content: string;
-  imageUrls?: string[];
+  imageKeys?: string[];
 }
 
 // ─── Q&A Detail ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

클래스 상세·레슨 페이지가 API 연동 없이 하드코딩된 상태로 출시 준비가 되지 않았음.
- FAQ·강사진 섹션이 정적 더미 데이터로 고정
- 레슨 QnA 제출 흐름 없음, 빌더 피드 상세 모달 없음
- 레슨 돌아보기 텍스트 입력이 단순 textarea (Figma 스펙: MarkdownEditor)
- `<img>` + `eslint-disable` 사용으로 룰 위반
- 베네핏 섹션 고양이 캐릭터·그림자 위치 오류

## Solution

- 클래스 API를 `axiosInstanceV5`로 전환하고 `CourseDetailResponse`에 FAQ·강사진 타입 추가
- 레슨 QnA 제출 모달(`LessonQnaSubmissionModal`) 신규 구현
- 빌더 피드 상세 모달(`LessonBuilderFeedDetailModal`) 신규 구현 — 카드 클릭 시 노출
- 레슨 돌아보기 tall textarea → `MarkdownEditor` (Figma 주석 반영)
- `<img>` 전체 `<Image unoptimized>`로 교체, `eslint-disable` 주석 제거
- 고양이 캐릭터를 in-flow 배치로 변경해 그림자 블리드 구조 수정
- 글로벌 푸터 적용, 코스 완주 페이지 레이아웃 개선

## Changes

### Features

| File | Description |
|------|-------------|
| `lesson-qna-submission-modal.tsx` | 레슨 QnA 제출 모달 (제목·내용·이미지 업로드) |
| `lesson-builder-feed-detail-modal.tsx` | 빌더 피드 상세 모달 (author·content·images·stats) |
| `lesson-builder-feed-card.tsx` | 피드 카드 클릭 → 상세 모달 연결, `onSelectFeed` prop |
| `lesson-review-form.tsx` | tall 질문 블록 textarea → MarkdownEditor |
| `lesson-qna-card.tsx` | answerCount + MessageSquare 아이콘, 설명 텍스트 Figma 스펙 반영 |
| `class/[id]/page.tsx` | FAQ 아코디언·강사진 섹션 API 데이터 연동 |
| `home/page.tsx` | 레슨 여정 맵 UI 개선 |
| `benefit-scroll-character.tsx` | 베네핏 섹션 고양이 캐릭터 신규 컴포넌트 |
| `footer.tsx` | 글로벌 푸터 컴포넌트 추가 |
| `axios.ts` | `axiosInstanceV5` 추가 (클래스 API 전용) |
| `course.types.ts` | `CourseDetailResponse` FAQ·강사진 필드, QnA 요청 타입 추가 |

### Bug Fixes

| File | Description |
|------|-------------|
| `benefit-scroll-character.tsx` | 고양이 캐릭터 absolute → in-flow 배치, 그림자 블리드 수정 |
| `lesson-builder-feed-card.tsx` | `<img>` + eslint-disable → `<Image unoptimized>` |

## Result

- 클래스 상세 페이지 FAQ·강사진이 실제 API 데이터로 렌더링됨
- 레슨 페이지에서 QnA 제출·조회·빌더 피드 열람 전체 흐름 동작
- MarkdownEditor로 레슨 돌아보기 작성 가능 (마크다운 문법·코드블록 지원)
- ESLint `<img>` 위반 0건

## Screenshots

| Before | After |
|--------|-------|
| 베네핏 고양이 위치 오류 | in-flow 배치로 정상 렌더링 |
| 빌더 피드 카드 클릭 무반응 | 클릭 시 상세 모달 노출 |

## Test plan

- [ ] 클래스 상세 페이지 → FAQ 아코디언 열고 닫기 정상 동작
- [ ] 클래스 상세 페이지 → 강사진 섹션 API 데이터 렌더링 확인
- [ ] 레슨 페이지 → 질문하기 버튼 → QnA 제출 모달 열림·제출·닫힘
- [ ] 레슨 페이지 → 빌더 피드 카드 클릭 → 상세 모달 노출
- [ ] 레슨 돌아보기 탭 → tall 질문 영역에 MarkdownEditor 렌더링
- [ ] QnA 카드 → answerCount 숫자 및 MessageSquare 아이콘 표시
- [ ] ESLint 에러 0개 (`yarn lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 코스 상세 페이지에 자주 묻는 질문(FAQ)과 강사진 소개 섹션 추가
  * 레슨 피드 상세 정보 모달 추가
  * Q&A 제출 시 이미지 첨부 및 임시저장(초안) 기능 추가
  * Q&A 및 학습 리뷰에 마크다운 에디터 적용

* **개선사항**
  * 레슨 UI에 잠금 상태, 학습 진행도, 소요 시간, 무료 여부 시각적 표시 강화

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/586)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->