### PR TITLE
빌더 피드 페이월 임시 비활성화 및 타입 수정

### DIFF
--- a/src/app/(landing)/class/[slug]/(learning)/_components/feed-tab.tsx
+++ b/src/app/(landing)/class/[slug]/(learning)/_components/feed-tab.tsx
@@ -84,7 +84,9 @@ export function FeedTab() {
     feedData?.feedCountLabel ??
     `지금까지 ${totalCount}개의 피드가 완성되었어요!`;
   const weeklyTopBuilder = feedData?.weeklyTopBuilder;
-  const paywall = feedData?.paywall ?? null;
+  // TODO: restore paywall when access control is re-enabled
+  // const paywall = feedData?.paywall ?? null;
+  const paywall = null;
 
   const emptyMessage =
     filter === '내 피드'

--- a/src/app/(landing)/class/[slug]/(learning)/_components/feed-tab.tsx
+++ b/src/app/(landing)/class/[slug]/(learning)/_components/feed-tab.tsx
@@ -13,6 +13,7 @@ import {
   useGetCourseCurriculum,
   useGetCourseDetail,
 } from '@/hooks/queries/course/course-api';
+import type { BuilderFeedPaywall } from '@/types/api/course.types';
 import { FeedListCard } from '../feed/_components/feed-list-card';
 import { PaginationBar } from '../feed/_components/pagination-bar';
 import { PaywallSection } from '../feed/_components/paywall-section';
@@ -86,7 +87,7 @@ export function FeedTab() {
   const weeklyTopBuilder = feedData?.weeklyTopBuilder;
   // TODO: restore paywall when access control is re-enabled
   // const paywall = feedData?.paywall ?? null;
-  const paywall = null;
+  const paywall: BuilderFeedPaywall | null = null;
 
   const emptyMessage =
     filter === '내 피드'


### PR DESCRIPTION
## Problem

빌더 피드 탭에서 페이월(유료 콘텐츠 잠금) 기능이 접근 제어 재정비 전까지 임시로 비활성화 필요.
추가로 `paywall = null` 할당 시 TypeScript가 암묵적 `any`로 추론하여 빌드 실패.

## Solution

- `feedData?.paywall` 참조를 주석 처리하고 `null`로 고정
- `BuilderFeedPaywall | null` 명시적 타입 annotation 추가로 빌드 통과

## Changes

### Bug Fixes
| File | Description |
|------|-------------|
| `feed-tab.tsx` | 페이월 임시 비활성화 (전체 공개), 암묵적 `any` 타입 에러 수정 |

## Result

- 빌더 피드 탭이 로그인/플랜 여부 관계없이 전체 공개로 표시
- `yarn build` 타입 에러 없이 통과

## Test plan

- [ ] 비로그인 상태에서 빌더 피드 탭 진입 — 페이월 없이 피드 전체 노출 확인
- [ ] 유료 플랜 미가입 상태에서도 피드 정상 표시 확인
- [ ] `yarn typecheck` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
