### PR TITLE
fix: 릴리즈 기록 리뷰 후속 보완

### DIFF
--- a/.github/workflows/record-backend-prod-release.yml
+++ b/.github/workflows/record-backend-prod-release.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Setup Node

--- a/ops/backend-release-dispatch.md
+++ b/ops/backend-release-dispatch.md
@@ -11,7 +11,36 @@ Backend production deploy success must call the frontend repository with `reposi
 ```json
 {
   "event_type": "backend-prod-deployed",
-  "client_payload": {}
+  "client_payload": {
+    "release_id": "prod-20260517-2100",
+    "env": "prod",
+    "summary": "backend patch release",
+    "backend": {
+      "repo": "study-platform-mvp",
+      "image": "zeroone-backend:v1.4.3-b7c8d9e",
+      "commit": "b7c8d9e",
+      "version": "v1.4.3",
+      "changed": true
+    },
+    "database": {
+      "changed": true,
+      "migration_version": "V45",
+      "migration_files": [
+        "src/main/resources/db/migration/V45__create_course_refund.sql"
+      ]
+    },
+    "rollback": {
+      "backend": "zeroone-backend:v1.4.2-a1b2c3d"
+    },
+    "metadata": {
+      "release_intent": "patch",
+      "bootstrap_mode": false,
+      "previous_deploy_image": "zeroone-backend:v1.4.2-a1b2c3d",
+      "pull_request_number": 1234,
+      "pull_request_labels": ["release:patch", "db:backup-confirmed"],
+      "backend_deploy_id": "backend-prod-123"
+    }
+  }
 }
 ```
 
@@ -21,7 +50,7 @@ The frontend workflow that receives this event is:
 .github/workflows/record-backend-prod-release.yml
 ```
 
-## Required payload
+## Required `client_payload`
 
 ```json
 {

--- a/ops/rollback.md
+++ b/ops/rollback.md
@@ -24,4 +24,4 @@ Rollback is based on fixed image tags recorded in `releases/`, never on pointer 
 3. Deploy the fixed frontend/backend images.
 4. Run backend health check.
 5. Run frontend smoke/E2E check.
-6. Record the rollback outcome in a follow-up release/incident note.
+6. Record the rollback outcome in a new `releases/prod-*.yaml` release record, then link any follow-up incident note from that record or the incident tracker.


### PR DESCRIPTION
## Summary
- backend-prod-deployed record workflow checkout base를 main으로 명시 고정
- backend dispatch 문서의 빈 client_payload 예시를 필수 스키마 포함 예시로 교체
- rollback 결과를 releases/prod-*.yaml에 기록하도록 SSOT 요구사항 명시

## Verification
- node YAML parse: .github/workflows/record-backend-prod-release.yml
- node scripts/release/validate-release-record.mjs releases
- git diff --check
- git push pre-push next build 통과 (sitemap local backend ECONNREFUSED warning only)