### PR TITLE
chore: 릴리즈 기록 기본 문구를 한국어로 정리

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -241,7 +241,7 @@ jobs:
             echo "DB_MIGRATION_FILES=${RELEASE_DB_MIGRATION_FILES:-}"
             echo "ROLLBACK_FRONTEND_IMAGE=${RELEASE_ROLLBACK_FRONTEND_IMAGE:-}"
             echo "ROLLBACK_BACKEND_IMAGE=${RELEASE_ROLLBACK_BACKEND_IMAGE:-}"
-            echo "DB_ROLLBACK_NOTE=${RELEASE_DB_ROLLBACK_NOTE:-DB rollback is not automated. Confirm app compatibility with the recorded DB state.}"
+            echo "DB_ROLLBACK_NOTE=${RELEASE_DB_ROLLBACK_NOTE:-DB 롤백은 자동화되어 있지 않습니다. 기록된 DB 상태와 앱 호환성을 확인하세요.}"
           } >> "$GITHUB_ENV"
 
       - name: Deploy frontend image to production server

--- a/docs/ops/release-record-shared-contract.md
+++ b/docs/ops/release-record-shared-contract.md
@@ -154,7 +154,7 @@ release_id: prod-20260517-2100
 env: prod
 service_version: v1.4.3
 
-summary: backend patch release
+summary: 백엔드 patch 배포
 
 components:
   frontend:
@@ -181,14 +181,7 @@ rollback:
   app_rollback_target:
     frontend: zeroone-frontend:v1.4.2-f1a2b3c
     backend: zeroone-backend:v1.4.2-a1b2c3d
-  db_rollback_note: Verify compatibility before app rollback if DB changed.
-
-deploy_order:
-  - db_migration
-  - backend
-  - backend_health_check
-  - frontend
-  - e2e_check
+  db_rollback_note: DB 변경이 있었다면 앱 롤백 전에 호환성을 확인하세요.
 
 deployed_at: 2026-05-17T21:00:00+09:00
 deployed_by: automation
@@ -218,7 +211,6 @@ metadata:
 - `database.migration_files`
 - `rollback.app_rollback_target.frontend`
 - `rollback.app_rollback_target.backend`
-- `deploy_order`
 - `deployed_at`
 - `deployed_by`
 - `status`

--- a/docs/ops/version-management.md
+++ b/docs/ops/version-management.md
@@ -124,7 +124,7 @@ rollback_backend_image: zerooneitkr/zeroone-backend:v0.6.3-e4f5g6h
 db_changed: false
 db_migration_version: V12
 db_migration_files:
-db_rollback_note: DB rollback is not automated. Confirm app compatibility with the recorded DB state.
+db_rollback_note: DB 롤백은 자동화되어 있지 않습니다. 기록된 DB 상태와 앱 호환성을 확인하세요.
 ```
 
 Bootstrap은 명시적으로 승인된 예외 경로입니다. `bootstrap: approved`가 없으면 첫 릴리즈 기록 생성은 실패해야 합니다.
@@ -191,7 +191,7 @@ components:
 - 프론트엔드 컨테이너가 고정 프론트엔드 이미지 태그로 실행 중인지 확인합니다.
 - 백엔드 health/API 호환성을 확인합니다.
 - `releases/prod-YYYYMMDD-HHmm.yaml`이 `main`에 커밋됐는지 확인합니다.
-- 릴리즈 기록에 frontend, backend, database, rollback, deploy order, deployed time, actor, `status: success`가 포함됐는지 확인합니다.
+- 릴리즈 기록에 frontend, backend, database, rollback, deployed time, actor, `status: success`가 포함됐는지 확인합니다.
 
 ## 중복 및 실패 규칙
 

--- a/scripts/release/generate-backend-prod-release-record.mjs
+++ b/scripts/release/generate-backend-prod-release-record.mjs
@@ -9,13 +9,6 @@ import {
 import { join } from 'node:path';
 
 const RELEASES_DIR = 'releases';
-const DEPLOY_ORDER = [
-  'db_migration',
-  'backend',
-  'backend_health_check',
-  'frontend',
-  'e2e_check',
-];
 const RELEASE_ID = /^prod-\d{8}-\d{4}$/;
 const VERSION = /^v\d+\.\d+\.\d+$/;
 const DATE_IN_TAG = /:.*\d{8}|:.*\d{4}-\d{2}-\d{2}/;
@@ -245,12 +238,12 @@ const deployedBy = getEnv('DEPLOYED_BY', 'automation');
 const summary =
   typeof payload.summary === 'string' && payload.summary.trim()
     ? payload.summary.trim()
-    : `backend ${releaseIntent} release`;
+    : `백엔드 ${releaseIntent} 배포`;
 const dbRollbackNote = getEnv(
   'DB_ROLLBACK_NOTE',
   dbChanged
-    ? 'Verify compatibility before app rollback if DB changed.'
-    : 'DB unchanged. Use fixed app image rollback targets if needed.',
+    ? 'DB 변경이 있었다면 앱 롤백 전에 호환성을 확인하세요.'
+    : 'DB 변경 없음. 필요 시 기록된 고정 앱 이미지 기준으로 롤백하세요.',
 );
 const pullRequestLabels = Array.isArray(metadata.pull_request_labels)
   ? metadata.pull_request_labels.map((label, index) =>
@@ -314,9 +307,6 @@ rollback:
     frontend: ${quote(frontendImage)}
     backend: ${quote(rollbackBackend)}
   db_rollback_note: ${quote(dbRollbackNote)}
-
-deploy_order:
-${DEPLOY_ORDER.map((item) => `  - ${item}`).join('\n')}
 
 deployed_at: ${quote(deployedAt)}
 deployed_by: ${quote(deployedBy)}

--- a/scripts/release/generate-prod-release-record.mjs
+++ b/scripts/release/generate-prod-release-record.mjs
@@ -9,14 +9,6 @@ import {
 import { join } from 'node:path';
 
 const RELEASES_DIR = 'releases';
-const DEPLOY_ORDER = [
-  'db_migration',
-  'backend',
-  'backend_health_check',
-  'frontend',
-  'e2e_check',
-];
-
 const getEnv = (name, fallback = '') => process.env[name]?.trim() || fallback;
 const required = (name) => {
   const value = getEnv(name);
@@ -98,10 +90,10 @@ const migrationFiles = getEnv('DB_MIGRATION_FILES')
   .filter(Boolean);
 const deployedAt = required('DEPLOYED_AT');
 const deployedBy = getEnv('DEPLOYED_BY', 'github-actions');
-const summary = getEnv('RELEASE_SUMMARY', 'Production frontend deployment');
+const summary = getEnv('RELEASE_SUMMARY', '프론트엔드 프로덕션 배포');
 const dbRollbackNote = getEnv(
   'DB_ROLLBACK_NOTE',
-  'DB rollback is not automated. Confirm app compatibility with the recorded DB state.',
+  'DB 롤백은 자동화되어 있지 않습니다. 기록된 DB 상태와 앱 호환성을 확인하세요.',
 );
 const backendChanged = /^true$/i.test(getEnv('BACKEND_CHANGED', 'false'));
 const frontendDeployId = getEnv(
@@ -171,9 +163,6 @@ rollback:
     frontend: ${quote(rollbackFrontend)}
     backend: ${quote(rollbackBackend)}
   db_rollback_note: ${quote(dbRollbackNote)}
-
-deploy_order:
-${DEPLOY_ORDER.map((item) => `  - ${item}`).join('\n')}
 
 deployed_at: ${quote(deployedAt)}
 deployed_by: ${quote(deployedBy)}

--- a/scripts/release/resolve-prod-release-intent.mjs
+++ b/scripts/release/resolve-prod-release-intent.mjs
@@ -227,7 +227,7 @@ const getIntent = async () => {
     body: '',
     labels: [],
     number: '',
-    title: getEnv('WORKFLOW_RELEASE_SUMMARY', 'Manual production deployment'),
+    title: getEnv('WORKFLOW_RELEASE_SUMMARY', '수동 프로덕션 배포'),
     source: 'none',
   };
 };
@@ -466,5 +466,5 @@ writeOutput({
     (previous
       ? parseField(previous.content, 'rollback.db_rollback_note')
       : '') ||
-    'DB rollback is not automated. Confirm app compatibility with the recorded DB state.',
+    'DB 롤백은 자동화되어 있지 않습니다. 기록된 DB 상태와 앱 호환성을 확인하세요.',
 });


### PR DESCRIPTION
## 작업 내용
- release record fallback summary 기본 문구를 한국어로 변경
- DB rollback note fallback 기본 문구를 한국어로 변경
- `deploy_order`를 release record YAML 생성/공유 계약 문서에서 제거
- 관련 workflow/script/doc 설명을 최신 스키마 기준으로 정리

## 변경 이유
- 자동 생성되는 운영 release record가 영어 fallback 문구 때문에 혼합 언어로 남아 읽기 어려웠습니다.
- `deploy_order`는 운영 절차 설명으로는 의미가 있지만, 최종 release record의 사실 기록 필드로는 불필요해 보여 제거했습니다.

## 검증 방법
- [x] `node --check scripts/release/resolve-prod-release-intent.mjs`
- [x] `node --check scripts/release/generate-prod-release-record.mjs`
- [x] `node --check scripts/release/generate-backend-prod-release-record.mjs`
- [x] `node scripts/release/validate-release-record.mjs releases`
- [x] `git diff --check`

## 브랜치 정보
- base: develop
- head: chore/release-record-ko-fallback-develop
- 기준 range: origin/develop..HEAD

## dev/QA 확인 포인트
- 새로 생성되는 `releases/prod-*.yaml`에서 summary/note fallback이 한국어로 나오는지
- 새로 생성되는 release record에 `deploy_order` 필드가 더 이상 포함되지 않는지
- backend dispatch 기반 record와 frontend-only record가 모두 validator를 통과하는지

## 배포 리스크 / 롤백
- production release record 생성 스키마와 fallback 문구만 건드린 변경입니다.
- 문제 시 해당 스크립트/문서 변경 commit을 되돌리면 됩니다.
