### PR TITLE
hotfix : 학습하러 가기 버튼 동일 URL push로 미이동 수정

### DIFF
--- a/src/app/(landing)/class/[id]/page.tsx
+++ b/src/app/(landing)/class/[id]/page.tsx
@@ -67,8 +67,10 @@ export default function ClassDetailPage({
   });
   const registerGiftEmailMutation = useRegisterGiftEmail();
 
-  const learningHomeHref =
-    slug === 'vibe-intro' ? '/class/vibe-intro/home' : `/class/${slug}`;
+  // 학습 홈 라우트는 `/class/vibe-intro/home` 하나뿐이고
+  // RoadmapTab의 COURSE_SLUG가 `vibe-intro`로 하드코딩돼 있어
+  // 다른 바이브 코스 슬러그(vibe-intro-claude-code 등)도 동일 라우트를 공유한다.
+  const learningHomeHref = '/class/vibe-intro/home';
 
   const chaptersForRoadmap = useMemo<ChapterForRoadmap[]>(() => {
     if (curriculum?.chapters && curriculum.chapters.length > 0) {


### PR DESCRIPTION
## Summary

- `/class/[id]` 상세 페이지의 `learningHomeHref`가 slug가 `vibe-intro`가 아닐 경우 `/class/${slug}` 즉 **현재 페이지와 동일한 URL**로 router.push 되어, 학습 페이지로 이동하지 않고 RSC 프리페치(`?_rsc=...`)만 200 OK로 응답하던 문제 수정.
- 현 시점 학습 홈 라우트는 `/class/vibe-intro/(learning)/home` 하나뿐이며, `RoadmapTab`의 `COURSE_SLUG`도 `vibe-intro`로 하드코딩돼 있어 다른 바이브 코스 슬러그(`vibe-intro-claude-code` 등)도 동일 라우트를 공유한다. fallback을 제거하고 항상 `/class/vibe-intro/home`으로 이동시킨다.

## Root Cause

```ts
// before
const learningHomeHref =
  slug === 'vibe-intro' ? '/class/vibe-intro/home' : `/class/${slug}`;
```

`slug === 'vibe-intro-claude-code'` 일 때 `/class/vibe-intro-claude-code`로 push → 현재 URL과 동일 → Next App Router는 같은 라우트 세그먼트라 RSC 프리페치만 발생시키고 페이지 전환은 일어나지 않음. 사용자가 본 `https://www.zeroone.it.kr/class/vibe-intro-claude-code?_rsc=bgvzn 200 OK` 가 정확히 그 증상.

```ts
// after
const learningHomeHref = '/class/vibe-intro/home';
```

## Scope

- Changed: `src/app/(landing)/class/[id]/page.tsx` (1 file, +4 -2)
- Touched only the `learningHomeHref` 상수. `handleStartCourse`, `useCreateCourseFreeEnrollment`, sidebar CTA 라벨 로직 등은 모두 그대로.

## Test plan

- [x] `yarn lint` (0 errors, warnings unchanged from main)
- [x] `yarn typecheck`
- [x] `yarn prettier` (biome format)
- [x] `yarn build` (Next.js production build 통과)
- [ ] 스테이징 검증
  - [ ] `/class/vibe-intro` PAID 사용자 클릭 → `/class/vibe-intro/home` 이동 (기존 동작 유지)
  - [ ] `/class/vibe-intro-claude-code` PAID 사용자 클릭 → `/class/vibe-intro/home` 이동 (버그 수정 핵심)
  - [ ] `FREE_ENROLLED` / `LOGIN_ONLY+canFreeEnroll` 사용자도 동일 라우트로 이동하는지 확인 (무료 등록 mutate 후 push 흐름 영향 없음)
  - [ ] `ANONYMOUS` 사용자 → 로그인 모달 트리거 (이 PR 범위 밖이지만 회귀 확인)

## Notes for reviewer

- 향후 코스 슬러그별 별도 학습 홈이 필요해지면 `learningHomeHref`를 slug → href 매핑 또는 동적 라우트(`/class/[slug]/(learning)/home`)로 다시 갈라야 한다. 그 시점까지는 모든 바이브 코스가 동일 학습 콘텐츠를 공유한다는 전제로 본 핫픽스를 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

- 클래스 페이지에서 학습 홈으로 이동할 때의 라우팅 동작이 일관되게 처리되도록 개선되었습니다. 이로 인해 페이지 네비게이션이 표준화되고, 사용자는 보다 안정적이고 일관성 있는 페이지 이동 경험을 얻을 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->