### PR TITLE
fix: 운영 프론트 이미지 전달 복구

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push-image
     env:
-      FRONTEND_IMAGE: ${{ needs.build-and-push-image.outputs.frontend_image }}
+      FRONTEND_IMAGE: zerooneitkr/zeroone-frontend:${{ needs.build-and-push-image.outputs.frontend_version }}-${{ needs.build-and-push-image.outputs.frontend_commit }}
       RELEASE_ID: ${{ needs.build-and-push-image.outputs.release_id }}
       DEPLOYED_AT: ${{ needs.build-and-push-image.outputs.deployed_at }}
       FRONTEND_COMMIT: ${{ needs.build-and-push-image.outputs.frontend_commit }}
@@ -247,15 +247,16 @@ jobs:
       - name: Deploy frontend image to production server
         run: |
           set -euo pipefail
-          sshpass -p '${{ secrets.SSH_PASSWORD }}' ssh ssh.zeroone.it.kr bash << 'EOF'
-            set -e
+          : "${FRONTEND_IMAGE:?FRONTEND_IMAGE is required}"
+          sshpass -p '${{ secrets.SSH_PASSWORD }}' ssh ssh.zeroone.it.kr \
+            "FRONTEND_IMAGE='$FRONTEND_IMAGE' bash -s" << 'EOF'
+            set -euo pipefail
             SUDO_PASSWORD='${{ secrets.SSH_PASSWORD }}'
-            FRONTEND_IMAGE='${{ needs.build-and-push-image.outputs.frontend_image }}'
+            : "${FRONTEND_IMAGE:?FRONTEND_IMAGE is required}"
 
-            echo "사용하지 않는 컨테이너, 이미지, 네트워크 정리 중 (볼륨제외)..."
-            echo "$SUDO_PASSWORD" | sudo -S docker stop frontend-prod || true
-            echo "$SUDO_PASSWORD" | sudo -S docker rm frontend-prod || true
-            echo "$SUDO_PASSWORD" | sudo -S docker system prune -a -f
+            echo "사용하지 않는 이미지, 네트워크 정리 중 (실행 중 컨테이너 보존, 볼륨 제외)..."
+            echo "$SUDO_PASSWORD" | sudo -S docker image prune -f || true
+            echo "$SUDO_PASSWORD" | sudo -S docker network prune -f || true
 
             cd ~/front/study-platform-client-prod || {
               echo "디렉토리가 없습니다. 생성합니다..."
@@ -288,16 +289,17 @@ jobs:
               restart: unless-stopped
           COMPOSE
 
-            echo "기존 컨테이너 완전 제거"
+            echo "도커 이미지 pull: $FRONTEND_IMAGE"
+            echo "$SUDO_PASSWORD" | sudo -S docker pull "$FRONTEND_IMAGE"
+
+            echo "기존 컨테이너 교체"
             echo "$SUDO_PASSWORD" | sudo -S docker compose -f docker-compose.prod.yml down || true
             echo "$SUDO_PASSWORD" | sudo -S docker stop frontend-prod || true
             echo "$SUDO_PASSWORD" | sudo -S docker rm frontend-prod || true
 
-            echo "도커 이미지 pull: $FRONTEND_IMAGE"
-            echo "$SUDO_PASSWORD" | sudo -S docker pull "$FRONTEND_IMAGE"
-
             echo "도커 컴포즈 재시작"
             echo "$SUDO_PASSWORD" | sudo -S docker compose -f docker-compose.prod.yml up -d
+            echo "$SUDO_PASSWORD" | sudo -S docker system prune -f || true
 
             echo "운영 서버 배포 완료"
           EOF


### PR DESCRIPTION
## 요약
- GitHub Actions job output으로 전달되던 `frontend_image`가 downstream deploy job에서 빈 값이 되어 운영 배포가 실패한 문제를 수정합니다.
- deploy job에서 이미지 전체 문자열을 output으로 받지 않고, 안전한 version/commit output으로 이미지 태그를 재구성합니다.
- 빈 이미지 값이면 서버 접속/컨테이너 제거 전에 즉시 실패하도록 가드를 추가했습니다.
- 새 이미지 pull 성공 이후에만 기존 컨테이너를 교체하도록 순서를 바꿔, 같은 문제가 재발해도 운영 컨테이너를 먼저 내리지 않게 했습니다.

## 검증
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy-prod.yml'); puts 'yaml ok'"`
- `git diff --check`
- `node scripts/release/validate-release-record.mjs releases`
- pre-push `next build` 통과
