### PR TITLE
fix: 레슨 임시저장 hydration 안정화

### DIFF
--- a/src/components/admin/courses/admin-lesson-management-page-client.tsx
+++ b/src/components/admin/courses/admin-lesson-management-page-client.tsx
@@ -50,6 +50,28 @@ const emptyLessonForm: AdminLessonUpsertRequest = {
   isPublished: false,
 };
 
+const normalizeLessonDraft = (
+  draft: AdminLessonUpsertRequest | undefined,
+): AdminLessonUpsertRequest | undefined => {
+  if (!draft) {
+    return undefined;
+  }
+
+  return {
+    chapterNumber: draft.chapterNumber ?? emptyLessonForm.chapterNumber,
+    lessonNumber: draft.lessonNumber ?? emptyLessonForm.lessonNumber,
+    title: draft.title ?? emptyLessonForm.title,
+    description: draft.description ?? emptyLessonForm.description,
+    content: draft.content ?? emptyLessonForm.content,
+    estimatedMinutes:
+      draft.estimatedMinutes ?? emptyLessonForm.estimatedMinutes,
+    retrospectivePurpose:
+      draft.retrospectivePurpose ?? emptyLessonForm.retrospectivePurpose,
+    isFree: draft.isFree ?? emptyLessonForm.isFree,
+    isPublished: draft.isPublished ?? emptyLessonForm.isPublished,
+  };
+};
+
 const formatDateTime = (value?: string | null) => {
   if (!value) return '-';
   const date = new Date(value);
@@ -274,13 +296,15 @@ export default function AdminLessonManagementPageClient({
       isFree: lessonDetailQuery.data.isFree,
       isPublished: lessonDetailQuery.data.isPublished,
     };
-    const draft = readAdminDraft<AdminLessonUpsertRequest>(
-      `lesson:${courseId}:edit:${lessonDetailQuery.data.lessonId}`,
+    const draft = normalizeLessonDraft(
+      readAdminDraft<AdminLessonUpsertRequest>(
+        `lesson:${courseId}:edit:${lessonDetailQuery.data.lessonId}`,
+      ),
     );
     // server에 본문이 있는데 draft의 본문이 비어 있으면 race condition으로 저장된 빈 form이므로
     // 무시하고 server data를 사용한다.
     const isMeaningfulDraft =
-      draft !== null &&
+      draft !== undefined &&
       (draft.content?.trim() ||
         (!serverLessonForm.content?.trim() &&
           (draft.title?.trim() || draft.lessonNumber !== undefined)));
@@ -300,8 +324,8 @@ export default function AdminLessonManagementPageClient({
 
   useEffect(() => {
     if (lessonFormMode !== 'create') return;
-    const draft = readAdminDraft<AdminLessonUpsertRequest>(
-      `lesson:${courseId}:create:new`,
+    const draft = normalizeLessonDraft(
+      readAdminDraft<AdminLessonUpsertRequest>(`lesson:${courseId}:create:new`),
     );
     if (!draft) return;
     setLessonForm(draft);
@@ -310,13 +334,15 @@ export default function AdminLessonManagementPageClient({
   }, [courseId, lessonFormMode, setLessonDraftStatus]);
 
   const startCreateLesson = () => {
+    const draft = normalizeLessonDraft(
+      readAdminDraft<AdminLessonUpsertRequest>(`lesson:${courseId}:create:new`),
+    );
+
     setLessonFormMode('create');
     setEditingLessonId(undefined);
     setHydratedLessonId(undefined);
     setLessonForm({
-      ...(readAdminDraft<AdminLessonUpsertRequest>(
-        `lesson:${courseId}:create:new`,
-      ) ?? emptyLessonForm),
+      ...(draft ?? emptyLessonForm),
       lessonNumber: lessons.length + 1,
     });
     setEditorVersion((prev) => prev + 1);


### PR DESCRIPTION
## Summary
- 레슨 목록 버튼 클릭 후 상세 hydrate 과정에서 임시저장본이 없을 때 `undefined.content`를 읽던 조건을 수정했습니다.
- 저장된 draft가 오래됐거나 일부 필드가 빠져도 기본 레슨 form shape으로 정규화하도록 했습니다.

## Root cause
`readAdminDraft()`는 저장된 draft가 없으면 `undefined`를 반환하는데, 기존 코드는 `draft !== null`만 검사했습니다. 그래서 정상적으로 draft가 없는 첫 클릭 상황에서도 `draft.content` 접근이 실행되어 관리자 에러 화면으로 떨어질 수 있었습니다.

## Verification
- `yarn lint:fix`
- `yarn prettier:fix` (Biome warning: `.codex/skills/clarify.md` symlink cycle)
- `yarn typecheck`
- pre-push `next build` passed (existing sitemap 401 warning only)