### PR TITLE
fix: 클래스 어드민 FRD 정합성 보강

### DIFF
--- a/src/components/admin/courses/admin-course-markdown-editor.tsx
+++ b/src/components/admin/courses/admin-course-markdown-editor.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useEffect, useRef, useState } from 'react';
 import MarkdownEditor from '@/components/common/ui/editor/markdown-editor';
-import { uploadAdminCourseImage } from '@/features/admin/course-management/model/admin-course-image-upload';
+import { uploadAdminLessonContentImage } from '@/features/admin/course-management/model/admin-course-image-upload';
 import {
   ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS,
   ADMIN_COURSE_MARKDOWN_MAX_IMAGE_COUNT,
@@ -12,6 +12,7 @@ import {
 
 interface AdminCourseMarkdownEditorProps {
   editorStateKey?: string;
+  lessonId?: number;
   value: string;
   onChange: (next: string) => void;
   placeholder?: string;
@@ -19,6 +20,7 @@ interface AdminCourseMarkdownEditorProps {
 
 function AdminCourseMarkdownEditor({
   editorStateKey,
+  lessonId,
   value,
   onChange,
   placeholder,
@@ -58,14 +60,24 @@ function AdminCourseMarkdownEditor({
         }}
         placeholder={placeholder}
         normalizeContent={normalizeAdminCourseMarkdownContent}
-        imageConfig={{
-          allowedImageExtensions:
-            ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS,
-          maxImageCount: ADMIN_COURSE_MARKDOWN_MAX_IMAGE_COUNT,
-          maxImageFileSize: ADMIN_COURSE_MARKDOWN_MAX_IMAGE_FILE_SIZE,
-          uploadImageFile: uploadAdminCourseImage,
-        }}
+        imageConfig={
+          lessonId
+            ? {
+                allowedImageExtensions:
+                  ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS,
+                maxImageCount: ADMIN_COURSE_MARKDOWN_MAX_IMAGE_COUNT,
+                maxImageFileSize: ADMIN_COURSE_MARKDOWN_MAX_IMAGE_FILE_SIZE,
+                uploadImageFile: (file) =>
+                  uploadAdminLessonContentImage({ lessonId, file }),
+              }
+            : undefined
+        }
       />
+      {!lessonId && (
+        <p className="font-designer-12r text-text-subtle mt-50">
+          레슨 본문 이미지는 레슨 생성 후 편집 모드에서 업로드할 수 있습니다.
+        </p>
+      )}
       <style jsx global>{`
         .admin-course-markdown-editor .tiptap-editor {
           min-height: var(--spacing-650);

--- a/src/components/admin/courses/admin-course-markdown-field.tsx
+++ b/src/components/admin/courses/admin-course-markdown-field.tsx
@@ -2,6 +2,7 @@ import AdminCourseField from '@/components/admin/courses/admin-course-field';
 import AdminCourseMarkdownEditor from '@/components/admin/courses/admin-course-markdown-editor';
 
 interface AdminCourseMarkdownFieldProps {
+  lessonId?: number;
   value: string;
   onChange: (content: string) => void;
   placeholder: string;
@@ -12,6 +13,7 @@ interface AdminCourseMarkdownFieldProps {
 }
 
 export default function AdminCourseMarkdownField({
+  lessonId,
   value,
   onChange,
   placeholder,
@@ -30,6 +32,7 @@ export default function AdminCourseMarkdownField({
         ) : (
           <AdminCourseMarkdownEditor
             editorStateKey={editorStateKey}
+            lessonId={lessonId}
             value={value}
             placeholder={placeholder}
             onChange={onChange}

--- a/src/components/admin/courses/admin-lesson-detail-page-client.tsx
+++ b/src/components/admin/courses/admin-lesson-detail-page-client.tsx
@@ -527,6 +527,7 @@ export default function AdminLessonDetailPageClient({
           </div>
           <AdminCourseMarkdownField
             editorStateKey={String(lessonId)}
+            lessonId={lessonId}
             value={lessonForm.content}
             isHydrating={isLessonFormLocked}
             hydratingText="레슨 저장 중입니다."

--- a/src/components/admin/courses/admin-lesson-management-page-client.tsx
+++ b/src/components/admin/courses/admin-lesson-management-page-client.tsx
@@ -876,6 +876,7 @@ export default function AdminLessonManagementPageClient({
                 ) : (
                   <AdminCourseMarkdownEditor
                     editorStateKey={`${lessonFormMode}:${editingLessonId ?? 'new'}:${editorVersion}`}
+                    lessonId={editingLessonId}
                     value={lessonForm.content}
                     placeholder="레슨 본문을 작성하세요. 이미지, 코드블록, 표, 링크를 사용할 수 있습니다."
                     onChange={(content) =>

--- a/src/components/admin/courses/admin-lesson-management-sections.tsx
+++ b/src/components/admin/courses/admin-lesson-management-sections.tsx
@@ -540,6 +540,7 @@ export function AdminLessonManagementContent({
             </div>
             <AdminCourseMarkdownField
               editorStateKey={lessonEditorStateKey}
+              lessonId={editingLessonId}
               value={lessonForm.content}
               helper="긴 레슨 본문은 마크다운/리치 텍스트 에디터로 작성합니다. 저장 값은 그대로 public 레슨 상세에 노출됩니다."
               isHydrating={isLessonFormLocked}

--- a/src/components/common/ui/editor/markdown-editor.tsx
+++ b/src/components/common/ui/editor/markdown-editor.tsx
@@ -265,8 +265,14 @@ function MarkdownEditor({
           return false;
         }
 
-        if (resolvedImageConfig && hasClipboardImageHint(clipboardData)) {
+        if (hasClipboardImageHint(clipboardData)) {
           event.preventDefault();
+          if (!resolvedImageConfig) {
+            setImageInsertError(
+              '현재 화면에서는 이미지 업로드를 사용할 수 없습니다.',
+            );
+            return true;
+          }
           handleClipboardPaste(editorInstance, clipboardData).catch(() => {
             setImageInsertError('이미지 붙여넣기에 실패했습니다.');
           });
@@ -295,10 +301,6 @@ function MarkdownEditor({
         return true;
       },
       handleDrop: (_, event) => {
-        if (!resolvedImageConfig) {
-          return false;
-        }
-
         const dataTransfer = event.dataTransfer;
         if (!dataTransfer) {
           return false;
@@ -313,6 +315,13 @@ function MarkdownEditor({
         }
 
         event.preventDefault();
+        if (!resolvedImageConfig) {
+          setImageInsertError(
+            '현재 화면에서는 이미지 업로드를 사용할 수 없습니다.',
+          );
+          return true;
+        }
+
         const editorInstance = getValidEditorInstance();
         const dropPosition = _.posAtCoords({
           left: event.clientX,

--- a/src/components/common/ui/editor/use-image-upload.ts
+++ b/src/components/common/ui/editor/use-image-upload.ts
@@ -98,8 +98,12 @@ export function useImageUpload(
           if (uploadedImageUrl) {
             uploadedImageUrls.push(uploadedImageUrl);
           }
-        } catch {
-          uploadErrors.push(`${file.name}: 업로드 실패`);
+        } catch (error) {
+          const message =
+            error instanceof Error && error.message.trim()
+              ? error.message.trim()
+              : '업로드 실패';
+          uploadErrors.push(`${file.name}: ${message}`);
         }
       }
 

--- a/src/features/admin/course-management/api/admin-course-management-api.ts
+++ b/src/features/admin/course-management/api/admin-course-management-api.ts
@@ -110,6 +110,18 @@ const normalizeAdminLessonQnaDetail = (
   })),
 });
 
+const normalizeDeleteResponse = <
+  T extends {
+    deleted?: boolean;
+    isDeleted?: boolean;
+  },
+>(
+  response: T,
+): T & { deleted: boolean } => ({
+  ...response,
+  deleted: response.deleted ?? response.isDeleted ?? false,
+});
+
 export const getAdminCourses = async ({
   status,
   page,
@@ -165,7 +177,7 @@ export const deleteAdminCourse = async (
     ApiBaseResponse<AdminCourseDeleteResponse>
   >(`admin/courses/${courseId}`);
 
-  return unwrap(response);
+  return normalizeDeleteResponse(unwrap(response));
 };
 
 export const getAdminCourseLessons = async (
@@ -222,7 +234,7 @@ export const deleteAdminLesson = async (
     ApiBaseResponse<AdminLessonDeleteResponse>
   >(`admin/lessons/${lessonId}`);
 
-  return unwrap(response);
+  return normalizeDeleteResponse(unwrap(response));
 };
 
 export const bulkUpdateAdminLessons = async ({

--- a/src/features/admin/course-management/model/admin-course-image-upload.ts
+++ b/src/features/admin/course-management/model/admin-course-image-upload.ts
@@ -1,9 +1,88 @@
+import { axiosInstanceV5 } from '@/api/client/axios';
+import type { ApiBaseResponse } from '@/features/admin/course-management/model/admin-course-management-contract';
 import { uploadCommunityMarkdownImage } from '@/features/community/model/community-markdown-image-upload';
+import { getFileExtension } from '@/utils/markdown-content-images';
 
-/**
- * 클래스 어드민은 아직 전용 이미지 업로드 티켓 API가 없어
- * 검증된 기존 업로드 인프라를 재사용한다.
- */
+interface AdminLessonContentImageUploadUrlResponse {
+  uploadUrl: string;
+  publicUrl: string;
+}
+
 export const uploadAdminCourseImage = async (file: File): Promise<string> => {
   return uploadCommunityMarkdownImage(file);
+};
+
+const readUploadError = async (response: Response) => {
+  const errorText = (await response.text()).trim();
+
+  if (!errorText) {
+    return '이미지 파일 업로드에 실패했습니다.';
+  }
+
+  try {
+    const parsed = JSON.parse(errorText) as { message?: unknown };
+    return typeof parsed.message === 'string'
+      ? parsed.message
+      : '이미지 파일 업로드에 실패했습니다.';
+  } catch {
+    return errorText;
+  }
+};
+
+const getAdminLessonImageExtension = (file: File) => {
+  const extension = getFileExtension(file.name);
+
+  if (!extension || extension === 'blob') {
+    return file.type.split('/')[1]?.toUpperCase() ?? '';
+  }
+
+  return extension.toUpperCase();
+};
+
+const uploadLessonContentImageFile = async ({
+  uploadUrl,
+  file,
+}: {
+  uploadUrl: string;
+  file: File;
+}) => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const response = await fetch(uploadUrl, {
+    method: 'PUT',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error(await readUploadError(response));
+  }
+};
+
+export const uploadAdminLessonContentImage = async ({
+  lessonId,
+  file,
+}: {
+  lessonId: number;
+  file: File;
+}): Promise<string> => {
+  const extension = getAdminLessonImageExtension(file);
+
+  if (!extension) {
+    throw new Error('이미지 파일 확장자를 확인할 수 없습니다.');
+  }
+
+  const response = await axiosInstanceV5.post<
+    ApiBaseResponse<AdminLessonContentImageUploadUrlResponse>
+  >(`admin/lessons/${lessonId}/content-images/upload-url`, null, {
+    params: { extension },
+  });
+  const ticket = response.data.content;
+
+  await uploadLessonContentImageFile({
+    uploadUrl: ticket.uploadUrl,
+    file,
+  });
+
+  return ticket.publicUrl;
 };

--- a/src/features/admin/course-management/model/admin-course-management-contract.ts
+++ b/src/features/admin/course-management/model/admin-course-management-contract.ts
@@ -81,6 +81,7 @@ export interface AdminCourseCreateResponse {
 
 export interface AdminCourseDeleteResponse {
   deleted: boolean;
+  isDeleted?: boolean;
   reason: string | null;
   status: AdminCourseStatus | null;
 }
@@ -130,6 +131,7 @@ export interface AdminLessonCreateResponse {
 
 export interface AdminLessonDeleteResponse {
   deleted: boolean;
+  isDeleted?: boolean;
   reason: string | null;
   isPublished: boolean | null;
 }

--- a/src/features/admin/course-management/model/admin-course-markdown.ts
+++ b/src/features/admin/course-management/model/admin-course-markdown.ts
@@ -1,13 +1,20 @@
 import {
-  COMMUNITY_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS,
   COMMUNITY_MARKDOWN_MAX_IMAGE_COUNT,
   COMMUNITY_MARKDOWN_MAX_IMAGE_FILE_SIZE,
 } from '@/types/community/markdown';
 import { normalizeMarkdownContent } from '@/utils/markdown-content-normalize';
 import { isHtmlContent } from '@/utils/markdown-content-shared';
 
-export const ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS =
-  COMMUNITY_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS;
+export const ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS = [
+  'jpg',
+  'jpeg',
+  'png',
+  'webp',
+  'gif',
+  'svg',
+  'heic',
+  'heif',
+] as const;
 export const ADMIN_COURSE_MARKDOWN_MAX_IMAGE_COUNT =
   COMMUNITY_MARKDOWN_MAX_IMAGE_COUNT;
 export const ADMIN_COURSE_MARKDOWN_MAX_IMAGE_FILE_SIZE =


### PR DESCRIPTION
## 요약
- FRD/백엔드 스펙의 레슨 본문 이미지 전용 upload-url API를 어드민 에디터에 연결
- 레슨 생성 전에는 lessonId가 없으므로 본문 이미지 업로드를 차단하고 안내 문구 표시
- 백엔드 삭제 응답의 isDeleted 필드를 프론트 deleted 계약으로 정규화
- 백엔드 FileExtensions에 맞춰 어드민 본문 이미지 확장자 정책 정리

## 확인한 스펙
- study-platform-mvp/docs/FRD/v0.6/class/1-7-implementation/api-contracts/L-admin-content.md
- study-platform-mvp/src/main/java/.../AdminCourseContentController.java
- study-platform-mvp/src/main/java/.../AdminCourseContentService.java
- study-platform-mvp/src/main/java/.../FileExtensions.java

## 검증
- yarn lint:fix (0 errors, 기존 warning만 남음)
- yarn prettier:fix (기존 .codex/skills/clarify.md symlink warning만 남음)
- yarn typecheck
- git push pre-push next build 통과 (기존 sitemap 401 로그는 build non-blocking)

🤖 Generated with Codex