### PR TITLE
결제 E2E 테스트 추가 (취소·환불·클래스 결제)

### DIFF
--- a/e2e/class/payment-success.spec.ts
+++ b/e2e/class/payment-success.spec.ts
@@ -1,0 +1,256 @@
+import { test, expect, type Page } from '@playwright/test';
+import { existsSync, readFileSync } from 'fs';
+import type {
+  CourseDetailResponse,
+  CoursePaymentConfirmResponse,
+} from '../../src/types/api/course.types';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const AUTH_FILE = 'e2e/fixtures/auth.json';
+const SLUG = 'vibe-intro';
+const COURSE_ID = 1;
+const SUCCESS_PATH =
+  `/class/${SLUG}/payment/success` +
+  `?paymentId=1&paymentKey=test_pk_D5GePAmors8Z&orderId=order-vibe-001&amount=99000`;
+
+// ─── Localhost auth cookie injection ─────────────────────────────────────────
+
+test.beforeEach(async ({ context, baseURL }) => {
+  if (baseURL?.startsWith('http://localhost') && existsSync(AUTH_FILE)) {
+    const { cookies } = JSON.parse(readFileSync(AUTH_FILE, 'utf-8')) as {
+      cookies: {
+        name: string;
+        value: string;
+        domain: string;
+        path: string;
+        expires: number;
+        httpOnly: boolean;
+        secure: boolean;
+        sameSite: 'Strict' | 'Lax' | 'None';
+      }[];
+    };
+    await context.addCookies(
+      cookies.map((c) => ({ ...c, domain: 'localhost', secure: false })),
+    );
+  }
+});
+
+// ─── Mock Factories ───────────────────────────────────────────────────────────
+
+function makeCourseDetail(): { content: CourseDetailResponse } {
+  return {
+    content: {
+      courseId: COURSE_ID,
+      slug: SLUG,
+      viewerStatus: 'PAID',
+      title: '바이브 코딩 인트로',
+      description: null,
+      thumbnailUrl: null,
+      learnerCount: 42,
+      durationDays: 30,
+      completionCount: 0,
+      exploringCount: 0,
+      plans: [],
+      earlyBirdEndsAt: null,
+      canFreeEnroll: null,
+      isFreeEnrolled: false,
+      freeLessonCount: 3,
+      journeyMapAvailable: true,
+      hasFullAccess: true,
+      isPaidEnrolled: true,
+      canPurchase: null,
+    },
+  };
+}
+
+function makeConfirmSuccess(
+  overrides: Partial<CoursePaymentConfirmResponse> = {},
+): { content: CoursePaymentConfirmResponse } {
+  return {
+    content: {
+      paymentId: 1,
+      courseId: COURSE_ID,
+      planId: null,
+      planCode: 'ALL_IN_ONE',
+      amount: 99000,
+      status: 'SUCCESS',
+      paymentMethod: 'CARD',
+      paidAt: '2026-05-18T09:00:00.000Z',
+      tossReceiptUrl: null,
+      virtualAccountNumber: null,
+      virtualAccountDueDate: null,
+      virtualAccountHolderName: null,
+      ...overrides,
+    },
+  };
+}
+
+function makeConfirmVirtualAccount(): {
+  content: CoursePaymentConfirmResponse;
+} {
+  return makeConfirmSuccess({
+    status: 'WAITING_FOR_DEPOSIT',
+    paymentMethod: 'VIRTUAL_ACCOUNT',
+    virtualAccountNumber: '1234567890',
+    virtualAccountDueDate: '2026-05-19T23:59:59.000Z',
+    virtualAccountHolderName: '(주)제로원',
+  });
+}
+
+// ─── Route Mock Helpers ───────────────────────────────────────────────────────
+
+async function mockCourseDetailApi(page: Page) {
+  await page.route(/\/courses\/vibe-intro$/, async (route) => {
+    await route.fulfill({ json: makeCourseDetail() });
+  });
+}
+
+async function mockConfirmApi(page: Page, json: object, status = 200) {
+  await page.route(/\/courses\/\d+\/payments\/toss\/confirm/, async (route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({ status, json });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+// waitForResponse handlers must be registered before goto to catch cascaded
+// requests: courseId resolves from detail response, then confirm fires.
+async function gotoSuccessPage(page: Page) {
+  await Promise.all([
+    page.waitForResponse((r) => /\/courses\/vibe-intro$/.test(r.url())),
+    page.waitForResponse((r) => r.url().includes('/payments/toss/confirm')),
+    page.goto(SUCCESS_PATH, { waitUntil: 'load' }),
+  ]);
+}
+
+// ─── Chunk 1: CARD 결제 성공 @auth ───────────────────────────────────────────
+// payment.spec.ts Chunk 6 already covers: basic heading, amount, CTA links,
+// error state text + navigation. Tests here cover unchecked specifics only.
+
+test.describe('결제 성공 — CARD @auth', () => {
+  test('결제 수단 "신용카드" + 금액 "99,000원" 표시', async ({ page }) => {
+    await mockCourseDetailApi(page);
+    await mockConfirmApi(page, makeConfirmSuccess());
+    await gotoSuccessPage(page);
+
+    await expect(page.getByText('신용카드')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('99,000원').first()).toBeVisible();
+  });
+
+  test('tossReceiptUrl 있을 때 "영수증 보기" 링크 표시', async ({ page }) => {
+    await mockCourseDetailApi(page);
+    await mockConfirmApi(
+      page,
+      makeConfirmSuccess({ tossReceiptUrl: 'https://receipt.toss.im/test' }),
+    );
+    await gotoSuccessPage(page);
+
+    const receiptLink = page.getByRole('link', { name: '영수증 보기' });
+    await expect(receiptLink).toBeVisible({ timeout: 10000 });
+    await expect(receiptLink).toHaveAttribute(
+      'href',
+      'https://receipt.toss.im/test',
+    );
+  });
+});
+
+// ─── Chunk 2: 가상계좌 입금 대기 @auth ───────────────────────────────────────
+
+test.describe('결제 성공 — 가상계좌 입금 대기 @auth', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCourseDetailApi(page);
+    await mockConfirmApi(page, makeConfirmVirtualAccount());
+  });
+
+  test('입금 대기 화면 — 계좌번호·금액 표시', async ({ page }) => {
+    await gotoSuccessPage(page);
+
+    await expect(page.getByText('입금 대기 중입니다.')).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText('1234567890')).toBeVisible();
+    await expect(page.getByText('99,000원')).toBeVisible();
+  });
+
+  test('"결제 관리로 가기" 링크 → /my-page?tab=payment', async ({ page }) => {
+    await gotoSuccessPage(page);
+    await expect(page.getByText('입금 대기 중입니다.')).toBeVisible({
+      timeout: 10000,
+    });
+
+    const link = page.getByRole('link', { name: '결제 관리로 가기' });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('href', '/my-page?tab=payment');
+  });
+
+  test('"결제 취소" 클릭 → cancel API 호출 → /class/vibe-intro/home 이동', async ({
+    page,
+  }) => {
+    // POST /courses/{courseId}/payments/{paymentId}/cancel
+    await page.route(/\/courses\/\d+\/payments\/\d+\/cancel/, async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({ status: 200, json: {} });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await gotoSuccessPage(page);
+    await expect(page.getByText('입금 대기 중입니다.')).toBeVisible({
+      timeout: 10000,
+    });
+
+    const [cancelResponse] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/cancel') && r.request().method() === 'POST',
+      ),
+      page.getByRole('button', { name: '결제 취소' }).click(),
+    ]);
+
+    expect(cancelResponse.status()).toBe(200);
+    await page.waitForURL('**/class/vibe-intro/home', { timeout: 5000 });
+    expect(page.url()).toContain('/class/vibe-intro/home');
+  });
+});
+
+// ─── Chunk 3: PAY202 — 이미 완료된 결제 @auth ─────────────────────────────────
+// isApiError() duck-type guard requires all four fields:
+// statusCode, errorCode, errorName, message.
+
+test.describe('결제 성공 — PAY202 (이미 완료된 결제) @auth', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCourseDetailApi(page);
+    await mockConfirmApi(
+      page,
+      {
+        statusCode: 400,
+        errorCode: 'PAY202',
+        errorName: 'DuplicatePayment',
+        message: '이미 완료된 결제입니다.',
+      },
+      400,
+    );
+  });
+
+  test('"이미 완료된 결제입니다." 텍스트 표시', async ({ page }) => {
+    await gotoSuccessPage(page);
+
+    await expect(page.getByText('이미 완료된 결제입니다.')).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test('"학습 홈으로 이동" 버튼 → /class/vibe-intro/home', async ({ page }) => {
+    await gotoSuccessPage(page);
+    await expect(
+      page.getByRole('button', { name: '학습 홈으로 이동' }),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: '학습 홈으로 이동' }).click();
+    await page.waitForURL('**/class/vibe-intro/home', { timeout: 5000 });
+    expect(page.url()).toContain('/class/vibe-intro/home');
+  });
+});

--- a/e2e/payment/cancel.spec.ts
+++ b/e2e/payment/cancel.spec.ts
@@ -1,0 +1,219 @@
+import { test, expect, type Page } from '@playwright/test';
+import { existsSync, readFileSync } from 'fs';
+import type { UserTransactionListResponse } from '../../src/api/openapi/models';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const AUTH_FILE = 'e2e/fixtures/auth.json';
+const PAYMENT_MANAGEMENT_PATH = '/payment-management';
+const PAYMENT_ID = 200;
+
+// ─── Localhost auth cookie injection ─────────────────────────────────────────
+
+test.beforeEach(async ({ context, baseURL }) => {
+  if (baseURL?.startsWith('http://localhost') && existsSync(AUTH_FILE)) {
+    const { cookies } = JSON.parse(readFileSync(AUTH_FILE, 'utf-8')) as {
+      cookies: {
+        name: string;
+        value: string;
+        domain: string;
+        path: string;
+        expires: number;
+        httpOnly: boolean;
+        secure: boolean;
+        sameSite: 'Strict' | 'Lax' | 'None';
+      }[];
+    };
+    await context.addCookies(
+      cookies.map((c) => ({ ...c, domain: 'localhost', secure: false })),
+    );
+  }
+});
+
+// ─── Mock Factories ───────────────────────────────────────────────────────────
+
+function makeTransaction(
+  overrides: Partial<UserTransactionListResponse> = {},
+): UserTransactionListResponse {
+  return {
+    groupStudyId: 2,
+    groupStudyTitle: '바이브 스터디',
+    groupStudyStartDate: '2026-06-01T00:00:00.000Z',
+    paymentId: PAYMENT_ID,
+    paymentCode: 'PAY-TEST-002',
+    latestTransactionType: 'PAYMENT_REQUESTED',
+    latestTransactionTypeDisplayName: '결제대기',
+    latestTransactionAmount: 99000,
+    paidAt: '2026-05-18T09:00:00.000Z',
+    paymentMethod: 'CARD',
+    paymentReceiptUrl: undefined,
+    virtualAccountInfo: undefined,
+    ...overrides,
+  };
+}
+
+function makeTransactionPage(transactions: UserTransactionListResponse[]) {
+  return {
+    content: {
+      content: transactions,
+      totalElements: transactions.length,
+      totalPages: 1,
+      size: 8,
+      number: 0,
+    },
+  };
+}
+
+// ─── Route Mock Helpers ───────────────────────────────────────────────────────
+
+async function mockTransactionsApi(
+  page: Page,
+  transactions: UserTransactionListResponse[],
+) {
+  await page.route(/\/mypage\/transactions/, async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ json: makeTransactionPage(transactions) });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+// POST /api/v1/payments/{paymentId}/cancel
+async function mockCancelPaymentApi(page: Page, status = 200) {
+  await page.route(/\/payments\/\d+\/cancel$/, async (route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status,
+        json: { content: null },
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+async function gotoPaymentManagement(page: Page) {
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/mypage/transactions')),
+    page.goto(PAYMENT_MANAGEMENT_PATH, { waitUntil: 'load' }),
+  ]);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('결제 관리 — 결제 취소 (PAYMENT_REQUESTED) @auth', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockTransactionsApi(page, [makeTransaction()]);
+  });
+
+  test('PAYMENT_REQUESTED → 스터디명·"결제대기" 배지·"결제 취소" 버튼 표시', async ({
+    page,
+  }) => {
+    await gotoPaymentManagement(page);
+
+    await expect(page.getByText('바이브 스터디').first()).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText('결제대기').first()).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: '결제 취소' }).first(),
+    ).toBeVisible();
+  });
+
+  test('"결제 취소" 클릭 → 모달 열림 + 확인 메시지 표시', async ({ page }) => {
+    await gotoPaymentManagement(page);
+    await expect(
+      page.getByRole('button', { name: '결제 취소' }).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: '결제 취소' }).first().click();
+
+    await expect(
+      page.getByText('해당 스터디의 결제를 취소하시겠습니까?'),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test('"결제 취소" confirm → POST /payments/{id}/cancel → "결제가 취소되었습니다." 토스트', async ({
+    page,
+  }) => {
+    await mockCancelPaymentApi(page);
+    await gotoPaymentManagement(page);
+
+    await page.getByRole('button', { name: '결제 취소' }).first().click();
+    await expect(
+      page.getByText('해당 스터디의 결제를 취소하시겠습니까?'),
+    ).toBeVisible({ timeout: 5000 });
+
+    const [cancelResponse] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/cancel') && r.request().method() === 'POST',
+      ),
+      page
+        .getByRole('dialog')
+        .getByRole('button', { name: '결제 취소' })
+        .click(),
+    ]);
+
+    expect(cancelResponse.status()).toBe(200);
+    await expect(page.getByText('결제가 취소되었습니다.')).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('"아니오" 클릭 → 모달 닫힘, cancel API 미호출', async ({ page }) => {
+    await gotoPaymentManagement(page);
+
+    await page.getByRole('button', { name: '결제 취소' }).first().click();
+    await expect(
+      page.getByText('해당 스터디의 결제를 취소하시겠습니까?'),
+    ).toBeVisible({ timeout: 5000 });
+
+    await page.getByRole('button', { name: '아니오' }).click();
+
+    await expect(
+      page.getByText('해당 스터디의 결제를 취소하시겠습니까?'),
+    ).not.toBeVisible({ timeout: 3000 });
+  });
+});
+
+test.describe('결제 관리 — 결제 취소 (PAYMENT_WAITING_FOR_DEPOSIT) @auth', () => {
+  test('PAYMENT_WAITING_FOR_DEPOSIT → "결제 취소" 버튼 표시', async ({
+    page,
+  }) => {
+    await mockTransactionsApi(page, [
+      makeTransaction({
+        latestTransactionType: 'PAYMENT_WAITING_FOR_DEPOSIT',
+        latestTransactionTypeDisplayName: '입금대기',
+        virtualAccountInfo: undefined,
+      }),
+    ]);
+    await gotoPaymentManagement(page);
+
+    await expect(page.getByText('입금대기').first()).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(
+      page.getByRole('button', { name: '결제 취소' }).first(),
+    ).toBeVisible();
+  });
+});
+
+test.describe('결제 관리 — PAYMENT_CANCELED 상태 @auth', () => {
+  test('"결제취소" 배지 표시, "결제 취소" 버튼 없음', async ({ page }) => {
+    await mockTransactionsApi(page, [
+      makeTransaction({
+        latestTransactionType: 'PAYMENT_CANCELED',
+        latestTransactionTypeDisplayName: '결제취소',
+      }),
+    ]);
+    await gotoPaymentManagement(page);
+
+    await expect(page.getByText('결제취소').first()).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(
+      page.getByRole('button', { name: '결제 취소' }),
+    ).not.toBeVisible();
+  });
+});

--- a/e2e/payment/refund.spec.ts
+++ b/e2e/payment/refund.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect, type Page } from '@playwright/test';
+import { existsSync, readFileSync } from 'fs';
+import type { UserTransactionListResponse } from '../../src/api/openapi/models';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const AUTH_FILE = 'e2e/fixtures/auth.json';
+const PAYMENT_MANAGEMENT_PATH = '/payment-management';
+const PAYMENT_ID = 100;
+
+// ─── Localhost auth cookie injection ─────────────────────────────────────────
+
+test.beforeEach(async ({ context, baseURL }) => {
+  if (baseURL?.startsWith('http://localhost') && existsSync(AUTH_FILE)) {
+    const { cookies } = JSON.parse(readFileSync(AUTH_FILE, 'utf-8')) as {
+      cookies: {
+        name: string;
+        value: string;
+        domain: string;
+        path: string;
+        expires: number;
+        httpOnly: boolean;
+        secure: boolean;
+        sameSite: 'Strict' | 'Lax' | 'None';
+      }[];
+    };
+    await context.addCookies(
+      cookies.map((c) => ({ ...c, domain: 'localhost', secure: false })),
+    );
+  }
+});
+
+// ─── Mock Factories ───────────────────────────────────────────────────────────
+
+function makeTransaction(
+  overrides: Partial<UserTransactionListResponse> = {},
+): UserTransactionListResponse {
+  return {
+    groupStudyId: 1,
+    groupStudyTitle: '바이브 스터디',
+    groupStudyStartDate: '2026-06-01T00:00:00.000Z',
+    paymentId: PAYMENT_ID,
+    paymentCode: 'PAY-TEST-001',
+    latestTransactionType: 'PAYMENT_SUCCESS',
+    latestTransactionTypeDisplayName: '결제완료',
+    latestTransactionAmount: 99000,
+    paidAt: '2026-05-18T09:00:00.000Z',
+    paymentMethod: 'CARD',
+    paymentReceiptUrl: undefined,
+    virtualAccountInfo: undefined,
+    ...overrides,
+  };
+}
+
+// useGetMyTransactions returns data.content (PageResponse), and the page reads
+// paymentListData?.content (the array). Mock must use double-wrapped structure.
+function makeTransactionPage(transactions: UserTransactionListResponse[]) {
+  return {
+    content: {
+      content: transactions,
+      totalElements: transactions.length,
+      totalPages: 1,
+      size: 8,
+      number: 0,
+    },
+  };
+}
+
+// ─── Route Mock Helpers ───────────────────────────────────────────────────────
+
+async function mockTransactionsApi(
+  page: Page,
+  transactions: UserTransactionListResponse[],
+) {
+  await page.route(/\/mypage\/transactions/, async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ json: makeTransactionPage(transactions) });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+// POST /api/v1/payments/{paymentId}/refunds
+async function mockRefundRequestApi(page: Page, status = 201) {
+  await page.route(/\/payments\/\d+\/refunds$/, async (route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status,
+        json: { content: { refundId: 1, refundCode: 'REF-001' } },
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+async function gotoPaymentManagement(page: Page) {
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/mypage/transactions')),
+    page.goto(PAYMENT_MANAGEMENT_PATH, { waitUntil: 'load' }),
+  ]);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('결제 관리 — 환불 요청 @auth', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockTransactionsApi(page, [makeTransaction()]);
+  });
+
+  test('PAYMENT_SUCCESS → 스터디명·"결제완료" 배지·"환불 요청" 버튼 표시', async ({
+    page,
+  }) => {
+    await gotoPaymentManagement(page);
+
+    await expect(page.getByText('바이브 스터디').first()).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText('결제완료').first()).toBeVisible();
+    await expect(page.getByRole('button', { name: '환불 요청' })).toBeVisible();
+  });
+
+  test('"환불 요청" 클릭 → 모달 열림 + 참여 불가 경고 표시', async ({
+    page,
+  }) => {
+    await gotoPaymentManagement(page);
+    await expect(page.getByRole('button', { name: '환불 요청' })).toBeVisible({
+      timeout: 10000,
+    });
+
+    await page.getByRole('button', { name: '환불 요청' }).click();
+
+    await expect(
+      page.getByText('환불 요청 시 진행하시는 스터디에'),
+    ).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('더 이상 참여할 수 없습니다.')).toBeVisible();
+  });
+
+  test('"환불 요청하기" → POST /payments/{id}/refunds → "환불 요청이 접수되었습니다." 토스트', async ({
+    page,
+  }) => {
+    await mockRefundRequestApi(page);
+    await gotoPaymentManagement(page);
+
+    await page.getByRole('button', { name: '환불 요청' }).click();
+    await expect(
+      page.getByText('환불 요청 시 진행하시는 스터디에'),
+    ).toBeVisible({ timeout: 5000 });
+
+    const [refundResponse] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/refunds') && r.request().method() === 'POST',
+      ),
+      page.getByRole('button', { name: '환불 요청하기' }).click(),
+    ]);
+
+    expect(refundResponse.status()).toBe(201);
+    await expect(page.getByText('환불 요청이 접수되었습니다.')).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('"아니오" 클릭 → 모달 닫힘, refund API 미호출', async ({ page }) => {
+    await gotoPaymentManagement(page);
+
+    await page.getByRole('button', { name: '환불 요청' }).click();
+    await expect(
+      page.getByText('환불 요청 시 진행하시는 스터디에'),
+    ).toBeVisible({ timeout: 5000 });
+
+    await page.getByRole('button', { name: '아니오' }).click();
+
+    await expect(
+      page.getByText('환불 요청 시 진행하시는 스터디에'),
+    ).not.toBeVisible({ timeout: 3000 });
+  });
+});
+
+test.describe('결제 관리 — REFUND_REQUESTED 상태 @auth', () => {
+  test('"환불요청" 배지 표시, "환불 요청" 버튼 없음', async ({ page }) => {
+    await mockTransactionsApi(page, [
+      makeTransaction({
+        latestTransactionType: 'REFUND_REQUESTED',
+        refundId: 1,
+        refundCode: 'REF-001',
+      }),
+    ]);
+    await gotoPaymentManagement(page);
+
+    await expect(page.getByText('환불요청').first()).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(
+      page.getByRole('button', { name: '환불 요청' }),
+    ).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Problem

결제 관리 페이지(`/payment-management`)의 결제 취소·환불 요청 플로우와 클래스 결제 성공 페이지(`/payment/success`)에 E2E 커버리지가 없었음. 또한 `refund.spec.ts`의 2개 테스트가 Playwright strict mode violation으로 실패 중이었음.

**root cause (refund 실패)**: `/payment-management` 페이지는 동일 데이터를 데스크톱 테이블(`hidden sm:block`)과 모바일 카드(`sm:hidden`) 두 곳에 렌더링함. `getByText('바이브 스터디')` 등 locator가 두 요소에 매칭되어 strict mode violation / timeout 발생.

## Solution

- **refund.spec.ts**: 중복 매칭 locator에 `.first()` 추가 — DOM 순서상 앞에 오는 데스크톱 테이블 요소 선택
- **cancel.spec.ts**: 결제 취소 플로우 E2E 신규 작성 (6개 테스트)
- 모달 확인 버튼 동명 충돌(`결제 취소` × 2) → `page.getByRole('dialog').getByRole('button', ...)` 로 스코프 좁힘

## Changes

### Bug Fixes
| File | Description |
|------|-------------|
| `e2e/payment/refund.spec.ts` | `.first()` 추가로 strict mode violation 수정 (Test 1, 5) |

### Features
| File | Description |
|------|-------------|
| `e2e/payment/cancel.spec.ts` | 결제 취소 E2E 6개 (PAYMENT_REQUESTED, WAITING_FOR_DEPOSIT, CANCELED 케이스) |

## Result

- `e2e/payment/refund.spec.ts` 5/5 통과 (기존 2개 실패 → 수정)
- `e2e/payment/cancel.spec.ts` 6/6 통과 (신규)
- `e2e/class/payment-success.spec.ts` 7/7 통과 (직전 커밋)
- 결제 관련 핵심 플로우 전체에 E2E 커버리지 확보

## Test plan

- [ ] `yarn e2e e2e/payment/refund.spec.ts` — 5/5 통과 확인
- [ ] `yarn e2e e2e/payment/cancel.spec.ts` — 6/6 통과 확인
- [ ] `yarn e2e e2e/class/payment-success.spec.ts` — 7/7 통과 확인
- [ ] `yarn e2e --grep-invert @auth` — CI 모드 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 결제 성공 페이지에서 결제 방법, 금액, 영수증 링크 표시 및 입금 대기 상태 검증을 위한 자동화 테스트 추가
  * 결제 취소 기능의 상태별 동작(결제 대기, 입금 대기, 취소됨) 검증을 위한 자동화 테스트 추가
  * 환불 요청 기능에서 성공 상태 시 환불 버튼 표시 및 취소 완료 후 배지 변경을 검증하는 자동화 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->