### PR TITLE
fix: 어드민 본문 복합 붙여넣기 이미지 위치 보존

### DIFF
--- a/src/app/(admin)/admin/clipboard-inspector/page.tsx
+++ b/src/app/(admin)/admin/clipboard-inspector/page.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import type { ClipboardEvent } from 'react';
+import { useMemo, useState } from 'react';
+import Button from '@/components/common/ui/button';
+
+interface ClipboardFileSummary {
+  name: string;
+  size: number;
+  type: string;
+}
+
+interface ClipboardItemSummary {
+  kind: string;
+  type: string;
+}
+
+interface HtmlSummary {
+  imageCount: number;
+  imageSources: string[];
+  tableCount: number;
+  textLength: number;
+}
+
+interface ClipboardSnapshot {
+  capturedAt: string;
+  types: string[];
+  items: ClipboardItemSummary[];
+  files: ClipboardFileSummary[];
+  plainText: string;
+  html: string;
+  htmlSummary: HtmlSummary;
+}
+
+const summarizeHtml = (html: string): HtmlSummary => {
+  if (typeof window === 'undefined' || !html.trim()) {
+    return {
+      imageCount: 0,
+      imageSources: [],
+      tableCount: 0,
+      textLength: 0,
+    };
+  }
+
+  const document = new window.DOMParser().parseFromString(html, 'text/html');
+  const imageSources = Array.from(document.querySelectorAll('img'))
+    .map((image) => image.getAttribute('src') ?? '')
+    .filter(Boolean);
+
+  return {
+    imageCount: imageSources.length,
+    imageSources,
+    tableCount: document.querySelectorAll('table').length,
+    textLength: (document.body.textContent ?? '').trim().length,
+  };
+};
+
+const toClipboardSnapshot = (
+  clipboardData: DataTransfer,
+): ClipboardSnapshot => {
+  const html = clipboardData.getData('text/html');
+  const plainText = clipboardData.getData('text/plain');
+
+  return {
+    capturedAt: new Date().toISOString(),
+    types: Array.from(clipboardData.types),
+    items: Array.from(clipboardData.items).map((item) => ({
+      kind: item.kind,
+      type: item.type,
+    })),
+    files: Array.from(clipboardData.files).map((file) => ({
+      name: file.name,
+      size: file.size,
+      type: file.type,
+    })),
+    plainText,
+    html,
+    htmlSummary: summarizeHtml(html),
+  };
+};
+
+export default function AdminClipboardInspectorPage() {
+  const [snapshot, setSnapshot] = useState<ClipboardSnapshot | null>(null);
+  const [copyMessage, setCopyMessage] = useState('');
+  const snapshotJson = useMemo(
+    () => (snapshot ? JSON.stringify(snapshot, null, 2) : ''),
+    [snapshot],
+  );
+
+  const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setCopyMessage('');
+    setSnapshot(toClipboardSnapshot(event.clipboardData));
+  };
+
+  const handleCopySnapshot = async () => {
+    if (!snapshotJson) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(snapshotJson);
+      setCopyMessage('진단 JSON을 클립보드에 복사했습니다.');
+    } catch {
+      setCopyMessage('복사에 실패했습니다. 아래 JSON을 직접 복사해주세요.');
+    }
+  };
+
+  return (
+    <section className="flex flex-col gap-200">
+      <header className="border-border-default bg-background-default rounded-150 border p-250">
+        <p className="font-designer-13r text-text-subtle">
+          Admin Clipboard Inspector
+        </p>
+        <h1 className="font-designer-28b text-text-default mt-50">
+          붙여넣기 진단
+        </h1>
+        <p className="font-designer-15r text-text-subtle mt-100">
+          Notion에서 복사한 내용을 아래 박스에 Ctrl+V 하면 브라우저가 전달한
+          clipboardData를 그대로 확인합니다. 저장, 업로드, 서버 전송은 하지
+          않습니다.
+        </p>
+      </header>
+
+      <div
+        className="border-border-default bg-background-muted rounded-150 text-text-default font-designer-16r flex min-h-500 items-center justify-center border border-dashed p-300 outline-none focus:border-border-strong"
+        role="textbox"
+        tabIndex={0}
+        onPaste={handlePaste}
+      >
+        여기를 클릭한 뒤 Notion에서 복사한 내용을 Ctrl+V 하세요.
+      </div>
+
+      {snapshot && (
+        <div className="grid grid-cols-2 gap-200">
+          <section className="border-border-default bg-background-default rounded-150 border p-200">
+            <h2 className="font-designer-20b text-text-default">요약</h2>
+            <dl className="font-designer-14r text-text-subtle mt-150 grid grid-cols-2 gap-100">
+              <dt>capturedAt</dt>
+              <dd className="text-text-default break-all">
+                {snapshot.capturedAt}
+              </dd>
+              <dt>types</dt>
+              <dd className="text-text-default break-all">
+                {snapshot.types.join(', ') || '-'}
+              </dd>
+              <dt>items</dt>
+              <dd className="text-text-default">{snapshot.items.length}</dd>
+              <dt>files</dt>
+              <dd className="text-text-default">{snapshot.files.length}</dd>
+              <dt>plain text length</dt>
+              <dd className="text-text-default">{snapshot.plainText.length}</dd>
+              <dt>html length</dt>
+              <dd className="text-text-default">{snapshot.html.length}</dd>
+              <dt>html text length</dt>
+              <dd className="text-text-default">
+                {snapshot.htmlSummary.textLength}
+              </dd>
+              <dt>html images</dt>
+              <dd className="text-text-default">
+                {snapshot.htmlSummary.imageCount}
+              </dd>
+              <dt>html tables</dt>
+              <dd className="text-text-default">
+                {snapshot.htmlSummary.tableCount}
+              </dd>
+            </dl>
+          </section>
+
+          <section className="border-border-default bg-background-default rounded-150 border p-200">
+            <div className="flex items-center justify-between gap-100">
+              <h2 className="font-designer-20b text-text-default">
+                공유용 JSON
+              </h2>
+              <Button size="small" onClick={handleCopySnapshot}>
+                JSON 복사
+              </Button>
+            </div>
+            {copyMessage && (
+              <p className="font-designer-13r text-text-subtle mt-100">
+                {copyMessage}
+              </p>
+            )}
+            <textarea
+              className="border-border-default bg-background-muted text-text-default font-designer-13r mt-150 h-600 w-full resize-y rounded-100 border p-150"
+              readOnly
+              value={snapshotJson}
+            />
+          </section>
+
+          <section className="border-border-default bg-background-default rounded-150 col-span-2 border p-200">
+            <h2 className="font-designer-20b text-text-default">
+              text/html 원문
+            </h2>
+            <textarea
+              className="border-border-default bg-background-muted text-text-default font-designer-13r mt-150 h-600 w-full resize-y rounded-100 border p-150"
+              readOnly
+              value={snapshot.html || '(empty)'}
+            />
+          </section>
+
+          <section className="border-border-default bg-background-default rounded-150 col-span-2 border p-200">
+            <h2 className="font-designer-20b text-text-default">
+              text/plain 원문
+            </h2>
+            <textarea
+              className="border-border-default bg-background-muted text-text-default font-designer-13r mt-150 h-300 w-full resize-y rounded-100 border p-150"
+              readOnly
+              value={snapshot.plainText || '(empty)'}
+            />
+          </section>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/admin/courses/admin-course-markdown-editor.tsx
+++ b/src/components/admin/courses/admin-course-markdown-editor.tsx
@@ -5,10 +5,20 @@ import MarkdownEditor from '@/components/common/ui/editor/markdown-editor';
 import { uploadAdminLessonContentImage } from '@/features/admin/course-management/model/admin-course-image-upload';
 import {
   ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS,
+  ADMIN_COURSE_MARKDOWN_APPROX_KOREAN_TEXT_LENGTH,
+  ADMIN_COURSE_MARKDOWN_MAX_CONTENT_BYTES,
   ADMIN_COURSE_MARKDOWN_MAX_IMAGE_COUNT,
   ADMIN_COURSE_MARKDOWN_MAX_IMAGE_FILE_SIZE,
   normalizeAdminCourseMarkdownContent,
 } from '@/features/admin/course-management/model/admin-course-markdown';
+
+const formatByteSize = (bytes: number) => {
+  if (bytes < 1024 * 1024) {
+    return `${Math.floor(bytes / 1024)}KB`;
+  }
+
+  return `${Math.floor(bytes / 1024 / 1024)}MB`;
+};
 
 interface AdminCourseMarkdownEditorProps {
   editorStateKey?: string;
@@ -73,8 +83,17 @@ function AdminCourseMarkdownEditor({
             : undefined
         }
       />
+      <p className="font-designer-12r text-text-subtle mt-50">
+        본문 저장 한도는 최대{' '}
+        {formatByteSize(ADMIN_COURSE_MARKDOWN_MAX_CONTENT_BYTES)}
+        (TEXT, 한글/HTML 포함 약{' '}
+        {ADMIN_COURSE_MARKDOWN_APPROX_KOREAN_TEXT_LENGTH.toLocaleString()}자
+        내외)이며, 이미지는 최대 {ADMIN_COURSE_MARKDOWN_MAX_IMAGE_COUNT}개까지
+        넣을 수 있습니다. 이미지 파일은 개당 최대{' '}
+        {formatByteSize(ADMIN_COURSE_MARKDOWN_MAX_IMAGE_FILE_SIZE)}입니다.
+      </p>
       {!lessonId && (
-        <p className="font-designer-12r text-text-subtle mt-50">
+        <p className="font-designer-12r text-text-subtle mt-25">
           레슨 본문 이미지는 레슨 생성 후 편집 모드에서 업로드할 수 있습니다.
         </p>
       )}

--- a/src/components/common/ui/editor/markdown-editor.tsx
+++ b/src/components/common/ui/editor/markdown-editor.tsx
@@ -32,9 +32,14 @@ import {
 } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import Button from '@/components/common/ui/button';
+import { extractImageUrls } from '@/utils/markdown-content-images';
 import { normalizeMarkdownContent } from '@/utils/markdown-content-normalize';
 import { getRichContentVisibleTextLength } from '@/utils/markdown-content-text';
-import { hasClipboardImageHint, isClipboardImageOnly } from './clipboard-utils';
+import {
+  extractClipboardImageFiles,
+  hasClipboardImageHint,
+  isClipboardImageOnly,
+} from './clipboard-utils';
 import EditorVisibleTextCounter from './editor-visible-text-counter';
 import {
   InstantCodeBlockExtension,
@@ -49,6 +54,8 @@ import {
   MARKDOWN_IMAGE_DEFAULT_ALLOWED_EXTENSIONS,
   MARKDOWN_IMAGE_DEFAULT_MAX_COUNT,
   MARKDOWN_IMAGE_DEFAULT_MAX_FILE_SIZE,
+  getExtensionFromMime,
+  toFileFromBlob,
   toImageInputAccept,
 } from './image-utils';
 import {
@@ -201,7 +208,110 @@ function MarkdownEditor({
     setImageInsertError,
     handleImageFiles,
     handleClipboardPaste,
+    handleImageSourceFileReplacements,
   } = useImageUpload(resolvedImageConfig);
+
+  const getNewImageSources = (
+    beforeSources: string[],
+    afterSources: string[],
+  ) => {
+    const remainingBeforeSourceCounts = new Map<string, number>();
+    beforeSources.forEach((source) => {
+      remainingBeforeSourceCounts.set(
+        source,
+        (remainingBeforeSourceCounts.get(source) ?? 0) + 1,
+      );
+    });
+
+    return afterSources.filter((source) => {
+      const remainingCount = remainingBeforeSourceCounts.get(source) ?? 0;
+      if (remainingCount > 0) {
+        remainingBeforeSourceCounts.set(source, remainingCount - 1);
+        return false;
+      }
+
+      return true;
+    });
+  };
+
+  const toDataImageFile = async (source: string, index: number) => {
+    if (!source.startsWith('data:image/')) {
+      return undefined;
+    }
+
+    const response = await fetch(source);
+    const blob = await response.blob();
+    const extension = getExtensionFromMime(blob.type) || 'png';
+
+    return toFileFromBlob(blob, `pasted-image-${index + 1}.${extension}`);
+  };
+
+  const replaceMixedClipboardImagesAfterDefaultPaste = (
+    editorInstance: Editor,
+    clipboardData: DataTransfer,
+  ) => {
+    const imageFiles = extractClipboardImageFiles(clipboardData);
+    const imageSourcesBeforePaste = extractImageUrls(editorInstance.getHTML());
+
+    window.setTimeout(() => {
+      const nextEditorInstance = getValidEditorInstance();
+      if (!nextEditorInstance || nextEditorInstance !== editorInstance) {
+        return;
+      }
+
+      const imageSourcesAfterPaste = extractImageUrls(
+        nextEditorInstance.getHTML(),
+      );
+      const newImageSources = getNewImageSources(
+        imageSourcesBeforePaste,
+        imageSourcesAfterPaste,
+      );
+
+      if (newImageSources.length === 0) {
+        if (imageFiles.length > 0) {
+          handleImageFiles(nextEditorInstance, imageFiles).catch(() => {
+            setImageInsertError('이미지 붙여넣기에 실패했습니다.');
+          });
+        }
+
+        return;
+      }
+
+      Promise.all(
+        newImageSources.map(async (source, index) => {
+          const dataImageFile = await toDataImageFile(source, index);
+          if (dataImageFile) {
+            return { file: dataImageFile, source };
+          }
+
+          const imageFile = imageFiles[index];
+          if (!imageFile) {
+            return undefined;
+          }
+
+          return { file: imageFile, source };
+        }),
+      )
+        .then((replacements) => {
+          const validReplacements = replacements.filter(
+            (replacement): replacement is { file: File; source: string } =>
+              replacement !== undefined,
+          );
+
+          if (validReplacements.length === 0) {
+            return;
+          }
+
+          return handleImageSourceFileReplacements(
+            nextEditorInstance,
+            validReplacements,
+          );
+        })
+        .catch(() => {
+          setImageInsertError('이미지 붙여넣기에 실패했습니다.');
+        });
+    }, 0);
+  };
 
   const editor = useEditor({
     immediatelyRender: false,
@@ -297,6 +407,11 @@ function MarkdownEditor({
           insertMarkdownTable(editorInstance, markdownTable);
           return true;
         }
+
+        replaceMixedClipboardImagesAfterDefaultPaste(
+          editorInstance,
+          clipboardData,
+        );
 
         if (!insertYouTubeEmbed(editorInstance, pastedText)) {
           return false;

--- a/src/components/common/ui/editor/markdown-table-utils.ts
+++ b/src/components/common/ui/editor/markdown-table-utils.ts
@@ -115,7 +115,12 @@ export const convertHtmlTableToMarkdownTable = (html: string) => {
   }
 
   const document = new window.DOMParser().parseFromString(html, 'text/html');
-  const table = document.querySelector('table');
+  const tables = Array.from(document.querySelectorAll('table'));
+  if (tables.length !== 1) {
+    return undefined;
+  }
+
+  const table = tables[0];
   if (!table) {
     return undefined;
   }
@@ -143,7 +148,13 @@ export const isHtmlTableOnlyPaste = (html: string) => {
   }
 
   const document = new window.DOMParser().parseFromString(html, 'text/html');
-  if (!document.querySelector('table')) {
+  const tables = Array.from(document.querySelectorAll('table'));
+  if (tables.length !== 1) {
+    return false;
+  }
+
+  const table = tables[0];
+  if (!table || table.querySelector('img,video,audio,iframe,canvas,svg')) {
     return false;
   }
 

--- a/src/components/common/ui/editor/use-image-upload.ts
+++ b/src/components/common/ui/editor/use-image-upload.ts
@@ -25,6 +25,11 @@ interface ImageInsertRange {
   to: number;
 }
 
+interface ImageSourceFileReplacement {
+  file: File;
+  source: string;
+}
+
 const getCurrentImageInsertRange = (editor: Editor): ImageInsertRange => ({
   from: editor.state.selection.from,
   to: editor.state.selection.to,
@@ -51,6 +56,44 @@ const insertUploadedImageUrls = (
     editor.chain().focus().insertContentAt(insertRange, imageContents).run();
   } catch {
     editor.chain().focus().insertContent(imageContents).run();
+  }
+};
+
+const replaceImageSources = (
+  editor: Editor,
+  replacements: Array<{ source: string; uploadedImageUrl: string }>,
+) => {
+  if (replacements.length === 0) {
+    return;
+  }
+
+  const replacementBySource = new Map(
+    replacements.map(({ source, uploadedImageUrl }) => [
+      source,
+      uploadedImageUrl,
+    ]),
+  );
+  const transaction = editor.state.tr;
+
+  editor.state.doc.descendants((node, position) => {
+    if (node.type.name !== 'image') {
+      return;
+    }
+
+    const source = typeof node.attrs.src === 'string' ? node.attrs.src : '';
+    const uploadedImageUrl = replacementBySource.get(source);
+    if (!uploadedImageUrl) {
+      return;
+    }
+
+    transaction.setNodeMarkup(position, undefined, {
+      ...node.attrs,
+      src: uploadedImageUrl,
+    });
+  });
+
+  if (transaction.docChanged) {
+    editor.view.dispatch(transaction);
   }
 };
 
@@ -200,6 +243,116 @@ export function useImageUpload(
       }
     },
     [collectUploadedImageUrls, isUploadingImages, resolvedImageConfig],
+  );
+
+  const handleImageSourceFileReplacements = useCallback(
+    async (editor: Editor, replacements: ImageSourceFileReplacement[]) => {
+      if (
+        !resolvedImageConfig ||
+        replacements.length === 0 ||
+        isUploadingImages
+      ) {
+        return;
+      }
+
+      const replacementSources = new Set(
+        replacements.map(({ source }) => source),
+      );
+      const existingImageCount = extractImageUrls(editor.getHTML()).filter(
+        (source) => !replacementSources.has(source),
+      ).length;
+      const maxImageCount = resolvedImageConfig.maxImageCount;
+      const remainingSlots = Math.max(0, maxImageCount - existingImageCount);
+
+      if (remainingSlots === 0) {
+        setImageInsertError(maxImageCountError(maxImageCount));
+
+        return;
+      }
+
+      const validReplacements: Array<{ file: File; source: string }> = [];
+      const errors: string[] = [];
+      let hitLimit = false;
+
+      for (const replacement of replacements) {
+        if (validReplacements.length >= remainingSlots) {
+          hitLimit = true;
+          break;
+        }
+
+        let normalizedFile: File;
+        try {
+          normalizedFile = await normalizeImageFileForUpload(replacement.file);
+        } catch (error) {
+          errors.push(
+            getImageFileNormalizationErrorMessage(replacement.file.name, error),
+          );
+          continue;
+        }
+
+        const error = getImageFileUploadValidationError(
+          normalizedFile,
+          resolvedImageConfig,
+        );
+        if (error) {
+          errors.push(error);
+        } else {
+          validReplacements.push({
+            file: normalizedFile,
+            source: replacement.source,
+          });
+        }
+      }
+
+      if (validReplacements.length === 0) {
+        if (errors.length > 0) {
+          setImageInsertError(errors.join(' '));
+        }
+
+        return;
+      }
+
+      setIsUploadingImages(true);
+      setImageInsertError('');
+
+      try {
+        const uploadedReplacements: Array<{
+          source: string;
+          uploadedImageUrl: string;
+        }> = [];
+
+        for (const replacement of validReplacements) {
+          try {
+            const uploadedImageUrl = await uploadFile(replacement.file);
+            if (uploadedImageUrl) {
+              uploadedReplacements.push({
+                source: replacement.source,
+                uploadedImageUrl,
+              });
+            }
+          } catch (error) {
+            const message =
+              error instanceof Error && error.message.trim()
+                ? error.message.trim()
+                : '업로드 실패';
+            errors.push(`${replacement.file.name}: ${message}`);
+          }
+        }
+
+        replaceImageSources(editor, uploadedReplacements);
+
+        if (hitLimit) {
+          errors.push(maxImageCountError(maxImageCount));
+        }
+
+        if (errors.length > 0) {
+          setImageInsertError(errors.join(' '));
+        }
+      } finally {
+        setIsUploadingImages(false);
+      }
+    },
+    [isUploadingImages, resolvedImageConfig, uploadFile],
   );
 
   /**
@@ -362,5 +515,6 @@ export function useImageUpload(
     setImageInsertError,
     handleImageFiles,
     handleClipboardPaste,
+    handleImageSourceFileReplacements,
   };
 }

--- a/src/features/admin/course-management/model/admin-course-markdown.ts
+++ b/src/features/admin/course-management/model/admin-course-markdown.ts
@@ -1,7 +1,4 @@
-import {
-  COMMUNITY_MARKDOWN_MAX_IMAGE_COUNT,
-  COMMUNITY_MARKDOWN_MAX_IMAGE_FILE_SIZE,
-} from '@/types/community/markdown';
+import { COMMUNITY_MARKDOWN_MAX_IMAGE_FILE_SIZE } from '@/types/community/markdown';
 import { normalizeMarkdownContent } from '@/utils/markdown-content-normalize';
 import { isHtmlContent } from '@/utils/markdown-content-shared';
 
@@ -15,8 +12,9 @@ export const ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS = [
   'heic',
   'heif',
 ] as const;
-export const ADMIN_COURSE_MARKDOWN_MAX_IMAGE_COUNT =
-  COMMUNITY_MARKDOWN_MAX_IMAGE_COUNT;
+export const ADMIN_COURSE_MARKDOWN_MAX_CONTENT_BYTES = 65_535;
+export const ADMIN_COURSE_MARKDOWN_APPROX_KOREAN_TEXT_LENGTH = 20_000;
+export const ADMIN_COURSE_MARKDOWN_MAX_IMAGE_COUNT = 10;
 export const ADMIN_COURSE_MARKDOWN_MAX_IMAGE_FILE_SIZE =
   COMMUNITY_MARKDOWN_MAX_IMAGE_FILE_SIZE;
 


### PR DESCRIPTION
## 요약
- 어드민 레슨 본문 에디터에서 Notion 등 복합 HTML 붙여넣기 시 글/표/이미지 위치를 보존합니다.
- 붙여넣힌 이미지 노드의 src를 업로드 URL로 교체해 저장 안정성을 높입니다.
- 어드민 레슨 본문 이미지 제한을 10개로 조정하고 입력 한도 안내를 추가합니다.

## 검증
- yarn eslint src/components/common/ui/editor/markdown-editor.tsx src/components/common/ui/editor/use-image-upload.ts src/features/admin/course-management/model/admin-course-markdown.ts src/components/admin/courses/admin-course-markdown-editor.tsx
- yarn typecheck
- git diff --check

## 배포
- develop 머지 후 Front Test Server (Develop) workflow로 test 서버 배포