### PR TITLE
fix: 어드민 레슨 응답 안정화

### DIFF
--- a/src/features/admin/course-management/api/admin-course-management-api.test.ts
+++ b/src/features/admin/course-management/api/admin-course-management-api.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { axiosInstanceV5 } from '@/api/client/axios';
+import type { AdminLessonDetailResponse } from '@/features/admin/course-management/model/admin-course-management-contract';
+import { getAdminLessonDetail } from './admin-course-management-api';
+
+vi.mock('@/api/client/axios', () => ({
+  axiosInstanceV5: {
+    get: vi.fn(),
+  },
+}));
+
+const mockedGet = vi.mocked(axiosInstanceV5.get);
+
+const lessonContent: AdminLessonDetailResponse = {
+  lessonId: 1,
+  chapterNumber: 1,
+  lessonNumber: 1,
+  title: '1일차 오리엔테이션',
+  description: null,
+  content: '<p>본문</p>',
+  estimatedMinutes: 30,
+  retrospectivePurpose: 'PRACTICE_PROOF' as const,
+  isFree: true,
+  isPublished: true,
+};
+
+describe('admin course management api', () => {
+  beforeEach(() => {
+    mockedGet.mockReset();
+  });
+
+  it('unwraps the standard Axios BaseResponse envelope for lesson detail', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        statusCode: 200,
+        timestamp: '2026-05-15T20:00:00',
+        content: lessonContent,
+        message: null,
+      },
+    });
+
+    await expect(getAdminLessonDetail(1)).resolves.toMatchObject({
+      lessonId: 1,
+      content: '<p>본문</p>',
+    });
+  });
+
+  it('also accepts an already-unwrapped BaseResponse after retry interceptors', async () => {
+    mockedGet.mockResolvedValueOnce({
+      statusCode: 200,
+      timestamp: '2026-05-15T20:00:00',
+      content: { ...lessonContent, content: undefined },
+      message: null,
+    });
+
+    await expect(getAdminLessonDetail(1)).resolves.toMatchObject({
+      lessonId: 1,
+      content: '',
+    });
+  });
+});

--- a/src/features/admin/course-management/api/admin-course-management-api.ts
+++ b/src/features/admin/course-management/api/admin-course-management-api.ts
@@ -27,8 +27,33 @@ import type {
   ApiPageResponse,
 } from '@/features/admin/course-management/model/admin-course-management-contract';
 
-const unwrap = <T>(response: { data: ApiBaseResponse<T> }) =>
-  response.data.content;
+type ApiEnvelope<T> = ApiBaseResponse<T> | { data?: ApiBaseResponse<T> };
+
+const isApiBaseResponse = <T>(value: unknown): value is ApiBaseResponse<T> => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'statusCode' in value &&
+    'timestamp' in value &&
+    'content' in value
+  );
+};
+
+const unwrap = <T>(response: ApiEnvelope<T>): T => {
+  if (!response) {
+    throw new Error('API 응답 본문 형식이 올바르지 않습니다.');
+  }
+
+  if ('data' in response && isApiBaseResponse<T>(response.data)) {
+    return response.data.content;
+  }
+
+  if (isApiBaseResponse<T>(response)) {
+    return response.content;
+  }
+
+  throw new Error('API 응답 본문 형식이 올바르지 않습니다.');
+};
 
 const ADMIN_COURSE_LIST_MIN_SIZE = 1;
 const ADMIN_COURSE_LIST_MAX_SIZE = 50;
@@ -61,9 +86,9 @@ const normalizeAdminCoursePage = (
 });
 
 const normalizeAdminLessonRetrospective = (
-  response: AdminLessonRetrospectiveResponse,
+  response: AdminLessonRetrospectiveResponse | undefined,
 ): AdminLessonRetrospectiveResponse => ({
-  retrospectives: response.retrospectives.map((retrospective) => ({
+  retrospectives: (response?.retrospectives ?? []).map((retrospective) => ({
     ...retrospective,
     understandingScore:
       retrospective.understandingScore ?? retrospective.starRating ?? 0,
@@ -76,9 +101,9 @@ const normalizeAdminLessonRetrospective = (
 });
 
 const normalizeAdminLessonBuilderFeeds = (
-  response: AdminLessonBuilderFeedsResponse,
+  response: AdminLessonBuilderFeedsResponse | undefined,
 ): AdminLessonBuilderFeedsResponse => ({
-  feeds: response.feeds.map((feed) => ({
+  feeds: (response?.feeds ?? []).map((feed) => ({
     ...feed,
     imageUrls: feed.imageUrls ?? [],
     operatorPick: feed.operatorPick ?? feed.isOperatorPick ?? false,
@@ -87,27 +112,40 @@ const normalizeAdminLessonBuilderFeeds = (
 });
 
 const normalizeAdminLessonQnas = (
-  response: AdminLessonQnaListResponse,
+  response: AdminLessonQnaListResponse | undefined,
 ): AdminLessonQnaListResponse => ({
-  myQnas: response.myQnas ?? [],
-  qnas: (response.qnas ?? []).map((qna) => ({
+  myQnas: response?.myQnas ?? [],
+  qnas: (response?.qnas ?? []).map((qna) => ({
     ...qna,
     answerCount: qna.answerCount ?? (qna.answerStatus === 'ANSWERED' ? 1 : 0),
     viewCount: qna.viewCount ?? 0,
     isMyQuestion: qna.isMyQuestion ?? false,
   })),
-  totalCount: response.totalCount,
+  totalCount: response?.totalCount ?? 0,
 });
 
 const normalizeAdminLessonQnaDetail = (
   response: AdminLessonQnaDetailResponse,
 ): AdminLessonQnaDetailResponse => ({
   ...response,
+  content: response.content ?? '',
   imageUrls: response.imageUrls ?? [],
   answers: (response.answers ?? []).map((answer) => ({
     ...answer,
     imageUrls: answer.imageUrls ?? [],
   })),
+});
+
+const normalizeAdminLessonDetail = (
+  response: AdminLessonDetailResponse,
+): AdminLessonDetailResponse => ({
+  ...response,
+  description: response.description ?? '',
+  content: response.content ?? '',
+  estimatedMinutes: response.estimatedMinutes ?? 30,
+  retrospectivePurpose: response.retrospectivePurpose ?? 'PRACTICE_PROOF',
+  isFree: response.isFree ?? false,
+  isPublished: response.isPublished ?? false,
 });
 
 const normalizeDeleteResponse = <
@@ -197,7 +235,7 @@ export const getAdminLessonDetail = async (
     ApiBaseResponse<AdminLessonDetailResponse>
   >(`admin/lessons/${lessonId}`);
 
-  return unwrap(response);
+  return normalizeAdminLessonDetail(unwrap(response));
 };
 
 export const createAdminLesson = async ({


### PR DESCRIPTION
## 요약\n- 어드민 클래스 API 공통 unwrap이 AxiosResponse와 BaseResponse body를 모두 처리하도록 보강\n- 레슨 상세/운영 데이터에서 content/배열 필드가 비어도 빈 문자열/빈 배열로 정규화\n- 레슨 클릭 시 undefined.content 접근으로 관리자 오류 화면이 뜨는 회귀를 재현하는 단위 테스트 추가\n\n## 원인\n- 테스트 DB의 course_id=1 레슨/lesson_content 정합성은 정상입니다.\n- 실제 크래시는 프론트 API unwrap이 항상 response.data.content만 가정해서 응답 envelope가 달라지는 경로에서 undefined.content를 읽는 문제였습니다.\n\n## 검증\n- yarn lint:fix\n- yarn prettier:fix (Biome warning: .codex symlink cycle)\n- yarn typecheck\n- yarn vitest run src/features/admin/course-management/api/admin-course-management-api.test.ts\n- git push pre-push next build 통과 (sitemap study pages 401 fetch warning은 기존 빌드 중 허용 warning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 관리자 과정 관리 API의 응답 처리 검증을 위한 테스트 추가

* **버그 수정**
  * API 응답 형식 처리의 안정성 향상
  * 불완전하거나 누락된 응답 데이터에 대한 예외 처리 개선
  * 관리자 기능의 신뢰성 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/598)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->