### PR TITLE
fix: admin 레슨 본문 사라짐 + 챕터 description 노출

### DIFF
--- a/src/app/(landing)/class/[id]/page.tsx
+++ b/src/app/(landing)/class/[id]/page.tsx
@@ -130,7 +130,7 @@ export default function ClassDetailPage({
       return curriculum.chapters.map((chapter) => ({
         num: String(chapter.chapterNumber).padStart(2, '0'),
         title: chapter.title,
-        desc: '',
+        desc: chapter.description ?? '',
         lessons: chapter.lessons.map((lesson) => ({
           order: lesson.order,
           title: lesson.title,

--- a/src/app/(landing)/class/vibe-intro/(learning)/home/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/(learning)/home/page.tsx
@@ -31,6 +31,7 @@ const FALLBACK_CHAPTERS: CourseCurriculumChapterResponse[] = [
     order: 1,
     chapterNumber: 1,
     title: '시작하기',
+    description: null,
     estimatedMinutes: 0,
     lessons: [
       {
@@ -64,6 +65,7 @@ const FALLBACK_CHAPTERS: CourseCurriculumChapterResponse[] = [
     order: 2,
     chapterNumber: 2,
     title: '심화하기',
+    description: null,
     estimatedMinutes: 0,
     lessons: [
       {
@@ -113,6 +115,7 @@ const FALLBACK_CHAPTERS: CourseCurriculumChapterResponse[] = [
     order: 3,
     chapterNumber: 3,
     title: '완성하기',
+    description: null,
     estimatedMinutes: 0,
     lessons: [
       {

--- a/src/components/admin/courses/admin-lesson-management-page-client.tsx
+++ b/src/components/admin/courses/admin-lesson-management-page-client.tsx
@@ -153,6 +153,11 @@ export default function AdminLessonManagementPageClient({
   >();
   const [editorVersion, setEditorVersion] = useState(0);
   const draftKey = `lesson:${courseId}:${lessonFormMode}:${editingLessonId ?? 'new'}`;
+  // edit 모드에서는 server hydration이 끝난 뒤에만 draft 자동저장을 활성화한다.
+  // 그렇지 않으면 빈 초기 form이 server 응답보다 먼저 localStorage에 저장되어
+  // 다음 진입 시 빈 draft가 우선되며 기존 본문이 사라진 것처럼 보이게 된다.
+  const isLessonHydrated =
+    lessonFormMode === 'create' || hydratedLessonId === editingLessonId;
   const {
     status: lessonDraftStatus,
     setStatus: setLessonDraftStatus,
@@ -160,6 +165,7 @@ export default function AdminLessonManagementPageClient({
   } = useAdminLocalDraft({
     draftKey,
     value: lessonForm,
+    enabled: isLessonHydrated,
   });
 
   const createLessonMutation = useCreateAdminLessonMutation();
@@ -268,9 +274,16 @@ export default function AdminLessonManagementPageClient({
     const draft = readAdminDraft<AdminLessonUpsertRequest>(
       `lesson:${courseId}:edit:${lessonDetailQuery.data.lessonId}`,
     );
+    // 본문·제목·번호 모두 비어 있는 draft는 race condition으로 저장된 빈 form일 가능성이 높으므로
+    // 무시하고 server data를 사용한다.
+    const isMeaningfulDraft =
+      draft != null &&
+      (draft.content?.trim() ||
+        draft.title?.trim() ||
+        draft.lessonNumber !== undefined);
 
-    setLessonForm(draft ?? serverLessonForm);
-    if (draft) {
+    setLessonForm(isMeaningfulDraft ? draft : serverLessonForm);
+    if (isMeaningfulDraft) {
       setLessonDraftStatus('restored');
     }
     setHydratedLessonId(lessonDetailQuery.data.lessonId);

--- a/src/components/admin/courses/admin-lesson-management-page-client.tsx
+++ b/src/components/admin/courses/admin-lesson-management-page-client.tsx
@@ -274,13 +274,13 @@ export default function AdminLessonManagementPageClient({
     const draft = readAdminDraft<AdminLessonUpsertRequest>(
       `lesson:${courseId}:edit:${lessonDetailQuery.data.lessonId}`,
     );
-    // 본문·제목·번호 모두 비어 있는 draft는 race condition으로 저장된 빈 form일 가능성이 높으므로
+    // server에 본문이 있는데 draft의 본문이 비어 있으면 race condition으로 저장된 빈 form이므로
     // 무시하고 server data를 사용한다.
     const isMeaningfulDraft =
-      draft != null &&
+      draft !== null &&
       (draft.content?.trim() ||
-        draft.title?.trim() ||
-        draft.lessonNumber !== undefined);
+        (!serverLessonForm.content?.trim() &&
+          (draft.title?.trim() || draft.lessonNumber !== undefined)));
 
     setLessonForm(isMeaningfulDraft ? draft : serverLessonForm);
     if (isMeaningfulDraft) {

--- a/src/types/api/course.types.ts
+++ b/src/types/api/course.types.ts
@@ -151,6 +151,7 @@ export interface CourseCurriculumChapterResponse {
   order: number;
   chapterNumber: number;
   title: string;
+  description: string | null;
   estimatedMinutes: number;
   lessons: CourseCurriculumLessonResponse[];
 }
@@ -179,6 +180,7 @@ export interface CourseDrawerChapterResponse {
   chapterId: number;
   order: number;
   title: string;
+  description: string | null;
   defaultExpanded: boolean;
   lessons: CourseDrawerLessonResponse[];
 }


### PR DESCRIPTION
## Summary
- **이슈 1 (핵심)** — admin 레슨 편집 화면에서 기존 본문이 빈 채로 떠 그대로 저장하면 DB에 빈 content가 덮어씌워지던 race condition 수정
- **이슈 2** — `/class/{slug}` 로드맵의 챕터 description 노출. 백엔드 PR `code-zero-to-one/study-platform-mvp#1050`에서 응답에 추가된 `chapter.description` 필드 사용

## 이슈 1 — 본문 사라짐 race 분석
`admin-lesson-management-page-client.tsx`의 흐름:
1. `lessonForm` 초기값 = `emptyLessonForm`(`content: ''`)
2. `useAdminLocalDraft` 가 500ms 디바운스로 현재 form을 localStorage에 자동 저장
3. 동시에 `useAdminLessonDetailQuery` 가 server에서 lesson 본문 fetch
4. 두 번째 useEffect 에서 server 응답 도착 시 localStorage의 draft를 server data보다 **우선** 사용

네트워크 응답이 500ms 이상 걸리면 빈 form이 먼저 localStorage에 저장 → server data 도착 후 빈 draft 우선 → 에디터에 빈 채로 표시 → 사용자가 그 빈 form 그대로 저장하면 DB에 빈 content 덮어쓰기.

### Fix
- `useAdminLocalDraft({ enabled: isLessonHydrated })` 로 edit 모드에서는 server hydration 끝난 뒤에만 draft 자동저장
- 부가 안전망: 두 번째 useEffect에서 draft가 본문·제목·번호 모두 빈 값이면 무시하고 server data 우선

## 이슈 2 — 챕터 description 노출
- `CourseCurriculumChapterResponse` / `CourseDrawerChapterResponse` type에 `description: string | null` 필드 추가
- `/class/[id]/page.tsx` 의 `chaptersForRoadmap` 매핑이 `chapter.description ?? ''` 사용
- `/class/vibe-intro/(learning)/home/page.tsx` 의 `FALLBACK_CHAPTERS` 3개에 `description: null` 추가

## 의존성
- 백엔드 PR `code-zero-to-one/study-platform-mvp#1050` 머지·dev 배포 후에야 `description`이 실제 응답에 포함됨. 그 전엔 nullable 필드가 undefined여도 빈 문자열로 안전 폴백

## Test plan
- [ ] admin `/admin/courses/2/lessons/2` 진입 → 기존 본문 정상 표시 (race condition 미발생)
- [ ] 본문 안 건드리고 저장 → DB의 기존 content 유지 (덮어쓰기 없음)
- [ ] 백엔드 #1050 머지 후 `/class/vibe-intro` 로드맵에 챕터 description 표시 확인
- [ ] `/class/vibe-intro/home` fallback 동작 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 과목 챕터에 설명 필드가 추가되어 커리큘럼의 챕터 설명이 표시됩니다.
  * 기본(폴백) 커리큘럼 데이터에 챕터 설명 필드가 포함되어 예비 데이터의 설명 보완이 가능해졌습니다.

* **버그 수정**
  * 로컬 드래프트 자동저장이 클라이언트 준비 완료 시에만 활성화되도록 개선되었습니다.
  * 드래프트 복원 시 실제 내용이 있는 경우에만 적용되어 빈 드래프트가 덮어쓰지 않도록 수정되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/588)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->