### PR TITLE
write 페이지 edit 모드 통합 + 삭제/수정 네비게이션 수정

### DIFF
--- a/src/app/(landing)/class/vibe-intro/(learning)/feed/[id]/edit/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/(learning)/feed/[id]/edit/page.tsx
@@ -1,19 +1,11 @@
-'use client';
-
-import { useRouter } from 'next/navigation';
-import { use, useEffect } from 'react';
+import { redirect } from 'next/navigation';
+import { use } from 'react';
 
 export default function FeedEditPage({
   params,
 }: {
   params: Promise<{ id: string }>;
-}): null {
+}) {
   const { id } = use(params);
-  const router = useRouter();
-
-  useEffect(() => {
-    router.replace(`/class/vibe-intro/feed/${id}`);
-  }, [id, router]);
-
-  return null;
+  redirect(`/class/vibe-intro/feed/write?feedId=${id}`);
 }

--- a/src/app/(landing)/class/vibe-intro/(learning)/feed/[id]/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/(learning)/feed/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { ArrowLeft, MoreVertical } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { use, useState } from 'react';
 import {
   ROLE_LABELS,
@@ -21,6 +22,7 @@ import MarkdownContentCore from '@/components/common/ui/rich-text/markdown-conte
 import { useAuth } from '@/features/auth/model/use-auth';
 import {
   useCreateFeedComment,
+  useDeleteBuilderFeed,
   useGetBuilderFeedDetail,
   useGetBuilderFeeds,
   useGetFeedComments,
@@ -38,10 +40,12 @@ export default function FeedDetailPage({
   const feedId = parseInt(id, 10);
   const { memberId } = useAuth();
   const showToast = useToastStore((s) => s.showToast);
+  const router = useRouter();
 
   const [comment, setComment] = useState('');
   const [moreOpen, setMoreOpen] = useState(false);
   const [showReportModal, setShowReportModal] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [reportReason, setReportReason] = useState('');
   const [isProfileOpen, setIsProfileOpen] = useState(false);
 
@@ -56,6 +60,7 @@ export default function FeedDetailPage({
   const toggleLikeMutation = useToggleFeedLike();
   const createCommentMutation = useCreateFeedComment();
   const reportFeedMutation = useReportBuilderFeed();
+  const deleteFeedMutation = useDeleteBuilderFeed();
 
   const liked = feed?.isLiked ?? false;
   const likeCount = feed?.likeCount ?? 0;
@@ -141,6 +146,47 @@ export default function FeedDetailPage({
         </div>
       )}
 
+      {/* Delete confirm modal */}
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="flex w-5000 flex-col items-center gap-300 rounded-200 bg-background-default p-500">
+            <div className="text-center">
+              <p className="font-designer-20b text-gray-800">
+                피드를 삭제하시겠습니까?
+              </p>
+              <p className="mt-150 font-designer-16r text-gray-500">
+                삭제된 피드는 복구할 수 없습니다.
+              </p>
+            </div>
+            <div className="flex w-full gap-200">
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(false)}
+                className="flex h-700 flex-1 items-center justify-center rounded-100 border border-border-default font-designer-16m text-gray-800"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                disabled={deleteFeedMutation.isPending}
+                onClick={() =>
+                  deleteFeedMutation.mutate(feedId, {
+                    onSuccess: () => {
+                      showToast('피드가 삭제되었어요.');
+                      router.push('/class/vibe-intro/home?tab=feed');
+                    },
+                    onError: () => showToast('삭제에 실패했어요.', 'error'),
+                  })
+                }
+                className="flex h-700 flex-1 items-center justify-center rounded-100 bg-background-brand-default font-designer-16m text-text-inverse disabled:opacity-50"
+              >
+                삭제하기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {feed !== undefined && feed.author.memberId !== undefined && (
         <BuilderProfileModal
           memberId={feed.author.memberId}
@@ -198,7 +244,12 @@ export default function FeedDetailPage({
                         <>
                           <button
                             type="button"
-                            onClick={() => setMoreOpen(false)}
+                            onClick={() => {
+                              setMoreOpen(false);
+                              router.push(
+                                `/class/vibe-intro/feed/write?feedId=${feedId}`,
+                              );
+                            }}
                             className="flex items-center gap-125 whitespace-nowrap rounded-50 p-100 font-designer-16r text-gray-400 hover:bg-gray-100"
                           >
                             <FeedEditIcon className="h-300 w-300 shrink-0" />
@@ -206,7 +257,10 @@ export default function FeedDetailPage({
                           </button>
                           <button
                             type="button"
-                            onClick={() => setMoreOpen(false)}
+                            onClick={() => {
+                              setMoreOpen(false);
+                              setShowDeleteConfirm(true);
+                            }}
                             className="flex items-center gap-125 whitespace-nowrap rounded-50 p-100 font-designer-16r text-gray-400 hover:bg-gray-100"
                           >
                             <FeedDeleteIcon className="h-300 w-300 shrink-0" />

--- a/src/app/(landing)/class/vibe-intro/(learning)/feed/write/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/(learning)/feed/write/page.tsx
@@ -37,7 +37,9 @@ function FeedWriteContent() {
   const showToast = useToastStore((s) => s.showToast);
 
   const feedIdParam = searchParams.get('feedId');
-  const editFeedId = feedIdParam ? parseInt(feedIdParam, 10) : null;
+  const parsedFeedId = feedIdParam ? parseInt(feedIdParam, 10) : null;
+  const editFeedId =
+    parsedFeedId !== null && !Number.isNaN(parsedFeedId) ? parsedFeedId : null;
   const isEditMode = editFeedId !== null;
 
   const course = '바이브 코딩 입문자 코스';
@@ -266,7 +268,7 @@ function FeedWriteContent() {
                     />
                   </button>
                   {lessonOpen && (
-                    <div className="absolute left-0 top-full z-10 mt-75 max-h-[300px] w-full overflow-y-auto rounded-100 border border-border-default bg-background-default shadow-1">
+                    <div className="absolute left-0 top-full z-10 mt-75 max-h-3750 w-full overflow-y-auto rounded-100 border border-border-default bg-background-default shadow-1">
                       {allLessons.map((l) => (
                         <button
                           key={l.lessonId}

--- a/src/app/(landing)/class/vibe-intro/(learning)/feed/write/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/(learning)/feed/write/page.tsx
@@ -8,7 +8,6 @@ import { Suspense, useEffect, useRef, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import MarkdownEditor from '@/components/common/ui/editor/markdown-editor';
 import { uploadCommunityMarkdownImage } from '@/features/community/model/community-markdown-image-upload';
-import { extractPlainTextFromHtml } from '@/utils/markdown-content';
 import {
   useCreateBuilderFeed,
   useGetBuilderFeedDetail,
@@ -17,6 +16,7 @@ import {
   useUpdateBuilderFeed,
 } from '@/hooks/queries/course/course-api';
 import { useToastStore } from '@/stores/use-toast-store';
+import { extractPlainTextFromHtml } from '@/utils/markdown-content';
 
 interface AttachedImage {
   previewUrl: string;

--- a/src/app/(landing)/class/vibe-intro/(learning)/feed/write/page.tsx
+++ b/src/app/(landing)/class/vibe-intro/(learning)/feed/write/page.tsx
@@ -3,15 +3,18 @@
 import { ArrowLeft, ChevronDown, Plus, X } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useRef, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import MarkdownEditor from '@/components/common/ui/editor/markdown-editor';
 import { uploadCommunityMarkdownImage } from '@/features/community/model/community-markdown-image-upload';
+import { extractPlainTextFromHtml } from '@/utils/markdown-content';
 import {
   useCreateBuilderFeed,
+  useGetBuilderFeedDetail,
   useGetCourseCurriculum,
   useGetCourseDetail,
+  useUpdateBuilderFeed,
 } from '@/hooks/queries/course/course-api';
 import { useToastStore } from '@/stores/use-toast-store';
 
@@ -21,9 +24,23 @@ interface AttachedImage {
 }
 
 export default function FeedWritePage() {
+  return (
+    <Suspense>
+      <FeedWriteContent />
+    </Suspense>
+  );
+}
+
+function FeedWriteContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const showToast = useToastStore((s) => s.showToast);
-  const [course, setCourse] = useState('바이브 코딩 입문자 코스');
+
+  const feedIdParam = searchParams.get('feedId');
+  const editFeedId = feedIdParam ? parseInt(feedIdParam, 10) : null;
+  const isEditMode = editFeedId !== null;
+
+  const course = '바이브 코딩 입문자 코스';
   const [courseOpen, setCourseOpen] = useState(false);
   const [selectedLessonId, setSelectedLessonId] = useState<number | null>(null);
   const [lessonOpen, setLessonOpen] = useState(false);
@@ -31,12 +48,28 @@ export default function FeedWritePage() {
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [images, setImages] = useState<AttachedImage[]>([]);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
+  const [initialized, setInitialized] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { data: courseData } = useGetCourseDetail('vibe-intro');
   const courseId = courseData?.courseId ?? 0;
   const { data: curriculum } = useGetCourseCurriculum('vibe-intro');
   const createFeed = useCreateBuilderFeed();
+  const updateFeed = useUpdateBuilderFeed();
+
+  const { data: existingFeed } = useGetBuilderFeedDetail(editFeedId ?? 0);
+
+  useEffect(() => {
+    if (!isEditMode || !existingFeed || initialized) return;
+    setText(existingFeed.content);
+    setImages(
+      existingFeed.imageUrls.map((url) => ({
+        previewUrl: url,
+        key: new URL(url).pathname.slice(1),
+      })),
+    );
+    setInitialized(true);
+  }, [existingFeed, initialized, isEditMode]);
 
   const allLessons =
     curriculum?.chapters.flatMap((ch) =>
@@ -71,43 +104,74 @@ export default function FeedWritePage() {
   function handleImageRemove(index: number) {
     setImages((prev) => {
       const next = [...prev];
-      URL.revokeObjectURL(next[index].previewUrl);
-      next.splice(index, 1);
+      const removed = next.splice(index, 1)[0];
+      if (removed.previewUrl.startsWith('blob:')) {
+        URL.revokeObjectURL(removed.previewUrl);
+      }
       return next;
     });
   }
 
   function handleSubmit() {
-    if (!selectedLessonId) {
-      showToast('레슨을 선택해주세요.', 'error');
-      return;
-    }
-    if (!text.replace(/<[^>]*>/g, '').trim()) {
-      showToast('내용을 입력해주세요.', 'error');
-      return;
-    }
-    createFeed.mutate(
-      {
-        courseId,
-        request: {
-          lessonId: selectedLessonId,
-          content: text,
-          imageKeys: images.map((img) => img.key),
+    if (isEditMode) {
+      if (!extractPlainTextFromHtml(text)) {
+        showToast('내용을 입력해주세요.', 'error');
+        return;
+      }
+      updateFeed.mutate(
+        {
+          feedId: editFeedId,
+          request: { content: text, imageKeys: images.map((i) => i.key) },
         },
-      },
-      {
-        onSuccess: () => {
-          showToast('피드가 등록되었어요!');
-          router.push('/class/vibe-intro/home?tab=feed');
+        {
+          onSuccess: () => {
+            showToast('피드가 수정되었어요!');
+            router.push(`/class/vibe-intro/feed/${editFeedId}`);
+          },
+          onError: () => showToast('수정에 실패했어요.', 'error'),
         },
-        onError: () => showToast('등록에 실패했어요.', 'error'),
-      },
-    );
+      );
+    } else {
+      if (!selectedLessonId) {
+        showToast('레슨을 선택해주세요.', 'error');
+        return;
+      }
+      if (!extractPlainTextFromHtml(text)) {
+        showToast('내용을 입력해주세요.', 'error');
+        return;
+      }
+      createFeed.mutate(
+        {
+          courseId,
+          request: {
+            lessonId: selectedLessonId,
+            content: text,
+            imageKeys: images.map((img) => img.key),
+          },
+        },
+        {
+          onSuccess: () => {
+            showToast('피드가 등록되었어요!');
+            router.push('/class/vibe-intro/home?tab=feed');
+          },
+          onError: () => showToast('등록에 실패했어요.', 'error'),
+        },
+      );
+    }
   }
+
+  const backHref = isEditMode
+    ? `/class/vibe-intro/feed/${editFeedId}`
+    : '/class/vibe-intro/home?tab=feed';
+  const backLabel = isEditMode ? '피드로 돌아가기' : '빌더 피드 돌아가기';
+  const submitLabel = isEditMode ? '수정하기' : '등록하기';
+  const submitPending = isEditMode
+    ? updateFeed.isPending
+    : createFeed.isPending;
 
   return (
     <>
-      {/* Cancel confirmation modal */}
+      {/* Cancel confirmation modal — create mode only */}
       {showCancelModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
           <div className="flex w-5000 flex-col items-center gap-300 rounded-200 bg-background-default p-500">
@@ -140,88 +204,87 @@ export default function FeedWritePage() {
 
       <div className="w-full pb-800">
         <div className="mx-auto max-w-page px-600 pt-500">
-          {/* Back link */}
           <Link
-            href="/class/vibe-intro/home?tab=feed"
+            href={backHref}
             className="inline-flex items-center gap-125 font-designer-14m text-gray-800"
           >
             <ArrowLeft className="h-300 w-300" />
-            빌더 피드 돌아가기
+            {backLabel}
           </Link>
 
           <div className="mt-400 space-y-400">
-            {/* Course selector */}
-            <div>
-              <p className="mb-150 font-designer-16b text-gray-800">
-                어떤 코스에서 만든 결과물인가요?
-              </p>
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={() => setCourseOpen((p) => !p)}
-                  className="flex w-full items-center justify-between rounded-100 border border-border-default px-250 py-175 font-designer-16r text-gray-800"
-                >
-                  {course}
-                  <ChevronDown
-                    className={cn(
-                      'h-300 w-300 transition-transform',
-                      courseOpen && 'rotate-180',
-                    )}
-                  />
-                </button>
-                {courseOpen && (
-                  <div className="absolute left-0 top-full z-10 mt-75 w-full rounded-100 border border-border-default bg-background-default shadow-1">
-                    {['바이브 코딩 입문자 코스'].map((c) => (
-                      <button
-                        key={c}
-                        type="button"
-                        onClick={() => {
-                          setCourse(c);
-                          setCourseOpen(false);
-                        }}
-                        className="flex w-full items-center px-250 py-175 font-designer-16r text-gray-800 bg-gray-50 hover:bg-gray-100"
-                      >
-                        {c}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Lesson selector */}
-            <div className="relative">
-              <button
-                type="button"
-                onClick={() => setLessonOpen((p) => !p)}
-                className="flex w-full items-center justify-between rounded-100 border border-border-default px-250 py-175 font-designer-16r text-gray-800"
-              >
-                {selectedLessonLabel}
-                <ChevronDown
-                  className={cn(
-                    'h-300 w-300 transition-transform',
-                    lessonOpen && 'rotate-180',
-                  )}
-                />
-              </button>
-              {lessonOpen && (
-                <div className="absolute left-0 top-full z-10 mt-75 max-h-[300px] w-full overflow-y-auto rounded-100 border border-border-default bg-background-default shadow-1">
-                  {allLessons.map((l) => (
+            {/* Course/Lesson selectors — create mode only */}
+            {!isEditMode && (
+              <>
+                <div>
+                  <p className="mb-150 font-designer-16b text-gray-800">
+                    어떤 코스에서 만든 결과물인가요?
+                  </p>
+                  <div className="relative">
                     <button
-                      key={l.lessonId}
                       type="button"
-                      onClick={() => {
-                        setSelectedLessonId(l.lessonId);
-                        setLessonOpen(false);
-                      }}
-                      className="flex w-full items-center px-250 py-175 font-designer-16r text-gray-800 bg-gray-50 hover:bg-gray-100"
+                      onClick={() => setCourseOpen((p) => !p)}
+                      className="flex w-full items-center justify-between rounded-100 border border-border-default px-250 py-175 font-designer-16r text-gray-800"
                     >
-                      {l.label}
+                      {course}
+                      <ChevronDown
+                        className={cn(
+                          'h-300 w-300 transition-transform',
+                          courseOpen && 'rotate-180',
+                        )}
+                      />
                     </button>
-                  ))}
+                    {courseOpen && (
+                      <div className="absolute left-0 top-full z-10 mt-75 w-full rounded-100 border border-border-default bg-background-default shadow-1">
+                        {['바이브 코딩 입문자 코스'].map((c) => (
+                          <button
+                            key={c}
+                            type="button"
+                            onClick={() => setCourseOpen(false)}
+                            className="flex w-full items-center bg-gray-50 px-250 py-175 font-designer-16r text-gray-800 hover:bg-gray-100"
+                          >
+                            {c}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
                 </div>
-              )}
-            </div>
+
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setLessonOpen((p) => !p)}
+                    className="flex w-full items-center justify-between rounded-100 border border-border-default px-250 py-175 font-designer-16r text-gray-800"
+                  >
+                    {selectedLessonLabel}
+                    <ChevronDown
+                      className={cn(
+                        'h-300 w-300 transition-transform',
+                        lessonOpen && 'rotate-180',
+                      )}
+                    />
+                  </button>
+                  {lessonOpen && (
+                    <div className="absolute left-0 top-full z-10 mt-75 max-h-[300px] w-full overflow-y-auto rounded-100 border border-border-default bg-background-default shadow-1">
+                      {allLessons.map((l) => (
+                        <button
+                          key={l.lessonId}
+                          type="button"
+                          onClick={() => {
+                            setSelectedLessonId(l.lessonId);
+                            setLessonOpen(false);
+                          }}
+                          className="flex w-full items-center bg-gray-50 px-250 py-175 font-designer-16r text-gray-800 hover:bg-gray-100"
+                        >
+                          {l.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
 
             {/* Image upload */}
             <div>
@@ -285,26 +348,42 @@ export default function FeedWritePage() {
             <MarkdownEditor
               value={text}
               onChange={setText}
-              placeholder="코딩을 하며 다양한 순간을 글로 작성해보세요! 이번 레슨에서 배운 것, 새롭게 알게 된 것을 자유롭게 작성해보세요."
+              placeholder={
+                isEditMode
+                  ? '내용을 수정해주세요.'
+                  : '코딩을 하며 다양한 순간을 글로 작성해보세요! 이번 레슨에서 배운 것, 새롭게 알게 된 것을 자유롭게 작성해보세요.'
+              }
               uploadImage={uploadCommunityMarkdownImage}
             />
 
             {/* CTAs */}
             <div className="flex gap-200">
-              <button
-                type="button"
-                onClick={() => setShowCancelModal(true)}
-                className="flex h-700 flex-1 items-center justify-center rounded-100 border border-border-default font-designer-16m text-gray-800"
-              >
-                임시저장
-              </button>
+              {isEditMode ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    router.push(`/class/vibe-intro/feed/${editFeedId}`)
+                  }
+                  className="flex h-700 flex-1 items-center justify-center rounded-100 border border-border-default font-designer-16m text-gray-800"
+                >
+                  취소
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setShowCancelModal(true)}
+                  className="flex h-700 flex-1 items-center justify-center rounded-100 border border-border-default font-designer-16m text-gray-800"
+                >
+                  임시저장
+                </button>
+              )}
               <button
                 type="button"
                 onClick={handleSubmit}
-                disabled={createFeed.isPending}
+                disabled={submitPending}
                 className="flex h-700 flex-1 items-center justify-center rounded-100 bg-background-brand-default font-designer-16m text-text-inverse disabled:bg-gray-300"
               >
-                등록하기
+                {submitLabel}
               </button>
             </div>
           </div>

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -438,6 +438,7 @@ https://velog.io/@oneook/tailwindcss-4.0-%EB%AC%B4%EC%97%87%EC%9D%B4-%EB%8B%AC%E
   --spacing-10500: 840px;
   --spacing-3400: 272px;
   --spacing-3500: 280px;
+  --spacing-3750: 300px;
   --spacing-3875: 310px;
   --spacing-3888: 311px;
   --spacing-4275: 342px;

--- a/src/hooks/queries/course/course-api.ts
+++ b/src/hooks/queries/course/course-api.ts
@@ -811,6 +811,8 @@ export const useDeleteBuilderFeed = () => {
     onSuccess: async (_, feedId) => {
       queryClient.removeQueries({ queryKey: ['builderFeedDetail', feedId] });
       await queryClient.invalidateQueries({ queryKey: ['builderFeeds'] });
+      await queryClient.invalidateQueries({ queryKey: ['myBuilderFeeds'] });
+      await queryClient.invalidateQueries({ queryKey: ['myBuilderFeedStats'] });
     },
   });
 };
@@ -835,6 +837,7 @@ export const useUpdateBuilderFeed = () => {
         queryKey: ['builderFeedDetail', variables.feedId],
       });
       await queryClient.invalidateQueries({ queryKey: ['builderFeeds'] });
+      await queryClient.invalidateQueries({ queryKey: ['myBuilderFeeds'] });
     },
   });
 };

--- a/src/hooks/queries/course/course-api.ts
+++ b/src/hooks/queries/course/course-api.ts
@@ -16,6 +16,7 @@ import type {
   BuilderFeedReportCreateRequest,
   BuilderFeedShowcaseResponse,
   BuilderFeedStatsResponse,
+  BuilderFeedUpdateRequest,
   CourseCompletionRecapResponse,
   CourseCurriculumResponse,
   CourseDetailResponse,
@@ -797,6 +798,43 @@ export const useReportBuilderFeed = () => {
         content: { reportId: number };
       }>(`builder-feeds/${feedId}/report`, request);
       return data.content;
+    },
+  });
+};
+
+export const useDeleteBuilderFeed = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (feedId: number) => {
+      await axiosInstanceV5.delete(`builder-feeds/${feedId}`);
+    },
+    onSuccess: async (_, feedId) => {
+      queryClient.removeQueries({ queryKey: ['builderFeedDetail', feedId] });
+      await queryClient.invalidateQueries({ queryKey: ['builderFeeds'] });
+    },
+  });
+};
+
+export const useUpdateBuilderFeed = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      feedId,
+      request,
+    }: {
+      feedId: number;
+      request: BuilderFeedUpdateRequest;
+    }) => {
+      const { data } = await axiosInstanceV5.put<{
+        content: { feedId: number };
+      }>(`builder-feeds/${feedId}`, request);
+      return data.content;
+    },
+    onSuccess: async (_, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: ['builderFeedDetail', variables.feedId],
+      });
+      await queryClient.invalidateQueries({ queryKey: ['builderFeeds'] });
     },
   });
 };

--- a/src/types/api/course.types.ts
+++ b/src/types/api/course.types.ts
@@ -632,6 +632,13 @@ export interface GiftEmailResponse {
   email?: string;
 }
 
+// ─── Builder Feed Mutations ───────────────────────────────────────────────────
+
+export interface BuilderFeedUpdateRequest {
+  content: string;
+  imageKeys?: string[];
+}
+
 export interface GiftEmailCreateRequest {
   email: string;
 }


### PR DESCRIPTION
## Summary

- `feed/write` 페이지에 `?feedId` 쿼리 파라미터 감지로 create/edit 모드 분기 처리
- 수정하기 버튼이 `/feed/${id}/edit` 대신 `/feed/write?feedId=${id}`로 이동하도록 변경
- 기존 `/feed/${id}/edit` 라우트는 write 페이지로 redirect 처리 (북마크 호환)

## Changes

- **`feed/write/page.tsx`**: `<Suspense>` 래퍼 + `FeedWriteContent` 분리, `useSearchParams`로 edit 모드 감지, `initialized` 가드 패턴으로 기존 데이터 pre-fill, course/lesson 셀렉터 edit 모드에서 숨김, CTA 텍스트/동작 분기
- **`feed/[id]/page.tsx`**: 수정하기 onClick URL 변경 (`/edit` → `/write?feedId=X`)
- **`feed/[id]/edit/page.tsx`**: Server Component redirect로 교체
- **`course-api.ts`**: `useDeleteBuilderFeed`, `useUpdateBuilderFeed` 훅 추가
- **`course.types.ts`**: `BuilderFeedUpdateRequest` 타입 추가

## Test plan

- [ ] 본인 피드 상세 → 수정하기 → URL `/feed/write?feedId=X` 확인 → 기존 내용 pre-fill → 수정하기 버튼 → 상세 복귀
- [ ] 본인 피드 상세 → 삭제하기 → 확인 → 피드 리스트로 이동
- [ ] `/feed/${id}/edit` 직접 접근 → `/feed/write?feedId=${id}` redirect 확인
- [ ] `/feed/write` (파라미터 없이) → 기존 create 동작 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 피드 편집 기능 추가
  * 피드 삭제 시 확인 모달 추가

* **Bug Fixes**
  * 이미지 메모리 관리 개선

* **Chores**
  * 서버 호환성 및 라우팅 흐름 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->