### PR TITLE
fix: 복합 붙여넣기 표와 노션 이미지 안내 보존

### DIFF
--- a/src/app/(admin)/admin/clipboard-inspector/page.tsx
+++ b/src/app/(admin)/admin/clipboard-inspector/page.tsx
@@ -3,6 +3,7 @@
 import type { ClipboardEvent } from 'react';
 import { useMemo, useState } from 'react';
 import Button from '@/components/common/ui/button';
+import { NOTION_CLIPBOARD_TYPES } from '@/components/common/ui/editor/notion-clipboard-utils';
 
 interface ClipboardFileSummary {
   name: string;
@@ -29,6 +30,7 @@ interface ClipboardSnapshot {
   files: ClipboardFileSummary[];
   plainText: string;
   html: string;
+  notionPayloads: Record<string, string>;
   htmlSummary: HtmlSummary;
 }
 
@@ -60,6 +62,9 @@ const toClipboardSnapshot = (
 ): ClipboardSnapshot => {
   const html = clipboardData.getData('text/html');
   const plainText = clipboardData.getData('text/plain');
+  const notionPayloads = Object.fromEntries(
+    NOTION_CLIPBOARD_TYPES.map((type) => [type, clipboardData.getData(type)]),
+  );
 
   return {
     capturedAt: new Date().toISOString(),
@@ -75,6 +80,7 @@ const toClipboardSnapshot = (
     })),
     plainText,
     html,
+    notionPayloads,
     htmlSummary: summarizeHtml(html),
   };
 };
@@ -164,6 +170,16 @@ export default function AdminClipboardInspectorPage() {
               <dd className="text-text-default">
                 {snapshot.htmlSummary.tableCount}
               </dd>
+              <dt>Notion blocks length</dt>
+              <dd className="text-text-default">
+                {snapshot.notionPayloads['text/_notion-blocks-v3-production']
+                  ?.length ?? 0}
+              </dd>
+              <dt>Notion source length</dt>
+              <dd className="text-text-default">
+                {snapshot.notionPayloads['text/_notion-page-source-production']
+                  ?.length ?? 0}
+              </dd>
             </dl>
           </section>
 
@@ -209,6 +225,22 @@ export default function AdminClipboardInspectorPage() {
               value={snapshot.plainText || '(empty)'}
             />
           </section>
+
+          {Object.entries(snapshot.notionPayloads).map(([type, payload]) => (
+            <section
+              key={type}
+              className="border-border-default bg-background-default rounded-150 col-span-2 border p-200"
+            >
+              <h2 className="font-designer-20b text-text-default">
+                {type} 원문
+              </h2>
+              <textarea
+                className="border-border-default bg-background-muted text-text-default font-designer-13r mt-150 h-400 w-full resize-y rounded-100 border p-150"
+                readOnly
+                value={payload || '(empty)'}
+              />
+            </section>
+          ))}
         </div>
       )}
     </section>

--- a/src/components/common/ui/editor/markdown-editor.tsx
+++ b/src/components/common/ui/editor/markdown-editor.tsx
@@ -63,6 +63,7 @@ import {
   convertTabularTextToMarkdownTable,
   isHtmlTableOnlyPaste,
 } from './markdown-table-utils';
+import { normalizeRichClipboardHtml } from './rich-clipboard-normalizer';
 import { CODE_LANGUAGES, HEADING_OPTIONS, ToolbarButton } from './toolbar';
 import { useActiveCodeBlockControl } from './use-active-code-block-control';
 import { useImageUpload } from './use-image-upload';
@@ -246,12 +247,12 @@ function MarkdownEditor({
     return toFileFromBlob(blob, `pasted-image-${index + 1}.${extension}`);
   };
 
-  const replaceMixedClipboardImagesAfterDefaultPaste = (
+  const replaceMixedClipboardImagesAfterPaste = (
     editorInstance: Editor,
     clipboardData: DataTransfer,
+    imageSourcesBeforePaste: string[],
   ) => {
     const imageFiles = extractClipboardImageFiles(clipboardData);
-    const imageSourcesBeforePaste = extractImageUrls(editorInstance.getHTML());
 
     window.setTimeout(() => {
       const nextEditorInstance = getValidEditorInstance();
@@ -408,9 +409,38 @@ function MarkdownEditor({
           return true;
         }
 
-        replaceMixedClipboardImagesAfterDefaultPaste(
+        const normalizedRichClipboardHtml =
+          normalizeRichClipboardHtml(pastedHtml);
+
+        if (normalizedRichClipboardHtml.hasChanges) {
+          event.preventDefault();
+          const imageSourcesBeforePaste = extractImageUrls(
+            editorInstance.getHTML(),
+          );
+          editorInstance
+            .chain()
+            .focus()
+            .insertContent(normalizedRichClipboardHtml.html)
+            .run();
+          replaceMixedClipboardImagesAfterPaste(
+            editorInstance,
+            clipboardData,
+            imageSourcesBeforePaste,
+          );
+
+          if (normalizedRichClipboardHtml.notionAttachmentCount > 0) {
+            setImageInsertError(
+              'Notion 첨부 이미지는 원본 파일이 클립보드에 없어 위치에 안내 문구를 넣었습니다. 이미지는 직접 업로드해주세요.',
+            );
+          }
+
+          return true;
+        }
+
+        replaceMixedClipboardImagesAfterPaste(
           editorInstance,
           clipboardData,
+          extractImageUrls(editorInstance.getHTML()),
         );
 
         if (!insertYouTubeEmbed(editorInstance, pastedText)) {

--- a/src/components/common/ui/editor/markdown-table-utils.ts
+++ b/src/components/common/ui/editor/markdown-table-utils.ts
@@ -1,6 +1,7 @@
 const MARKDOWN_TABLE_SEPARATOR_CELL_PATTERN = /^:?-{3,}:?$/;
 
-const normalizeTableCell = (value: string) => value.replace(/\s+/g, ' ').trim();
+export const normalizeTableCell = (value: string) =>
+  value.replace(/\s+/g, ' ').trim();
 
 const splitMarkdownTableRow = (line: string) => {
   const trimmed = line.trim();
@@ -109,6 +110,24 @@ export const convertTabularTextToMarkdownTable = (text: string) => {
   ].join('\n');
 };
 
+export const convertHtmlTableElementToMarkdownTable = (table: Element) => {
+  const rows = Array.from(table.querySelectorAll('tr'))
+    .map((row) =>
+      Array.from(row.querySelectorAll('th,td')).map((cell) =>
+        normalizeTableCell(cell.textContent ?? ''),
+      ),
+    )
+    .filter((cells) => cells.length >= 2 && cells.some(Boolean));
+
+  if (rows.length === 0) {
+    return undefined;
+  }
+
+  return convertTabularTextToMarkdownTable(
+    rows.map((cells) => cells.join('\t')).join('\n'),
+  );
+};
+
 export const convertHtmlTableToMarkdownTable = (html: string) => {
   if (typeof window === 'undefined' || !html.trim()) {
     return undefined;
@@ -125,21 +144,7 @@ export const convertHtmlTableToMarkdownTable = (html: string) => {
     return undefined;
   }
 
-  const rows = Array.from(table.querySelectorAll('tr'))
-    .map((row) =>
-      Array.from(row.querySelectorAll('th,td')).map((cell) =>
-        normalizeTableCell(cell.textContent ?? ''),
-      ),
-    )
-    .filter((cells) => cells.length >= 2 && cells.some(Boolean));
-
-  if (rows.length === 0) {
-    return undefined;
-  }
-
-  return convertTabularTextToMarkdownTable(
-    rows.map((cells) => cells.join('\t')).join('\n'),
-  );
+  return convertHtmlTableElementToMarkdownTable(table);
 };
 
 export const isHtmlTableOnlyPaste = (html: string) => {

--- a/src/components/common/ui/editor/notion-clipboard-utils.ts
+++ b/src/components/common/ui/editor/notion-clipboard-utils.ts
@@ -1,0 +1,35 @@
+export const NOTION_BLOCKS_CLIPBOARD_TYPE = 'text/_notion-blocks-v3-production';
+export const NOTION_PAGE_SOURCE_CLIPBOARD_TYPE =
+  'text/_notion-page-source-production';
+
+export const NOTION_CLIPBOARD_TYPES = [
+  NOTION_BLOCKS_CLIPBOARD_TYPE,
+  NOTION_PAGE_SOURCE_CLIPBOARD_TYPE,
+] as const;
+
+export const isNotionClipboard = (clipboardData: DataTransfer) => {
+  const types = Array.from(clipboardData.types);
+
+  return NOTION_CLIPBOARD_TYPES.some((type) => types.includes(type));
+};
+
+export const getNotionClipboardPayloads = (clipboardData: DataTransfer) => {
+  return Object.fromEntries(
+    NOTION_CLIPBOARD_TYPES.map((type) => [type, clipboardData.getData(type)]),
+  );
+};
+
+const NOTION_ATTACHMENT_SOURCE_PATTERN = /^attachment:[^\s]+/i;
+
+export const isNotionAttachmentSource = (source: string) => {
+  return NOTION_ATTACHMENT_SOURCE_PATTERN.test(source.trim());
+};
+
+export const getNotionAttachmentPlaceholderText = (alt?: string) => {
+  const normalizedAlt = alt?.trim();
+  if (normalizedAlt) {
+    return `[Notion 이미지: ${normalizedAlt} - 원본 이미지를 다시 업로드해주세요.]`;
+  }
+
+  return '[Notion 이미지 - 원본 이미지를 다시 업로드해주세요.]';
+};

--- a/src/components/common/ui/editor/rich-clipboard-normalizer.ts
+++ b/src/components/common/ui/editor/rich-clipboard-normalizer.ts
@@ -1,0 +1,92 @@
+import { convertHtmlTableElementToMarkdownTable } from './markdown-table-utils';
+import {
+  getNotionAttachmentPlaceholderText,
+  isNotionAttachmentSource,
+} from './notion-clipboard-utils';
+
+interface RichClipboardNormalizationResult {
+  html: string;
+  hasChanges: boolean;
+  notionAttachmentCount: number;
+  tableCount: number;
+}
+
+const replaceElementWithParagraphLines = (
+  document: Document,
+  element: Element,
+  lines: readonly string[],
+) => {
+  const fragment = document.createDocumentFragment();
+
+  lines.forEach((line) => {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = line;
+    fragment.appendChild(paragraph);
+  });
+
+  element.replaceWith(fragment);
+};
+
+const normalizeTables = (document: Document) => {
+  let tableCount = 0;
+
+  Array.from(document.querySelectorAll('table')).forEach((table) => {
+    const markdownTable = convertHtmlTableElementToMarkdownTable(table);
+    if (!markdownTable) {
+      return;
+    }
+
+    replaceElementWithParagraphLines(
+      document,
+      table,
+      markdownTable.split('\n'),
+    );
+    tableCount += 1;
+  });
+
+  return tableCount;
+};
+
+const normalizeNotionAttachmentImages = (document: Document) => {
+  let notionAttachmentCount = 0;
+
+  Array.from(document.querySelectorAll('img')).forEach((image) => {
+    const source = image.getAttribute('src') ?? '';
+    if (!isNotionAttachmentSource(source)) {
+      return;
+    }
+
+    const paragraph = document.createElement('p');
+    paragraph.textContent = getNotionAttachmentPlaceholderText(
+      image.getAttribute('alt') ?? undefined,
+    );
+    image.replaceWith(paragraph);
+    notionAttachmentCount += 1;
+  });
+
+  return notionAttachmentCount;
+};
+
+export const normalizeRichClipboardHtml = (
+  html: string,
+): RichClipboardNormalizationResult => {
+  if (typeof window === 'undefined' || !html.trim()) {
+    return {
+      html,
+      hasChanges: false,
+      notionAttachmentCount: 0,
+      tableCount: 0,
+    };
+  }
+
+  const document = new window.DOMParser().parseFromString(html, 'text/html');
+  const tableCount = normalizeTables(document);
+  const notionAttachmentCount = normalizeNotionAttachmentImages(document);
+
+  return {
+    html: document.body.innerHTML,
+    hasChanges: tableCount > 0 || notionAttachmentCount > 0,
+    notionAttachmentCount,
+    tableCount,
+  };
+};


### PR DESCRIPTION
## Problem
Notion 등 복합 HTML을 레슨 본문에 붙여넣을 때 본문 중간의 `<table>`을 편집기가 표로 이해하지 못하고, Notion 첨부 이미지는 `attachment:` 참조만 들어와 이미지 위치가 사라질 수 있었습니다.

## Solution
- 공용 MarkdownEditor 붙여넣기 단계에 rich clipboard normalizer를 추가했습니다.
- 복합 HTML 내부의 `<table>`을 기존 렌더러가 이해하는 마크다운 표 문단으로 변환합니다.
- Notion `attachment:` 이미지는 원본 파일이 클립보드에 없으므로 해당 위치에 재업로드 안내 placeholder를 남깁니다.
- Notion 전용 clipboard payload를 inspector 화면에서 확인할 수 있게 했습니다.

## Verification
- `yarn eslint src/components/common/ui/editor/markdown-editor.tsx src/components/common/ui/editor/markdown-table-utils.ts src/components/common/ui/editor/rich-clipboard-normalizer.ts src/components/common/ui/editor/notion-clipboard-utils.ts 'src/app/(admin)/admin/clipboard-inspector/page.tsx'`
- `yarn biome format --write src/components/common/ui/editor/markdown-editor.tsx src/components/common/ui/editor/markdown-table-utils.ts src/components/common/ui/editor/rich-clipboard-normalizer.ts src/components/common/ui/editor/notion-clipboard-utils.ts 'src/app/(admin)/admin/clipboard-inspector/page.tsx'`
- `yarn typecheck`
- `git diff --check`
