### PR TITLE
fix: 관리자 Notion ZIP import 공통화

### DIFF
--- a/src/api/client/axios.ts
+++ b/src/api/client/axios.ts
@@ -57,11 +57,28 @@ export const axiosInstanceV5 = axios.create({
   withCredentials: true,
 });
 
+export const axiosInstanceForMultipartV5 = axios.create({
+  baseURL: `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v5/`,
+  timeout: 60000,
+  headers: {},
+  withCredentials: true,
+});
+
 attachApiLogger(axiosInstanceV5, 'client-v5-json');
+attachApiLogger(axiosInstanceForMultipartV5, 'client-v5-multipart');
 axiosInstanceV5.interceptors.request.use(attachAccessTokenToRequest);
+axiosInstanceForMultipartV5.interceptors.request.use(
+  attachAccessTokenToRequest,
+);
 axiosInstanceV5.interceptors.response.use(
   (config) => config,
   createClientAuthResponseRejectedHandler((requestConfig) =>
     axiosInstanceV5(requestConfig),
+  ),
+);
+axiosInstanceForMultipartV5.interceptors.response.use(
+  (config) => config,
+  createClientAuthResponseRejectedHandler((requestConfig) =>
+    axiosInstanceForMultipartV5(requestConfig),
   ),
 );

--- a/src/components/admin/courses/admin-lesson-detail-page-client.tsx
+++ b/src/components/admin/courses/admin-lesson-detail-page-client.tsx
@@ -4,6 +4,9 @@ import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import AdminCourseField from '@/components/admin/courses/admin-course-field';
 import AdminCourseMarkdownField from '@/components/admin/courses/admin-course-markdown-field';
+import AdminNotionZipImportButton, {
+  ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE,
+} from '@/components/admin/courses/admin-notion-zip-import-button';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import Badge from '@/components/common/ui/badge';
 import Button from '@/components/common/ui/button';
@@ -15,11 +18,14 @@ import type {
   AdminLessonUpsertRequest,
   AdminRetrospectivePurpose,
 } from '@/features/admin/course-management/model/admin-course-management-contract';
-import { normalizeAdminCourseMarkdownContent } from '@/features/admin/course-management/model/admin-course-markdown';
 import {
   ADMIN_RETROSPECTIVE_PURPOSE_OPTIONS,
   getAdminRetrospectivePurposeMeta,
 } from '@/features/admin/course-management/model/admin-course-presentation';
+import {
+  toAdminLessonForm,
+  toAdminLessonHydrationSnapshot,
+} from '@/features/admin/course-management/model/admin-lesson-form-mapper';
 import {
   getAdminLessonPayloadValidationError,
   toAdminLessonPayload,
@@ -29,6 +35,7 @@ import {
   useAdminLessonQnasQuery,
   useAdminLessonRetrospectivesQuery,
   useCreateAdminLessonQnaAnswerMutation,
+  useImportAdminLessonContentZipMutation,
   useUpdateAdminBuilderFeedCurationMutation,
   useUpdateAdminLessonMutation,
 } from '@/features/admin/course-management/model/use-admin-course-management-query';
@@ -67,6 +74,8 @@ export default function AdminLessonDetailPageClient({
   const lessonBuilderFeedsQuery = useAdminLessonBuilderFeedsQuery(lessonId);
   const lessonQnasQuery = useAdminLessonQnasQuery(lessonId);
   const updateLessonMutation = useUpdateAdminLessonMutation();
+  const importLessonContentZipMutation =
+    useImportAdminLessonContentZipMutation();
   const updateBuilderFeedCurationMutation =
     useUpdateAdminBuilderFeedCurationMutation();
   const createLessonQnaAnswerMutation = useCreateAdminLessonQnaAnswerMutation();
@@ -88,41 +97,19 @@ export default function AdminLessonDetailPageClient({
   const [isAwaitingLessonRefresh, setIsAwaitingLessonRefresh] = useState(false);
 
   const isLessonFormLocked =
-    updateLessonMutation.isPending || isAwaitingLessonRefresh;
+    updateLessonMutation.isPending ||
+    importLessonContentZipMutation.isPending ||
+    isAwaitingLessonRefresh;
 
   const lessonDetailSnapshot = lessonDetailQuery.data
-    ? JSON.stringify({
-        chapterNumber: lessonDetailQuery.data.chapterNumber,
-        lessonNumber: lessonDetailQuery.data.lessonNumber,
-        title: lessonDetailQuery.data.title,
-        description: '',
-        content: normalizeAdminCourseMarkdownContent(
-          lessonDetailQuery.data.content,
-        ),
-        estimatedMinutes: lessonDetailQuery.data.estimatedMinutes,
-        retrospectivePurpose: lessonDetailQuery.data.retrospectivePurpose,
-        isFree: lessonDetailQuery.data.isFree,
-        isPublished: lessonDetailQuery.data.isPublished,
-      })
+    ? toAdminLessonHydrationSnapshot(lessonDetailQuery.data)
     : '';
 
   useEffect(() => {
     if (!lessonDetailQuery.data) return;
     if (hydratedLessonSnapshot === lessonDetailSnapshot) return;
 
-    setLessonForm({
-      chapterNumber: lessonDetailQuery.data.chapterNumber,
-      lessonNumber: lessonDetailQuery.data.lessonNumber,
-      title: lessonDetailQuery.data.title,
-      description: lessonDetailQuery.data.description ?? '',
-      content: normalizeAdminCourseMarkdownContent(
-        lessonDetailQuery.data.content,
-      ),
-      estimatedMinutes: lessonDetailQuery.data.estimatedMinutes,
-      retrospectivePurpose: lessonDetailQuery.data.retrospectivePurpose,
-      isFree: lessonDetailQuery.data.isFree,
-      isPublished: lessonDetailQuery.data.isPublished,
-    });
+    setLessonForm(toAdminLessonForm(lessonDetailQuery.data));
     setHydratedLessonSnapshot(lessonDetailSnapshot);
   }, [hydratedLessonSnapshot, lessonDetailQuery.data, lessonDetailSnapshot]);
 
@@ -273,6 +260,25 @@ export default function AdminLessonDetailPageClient({
     );
   };
 
+  const handleImportNotionZip = (files: File[]) => {
+    const [file] = files;
+    if (!file || isLessonFormLocked) {
+      return;
+    }
+
+    importLessonContentZipMutation.mutate(
+      { lessonId, file },
+      {
+        onSuccess: (lessonDetail) => {
+          setLessonForm(toAdminLessonForm(lessonDetail));
+          setHydratedLessonSnapshot(
+            toAdminLessonHydrationSnapshot(lessonDetail),
+          );
+        },
+      },
+    );
+  };
+
   const handleToggleBuilderFeedCuration = ({
     feedId,
     currentOperatorPick,
@@ -398,6 +404,14 @@ export default function AdminLessonDetailPageClient({
           </div>
         </div>
         <div className="flex gap-75">
+          <AdminNotionZipImportButton
+            confirmMessage={ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE}
+            disabled={isLessonFormLocked}
+            loading={importLessonContentZipMutation.isPending}
+            onSelectFiles={handleImportNotionZip}
+          >
+            Notion ZIP import
+          </AdminNotionZipImportButton>
           <Button
             size="small"
             disabled={isLessonFormLocked}

--- a/src/components/admin/courses/admin-lesson-management-page-client.tsx
+++ b/src/components/admin/courses/admin-lesson-management-page-client.tsx
@@ -4,6 +4,9 @@ import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import AdminCourseField from '@/components/admin/courses/admin-course-field';
 import AdminCourseMarkdownEditor from '@/components/admin/courses/admin-course-markdown-editor';
+import AdminNotionZipImportButton, {
+  ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE,
+} from '@/components/admin/courses/admin-notion-zip-import-button';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import Badge from '@/components/common/ui/badge';
 import Button from '@/components/common/ui/button';
@@ -23,6 +26,7 @@ import {
   readAdminDraft,
   useAdminLocalDraft,
 } from '@/features/admin/course-management/model/admin-draft-storage';
+import { toAdminLessonForm } from '@/features/admin/course-management/model/admin-lesson-form-mapper';
 import {
   getAdminLessonPayloadValidationError,
   toAdminLessonPayload,
@@ -33,6 +37,8 @@ import {
   useAdminLessonRetrospectivesQuery,
   useCreateAdminLessonMutation,
   useDeleteAdminLessonMutation,
+  useCreateAdminLessonsFromNotionZipsMutation,
+  useImportAdminLessonContentZipMutation,
   useReorderAdminLessonsMutation,
   useUpdateAdminLessonMutation,
 } from '@/features/admin/course-management/model/use-admin-course-management-query';
@@ -174,6 +180,9 @@ export default function AdminLessonManagementPageClient({
   const [hydratedLessonId, setHydratedLessonId] = useState<
     number | undefined
   >();
+  const [recentlyImportedLessonIds, setRecentlyImportedLessonIds] = useState<
+    number[]
+  >([]);
   const [editorVersion, setEditorVersion] = useState(0);
   const draftKey = `lesson:${courseId}:${lessonFormMode}:${editingLessonId ?? 'new'}`;
   // edit 모드에서는 server hydration이 끝난 뒤에만 draft 자동저장을 활성화한다.
@@ -192,6 +201,10 @@ export default function AdminLessonManagementPageClient({
   });
 
   const createLessonMutation = useCreateAdminLessonMutation();
+  const createLessonsFromNotionZipsMutation =
+    useCreateAdminLessonsFromNotionZipsMutation();
+  const importLessonContentZipMutation =
+    useImportAdminLessonContentZipMutation();
   const updateLessonMutation = useUpdateAdminLessonMutation();
   const deleteLessonMutation = useDeleteAdminLessonMutation();
   const reorderLessonsMutation = useReorderAdminLessonsMutation();
@@ -243,6 +256,8 @@ export default function AdminLessonManagementPageClient({
   );
   const isLessonFormLocked =
     createLessonMutation.isPending ||
+    createLessonsFromNotionZipsMutation.isPending ||
+    importLessonContentZipMutation.isPending ||
     updateLessonMutation.isPending ||
     lessonDetailQuery.isFetching;
   const isListFiltered =
@@ -285,17 +300,7 @@ export default function AdminLessonManagementPageClient({
       return;
     }
 
-    const serverLessonForm = {
-      chapterNumber: lessonDetailQuery.data.chapterNumber,
-      lessonNumber: lessonDetailQuery.data.lessonNumber,
-      title: lessonDetailQuery.data.title,
-      description: lessonDetailQuery.data.description ?? '',
-      content: lessonDetailQuery.data.content,
-      estimatedMinutes: lessonDetailQuery.data.estimatedMinutes,
-      retrospectivePurpose: lessonDetailQuery.data.retrospectivePurpose,
-      isFree: lessonDetailQuery.data.isFree,
-      isPublished: lessonDetailQuery.data.isPublished,
-    };
+    const serverLessonForm = toAdminLessonForm(lessonDetailQuery.data);
     const draft = normalizeLessonDraft(
       readAdminDraft<AdminLessonUpsertRequest>(
         `lesson:${courseId}:edit:${lessonDetailQuery.data.lessonId}`,
@@ -401,6 +406,44 @@ export default function AdminLessonManagementPageClient({
     );
   };
 
+  const handleCreateLessonsFromNotionZips = (zipFiles: File[]) => {
+    if (zipFiles.length === 0 || isLessonFormLocked) return;
+
+    createLessonsFromNotionZipsMutation.mutate(
+      { courseId, files: zipFiles },
+      {
+        onSuccess: (response) => {
+          setLessonSearch('');
+          setChapterFilter('ALL');
+          setPublishedFilter('ALL');
+          setAccessFilter('ALL');
+          setRecentlyImportedLessonIds(
+            response.lessons.map((lesson) => lesson.lessonId),
+          );
+        },
+      },
+    );
+  };
+
+  const handleImportNotionZip = (files: File[]) => {
+    const [file] = files;
+    if (!file || isLessonFormLocked || !editingLessonId) {
+      return;
+    }
+
+    importLessonContentZipMutation.mutate(
+      { lessonId: editingLessonId, file },
+      {
+        onSuccess: (lessonDetail) => {
+          clearLessonDraft();
+          setLessonForm(toAdminLessonForm(lessonDetail));
+          setHydratedLessonId(lessonDetail.lessonId);
+          setEditorVersion((prev) => prev + 1);
+        },
+      },
+    );
+  };
+
   const handleDeleteLesson = (lesson: AdminLessonSummary) => {
     const confirmed = window.confirm(
       `${lesson.title} 레슨을 삭제할까요? 돌아보기 이력이 있으면 실제 삭제되지 않고 비게시 처리됩니다.`,
@@ -462,6 +505,14 @@ export default function AdminLessonManagementPageClient({
           </div>
         </div>
         <div className="flex gap-75">
+          <AdminNotionZipImportButton
+            multiple
+            disabled={isLessonFormLocked}
+            loading={createLessonsFromNotionZipsMutation.isPending}
+            onSelectFiles={handleCreateLessonsFromNotionZips}
+          >
+            Notion ZIP 다건 업로드
+          </AdminNotionZipImportButton>
           {lessonFormMode !== 'create' && (
             <Button color="secondary" size="small" onClick={startCreateLesson}>
               새 레슨 추가
@@ -561,6 +612,8 @@ export default function AdminLessonManagementPageClient({
                           'border-border-default flex items-start justify-between gap-100 border-b p-125',
                           editingLessonId === lesson.lessonId &&
                             'bg-fill-brand-subtle-default',
+                          recentlyImportedLessonIds.includes(lesson.lessonId) &&
+                            'bg-fill-success-subtle-default',
                         )}
                       >
                         <button
@@ -838,7 +891,20 @@ export default function AdminLessonManagementPageClient({
               미리보기입니다. unsafe HTML/script와 외부 이미지 scheme은 저장
               정책에서 허용되지 않습니다.
             </p>
+            <p className="font-designer-13r text-text-subtle mt-50">
+              Notion export ZIP 1개를 업로드하면 현재 레슨의 본문만 교체됩니다.
+            </p>
           </div>
+          {lessonFormMode === 'edit' && (
+            <AdminNotionZipImportButton
+              confirmMessage={ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE}
+              disabled={isLessonFormLocked || !editingLessonId}
+              loading={importLessonContentZipMutation.isPending}
+              onSelectFiles={handleImportNotionZip}
+            >
+              Notion ZIP import
+            </AdminNotionZipImportButton>
+          )}
           <div className="font-designer-13r text-text-subtle flex gap-125">
             <span>
               자동 임시저장:{' '}

--- a/src/components/admin/courses/admin-notion-zip-import-button.tsx
+++ b/src/components/admin/courses/admin-notion-zip-import-button.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import type { ChangeEvent } from 'react';
+import { useRef } from 'react';
+import Button from '@/components/common/ui/button';
+
+export const ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE =
+  '현재 레슨 본문을 ZIP 기준으로 교체할까요?\n제목, 설명, 챕터, 레슨 번호는 유지되고 본문만 바뀝니다.';
+
+interface AdminNotionZipImportButtonProps {
+  children: string;
+  disabled?: boolean;
+  loading?: boolean;
+  multiple?: boolean;
+  confirmMessage?: string;
+  onSelectFiles: (files: File[]) => void;
+}
+
+export default function AdminNotionZipImportButton({
+  children,
+  disabled = false,
+  loading = false,
+  multiple = false,
+  confirmMessage,
+  onSelectFiles,
+}: AdminNotionZipImportButtonProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleClick = () => {
+    if (disabled || loading) {
+      return;
+    }
+
+    inputRef.current?.click();
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    event.target.value = '';
+
+    if (files.length === 0 || disabled || loading) {
+      return;
+    }
+
+    if (confirmMessage && !window.confirm(confirmMessage)) {
+      return;
+    }
+
+    onSelectFiles(files);
+  };
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        accept=".zip"
+        className="hidden"
+        multiple={multiple}
+        type="file"
+        onChange={handleChange}
+      />
+      <Button
+        color="secondary"
+        size="small"
+        disabled={disabled}
+        loading={loading}
+        onClick={handleClick}
+      >
+        {children}
+      </Button>
+    </>
+  );
+}

--- a/src/features/admin/course-management/api/admin-course-management-api.test.ts
+++ b/src/features/admin/course-management/api/admin-course-management-api.test.ts
@@ -1,15 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { axiosInstanceV5 } from '@/api/client/axios';
+import {
+  axiosInstanceForMultipartV5,
+  axiosInstanceV5,
+} from '@/api/client/axios';
 import type { AdminLessonDetailResponse } from '@/features/admin/course-management/model/admin-course-management-contract';
-import { getAdminLessonDetail } from './admin-course-management-api';
+import {
+  createAdminLessonsFromNotionZips,
+  getAdminLessonDetail,
+  importAdminLessonContentZip,
+} from './admin-course-management-api';
 
 vi.mock('@/api/client/axios', () => ({
+  axiosInstanceForMultipartV5: {
+    post: vi.fn(),
+  },
   axiosInstanceV5: {
     get: vi.fn(),
   },
 }));
 
 const mockedGet = vi.mocked(axiosInstanceV5.get);
+const mockedMultipartPost = vi.mocked(axiosInstanceForMultipartV5.post);
 
 const lessonContent: AdminLessonDetailResponse = {
   lessonId: 1,
@@ -27,6 +38,7 @@ const lessonContent: AdminLessonDetailResponse = {
 describe('admin course management api', () => {
   beforeEach(() => {
     mockedGet.mockReset();
+    mockedMultipartPost.mockReset();
   });
 
   it('unwraps the standard Axios BaseResponse envelope for lesson detail', async () => {
@@ -57,5 +69,65 @@ describe('admin course management api', () => {
       lessonId: 1,
       content: '',
     });
+  });
+
+  it('imports a single Notion ZIP with the expected L-10A field name', async () => {
+    const file = new File(['zip'], 'lesson.zip', { type: 'application/zip' });
+    mockedMultipartPost.mockResolvedValueOnce({
+      data: {
+        statusCode: 200,
+        timestamp: '2026-05-18T10:00:00',
+        content: lessonContent,
+        message: null,
+      },
+    });
+
+    await expect(
+      importAdminLessonContentZip({ lessonId: 11, file }),
+    ).resolves.toMatchObject({ lessonId: 1 });
+
+    const [url, formData] = mockedMultipartPost.mock.calls[0];
+    expect(url).toBe('admin/lessons/11/imports/notion-zip');
+    expect(formData).toBeInstanceOf(FormData);
+    expect((formData as FormData).get('file')).toBe(file);
+  });
+
+  it('creates lessons from multiple Notion ZIPs with repeated files fields', async () => {
+    const files = [
+      new File(['zip-a'], 'lesson-a.zip', { type: 'application/zip' }),
+      new File(['zip-b'], 'lesson-b.zip', { type: 'application/zip' }),
+    ];
+    mockedMultipartPost.mockResolvedValueOnce({
+      data: {
+        statusCode: 201,
+        timestamp: '2026-05-18T10:00:00',
+        content: {
+          lessonCount: 2,
+          lessons: [
+            {
+              lessonId: 101,
+              chapterNumber: 1,
+              lessonNumber: 4,
+              title: 'AI 공방 설치 I',
+            },
+            {
+              lessonId: 102,
+              chapterNumber: 1,
+              lessonNumber: 5,
+              title: 'AI 공방 설치 II',
+            },
+          ],
+        },
+        message: null,
+      },
+    });
+
+    await expect(
+      createAdminLessonsFromNotionZips({ courseId: 7, files }),
+    ).resolves.toMatchObject({ lessonCount: 2 });
+
+    const [url, formData] = mockedMultipartPost.mock.calls[0];
+    expect(url).toBe('admin/courses/7/lessons/imports/notion-zips');
+    expect((formData as FormData).getAll('files')).toEqual(files);
   });
 });

--- a/src/features/admin/course-management/api/admin-course-management-api.ts
+++ b/src/features/admin/course-management/api/admin-course-management-api.ts
@@ -1,6 +1,10 @@
-import { axiosInstanceV5 } from '@/api/client/axios';
+import {
+  axiosInstanceForMultipartV5,
+  axiosInstanceV5,
+} from '@/api/client/axios';
 import type {
   AdminBuilderFeedCurationRequest,
+  AdminLessonBatchImportResponse,
   AdminCompletionMessageRequest,
   AdminCompletionMessageResponse,
   AdminCourseDetailResponse,
@@ -238,6 +242,23 @@ export const getAdminLessonDetail = async (
   return normalizeAdminLessonDetail(unwrap(response));
 };
 
+export const importAdminLessonContentZip = async ({
+  lessonId,
+  file,
+}: {
+  lessonId: number;
+  file: File;
+}): Promise<AdminLessonDetailResponse> => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const response = await axiosInstanceForMultipartV5.post<
+    ApiBaseResponse<AdminLessonDetailResponse>
+  >(`admin/lessons/${lessonId}/imports/notion-zip`, formData);
+
+  return normalizeAdminLessonDetail(unwrap(response));
+};
+
 export const createAdminLesson = async ({
   courseId,
   request,
@@ -248,6 +269,23 @@ export const createAdminLesson = async ({
   const response = await axiosInstanceV5.post<
     ApiBaseResponse<AdminLessonCreateResponse>
   >(`admin/courses/${courseId}/lessons`, request);
+
+  return unwrap(response);
+};
+
+export const createAdminLessonsFromNotionZips = async ({
+  courseId,
+  files,
+}: {
+  courseId: number;
+  files: File[];
+}): Promise<AdminLessonBatchImportResponse> => {
+  const formData = new FormData();
+  files.forEach((file) => formData.append('files', file));
+
+  const response = await axiosInstanceForMultipartV5.post<
+    ApiBaseResponse<AdminLessonBatchImportResponse>
+  >(`admin/courses/${courseId}/lessons/imports/notion-zips`, formData);
 
   return unwrap(response);
 };

--- a/src/features/admin/course-management/model/admin-course-management-contract.ts
+++ b/src/features/admin/course-management/model/admin-course-management-contract.ts
@@ -129,6 +129,18 @@ export interface AdminLessonCreateResponse {
   lessonId: number;
 }
 
+export interface AdminLessonImportResult {
+  lessonId: number;
+  chapterNumber: number;
+  lessonNumber: number;
+  title: string;
+}
+
+export interface AdminLessonBatchImportResponse {
+  lessonCount: number;
+  lessons: AdminLessonImportResult[];
+}
+
 export interface AdminLessonDeleteResponse {
   deleted: boolean;
   isDeleted?: boolean;

--- a/src/features/admin/course-management/model/admin-lesson-form-mapper.ts
+++ b/src/features/admin/course-management/model/admin-lesson-form-mapper.ts
@@ -1,0 +1,34 @@
+import type {
+  AdminLessonDetailResponse,
+  AdminLessonUpsertRequest,
+} from '@/features/admin/course-management/model/admin-course-management-contract';
+import { normalizeAdminCourseMarkdownContent } from '@/features/admin/course-management/model/admin-course-markdown';
+
+export const toAdminLessonForm = (
+  lesson: AdminLessonDetailResponse,
+): AdminLessonUpsertRequest => ({
+  chapterNumber: lesson.chapterNumber,
+  lessonNumber: lesson.lessonNumber,
+  title: lesson.title,
+  description: lesson.description ?? '',
+  content: normalizeAdminCourseMarkdownContent(lesson.content),
+  estimatedMinutes: lesson.estimatedMinutes,
+  retrospectivePurpose: lesson.retrospectivePurpose,
+  isFree: lesson.isFree,
+  isPublished: lesson.isPublished,
+});
+
+export const toAdminLessonHydrationSnapshot = (
+  lesson: AdminLessonDetailResponse,
+) =>
+  JSON.stringify({
+    chapterNumber: lesson.chapterNumber,
+    lessonNumber: lesson.lessonNumber,
+    title: lesson.title,
+    description: '',
+    content: normalizeAdminCourseMarkdownContent(lesson.content),
+    estimatedMinutes: lesson.estimatedMinutes,
+    retrospectivePurpose: lesson.retrospectivePurpose,
+    isFree: lesson.isFree,
+    isPublished: lesson.isPublished,
+  });

--- a/src/features/admin/course-management/model/use-admin-course-management-query.ts
+++ b/src/features/admin/course-management/model/use-admin-course-management-query.ts
@@ -3,6 +3,7 @@ import {
   createAdminCourse,
   bulkUpdateAdminLessons,
   createAdminLesson,
+  createAdminLessonsFromNotionZips,
   deleteAdminCourse,
   deleteAdminLesson,
   getAdminCourseDetail,
@@ -13,6 +14,7 @@ import {
   getAdminLessonQnaDetail,
   getAdminLessonQnas,
   getAdminLessonRetrospectives,
+  importAdminLessonContentZip,
   updateAdminBuilderFeedCuration,
   createAdminLessonQnaAnswer,
   getAdminLessonBuilderFeeds,
@@ -77,6 +79,38 @@ const showMutationError = (error: unknown) => {
   useToastStore
     .getState()
     .showToast(userMessage || '요청 처리 중 오류가 발생했습니다.', 'error');
+};
+
+const getNotionZipImportErrorMessage = (
+  error: unknown,
+  operation: 'single' | 'batch',
+) => {
+  const errorInfo = analyzeError(error);
+
+  if (errorInfo.statusCode === 404) {
+    return '대상을 찾지 못했습니다. 페이지를 새로고침한 뒤 다시 시도해주세요.';
+  }
+
+  if (errorInfo.statusCode === 409) {
+    return operation === 'batch'
+      ? '같은 챕터에 같은 레슨 번호가 이미 있어 생성할 수 없습니다. 기존 레슨 번호를 확인해주세요.'
+      : '본문 교체 중 충돌이 발생했습니다. 페이지를 새로고침한 뒤 다시 시도해주세요.';
+  }
+
+  if (errorInfo.statusCode === 400) {
+    return '올린 ZIP 형식을 해석하지 못했습니다. Notion export ZIP인지, markdown 1개와 이미지 파일이 함께 들어있는지 확인해주세요.';
+  }
+
+  return errorInfo.userMessage || 'ZIP import 처리 중 오류가 발생했습니다.';
+};
+
+const showNotionZipImportError = (
+  error: unknown,
+  operation: 'single' | 'batch',
+) => {
+  useToastStore
+    .getState()
+    .showToast(getNotionZipImportErrorMessage(error, operation), 'error');
 };
 
 export const useAdminCoursesQuery = (params: AdminCourseListParams) =>
@@ -217,6 +251,52 @@ export const useCreateAdminLessonMutation = () => {
       });
     },
     onError: showMutationError,
+  });
+};
+
+export const useImportAdminLessonContentZipMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: importAdminLessonContentZip,
+    onSuccess: async (lessonDetail) => {
+      useToastStore
+        .getState()
+        .showToast('본문을 ZIP 기준으로 교체했습니다.', 'success');
+      queryClient.setQueryData(
+        adminCourseManagementQueryKeys.lessonDetail(lessonDetail.lessonId),
+        lessonDetail,
+      );
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.lessonDetail(
+          lessonDetail.lessonId,
+        ),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: (error) => showNotionZipImportError(error, 'single'),
+  });
+};
+
+export const useCreateAdminLessonsFromNotionZipsMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createAdminLessonsFromNotionZips,
+    onSuccess: async (response, variables) => {
+      useToastStore
+        .getState()
+        .showToast(`${response.lessonCount}개 레슨을 생성했습니다.`, 'success');
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.lessons(variables.courseId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: (error) => showNotionZipImportError(error, 'batch'),
   });
 };
 


### PR DESCRIPTION
## 요약
- 관리자 Notion ZIP 업로드 API와 v5 multipart axios 인스턴스를 추가했습니다.
- ZIP 파일 선택/confirm/reset UI를 AdminNotionZipImportButton으로 공통화했습니다.
- lesson detail 응답을 form/snapshot으로 바꾸는 로직을 model helper로 분리하고 single/batch import 에러 문구를 분기했습니다.

## 검증
- git diff --check
- yarn lint:fix (0 errors, existing warnings only)
- yarn prettier:fix (exit 0; existing .codex symlink warning)
- yarn typecheck
- yarn test:unit src/features/admin/course-management/api/admin-course-management-api.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Notion ZIP 파일을 통한 레슨 콘텐츠 임포트 기능 추가
  * 단일 레슨의 본문을 ZIP 파일로 교체 가능
  * 여러 레슨을 한 번에 ZIP 파일로 생성 가능
  * 최근 임포트된 레슨을 목록에서 시각적으로 구분하여 표시

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->