### PR TITLE
fix: 노션 복붙 본문 유실 방지

### DIFF
--- a/src/components/common/ui/editor/clipboard-utils.ts
+++ b/src/components/common/ui/editor/clipboard-utils.ts
@@ -8,6 +8,21 @@ const URL_PATTERNS: Record<UrlKind, RegExp> = {
   'data-image': /^data:image\/[a-z0-9.+-]+;base64,/i,
 };
 
+const IMAGE_URL_PART =
+  /https?:\/\/[^\s"'<>]+\.(?:jpg|jpeg|png|webp|gif|bmp|avif|svg)(?:\?[^\s"'<>]*)?/gi;
+const DATA_IMAGE_TEXT_PART =
+  /data:image\/[a-z0-9.+-]+;base64,[a-zA-Z0-9+/=\s]+/gi;
+
+const removeHtmlWrappers = (html: string) => {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<img\b[^>]*>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
 /**
  * URLs가 지정된 타입 선택 패턴과 일치하는지 검증합니다.
  * @param text 검증할 URL 문자열
@@ -105,4 +120,40 @@ export const hasClipboardImageHint = (clipboardData: DataTransfer) => {
   const pastedText = clipboardData.getData('text/plain').trim();
 
   return isAllowedUrl(pastedText, ['image', 'data-image']);
+};
+
+/**
+ * 클립보드 내용이 실제 텍스트보다 이미지 데이터가 주도적일 때 true를 반환합니다.
+ * 텍스트가 존재하더라도 이미지 URL만 단독으로 들어 있으면 true로 간주됩니다.
+ * @param clipboardData 클립보드 데이터
+ * @returns 이미지 전용으로 보이면 true
+ */
+export const isClipboardImageOnly = (clipboardData: DataTransfer) => {
+  const pastedText = clipboardData.getData('text/plain').trim();
+  const pastedHtml = clipboardData.getData('text/html').trim();
+
+  if (pastedText) {
+    const textWithoutImageRefs = pastedText
+      .replace(IMAGE_URL_PART, '')
+      .replace(DATA_IMAGE_TEXT_PART, '')
+      .replace(/\s+/g, '')
+      .trim();
+
+    if (textWithoutImageRefs) {
+      return false;
+    }
+
+    return !!isAllowedUrl(pastedText, ['image', 'data-image']);
+  }
+
+  if (!pastedHtml) {
+    return extractClipboardImageFiles(clipboardData).length > 0;
+  }
+
+  const htmlText = removeHtmlWrappers(pastedHtml);
+  if (htmlText) {
+    return false;
+  }
+
+  return true;
 };

--- a/src/components/common/ui/editor/markdown-editor.tsx
+++ b/src/components/common/ui/editor/markdown-editor.tsx
@@ -34,7 +34,7 @@ import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import Button from '@/components/common/ui/button';
 import { normalizeMarkdownContent } from '@/utils/markdown-content-normalize';
 import { getRichContentVisibleTextLength } from '@/utils/markdown-content-text';
-import { hasClipboardImageHint } from './clipboard-utils';
+import { hasClipboardImageHint, isClipboardImageOnly } from './clipboard-utils';
 import EditorVisibleTextCounter from './editor-visible-text-counter';
 import {
   InstantCodeBlockExtension,
@@ -265,7 +265,11 @@ function MarkdownEditor({
           return false;
         }
 
-        if (hasClipboardImageHint(clipboardData)) {
+        const clipboardImageOnly =
+          hasClipboardImageHint(clipboardData) &&
+          isClipboardImageOnly(clipboardData);
+
+        if (clipboardImageOnly) {
           event.preventDefault();
           if (!resolvedImageConfig) {
             setImageInsertError(


### PR DESCRIPTION
## Summary
- 이미지 포함 클립보드가 실제 이미지 단독인지 판별하는 유틸 추가
- 텍스트+이미지 혼합 붙여넣기는 기본 에디터 paste 흐름으로 통과시켜 본문 유실 방지

## Verification
- yarn lint:fix (통과, 기존 warning 233개)
- yarn prettier:fix (통과, .codex/skills/clarify.md symlink warning 1개)
- yarn typecheck (통과)
- git push pre-push next build (통과, sitemap 생성 중 로컬 127.0.0.1:8080 연결 거부 로그는 fallback 후 빌드 완료)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 클립보드 이미지 붙여넣기 감지 로직을 개선하여 순수 이미지 데이터와 이미지 + 텍스트 혼합 콘텐츠를 더 정확하게 구분합니다. 마크다운 에디터의 붙여넣기 처리 정확도가 향상됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->