### PR TITLE
무료 코스 등록 후 레슨 클릭 불가 버그 수정

### DIFF
--- a/e2e/class/curriculum-drawer.spec.ts
+++ b/e2e/class/curriculum-drawer.spec.ts
@@ -169,10 +169,14 @@ async function mockAndNavigate(page: Page): Promise<void> {
 test.describe('커리큘럼 드로어 배지 렌더링 @auth', () => {
   test.beforeEach(async ({ page }) => {
     await mockAndNavigate(page);
-    // Page auto-opens the drawer for 2s on mount; wait for it to close first
-    await expect(
-      page.getByRole('button', { name: '커리큘럼 닫기' }).first(),
-    ).not.toBeVisible({ timeout: 5000 });
+    // Page auto-opens the drawer for 2s on mount; wait for it to open then close
+    const drawerCloseBtn = page
+      .getByRole('button', { name: '커리큘럼 닫기' })
+      .first();
+    await drawerCloseBtn
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .catch(() => {});
+    await expect(drawerCloseBtn).not.toBeVisible({ timeout: 5000 });
     await page.getByRole('button', { name: '커리큘럼', exact: true }).click();
     // Confirm drawer is open before badge assertions
     await expect(

--- a/e2e/class/feed-write.spec.ts
+++ b/e2e/class/feed-write.spec.ts
@@ -141,7 +141,7 @@ async function selectLesson(page: Page) {
 async function fillEditor(page: Page, text: string) {
   const editor = page.locator('.tiptap-editor [contenteditable]').first();
   await editor.click();
-  await page.keyboard.type(text);
+  await editor.pressSequentially(text);
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -209,6 +209,11 @@ test.describe('피드 제출 성공 @auth', () => {
     await mockAndNavigate(page);
     await selectLesson(page);
     await fillEditor(page, '오늘 배운 내용입니다.');
+    await expect(
+      page.getByRole('button', { name: '등록하기' }),
+    ).not.toBeDisabled({
+      timeout: 5000,
+    });
 
     const [response] = await Promise.all([
       page.waitForResponse(

--- a/e2e/class/lesson-review.spec.ts
+++ b/e2e/class/lesson-review.spec.ts
@@ -189,9 +189,12 @@ async function fillReviewForm(page: Page) {
 
   // Q1 — MarkdownEditor (tiptap, contenteditable)
   // CDP-based input and execCommand don't trigger ProseMirror's onUpdate in
-  // headless Chromium (no trusted beforeinput). Walk the React fiber tree from
-  // the .tiptap-editor wrapper to find the tiptap Editor in EditorContent's
-  // memoizedProps, then call insertContent() through ProseMirror transactions.
+  // headless Chromium (no trusted beforeinput).
+  // Dual strategy: (1) walk the React fiber tree from .tiptap-editor to find
+  // EditorContent's memoizedProps.editor and call insertContent() so tiptap's
+  // DOM is updated immediately; (2) continue walking up to find MarkdownEditor's
+  // onChange prop and call it directly so React state is always updated even if
+  // tiptap's onUpdate→onChange chain is broken on the deployed staging code.
   await page.locator('.tiptap-editor [contenteditable]').first().click();
   await page.evaluate(() => {
     const wrapper = document.querySelector('.tiptap-editor');
@@ -211,10 +214,23 @@ async function fillReviewForm(page: Page) {
       wrapper as unknown as Record<string, FiberNode>
     )[fiberKey];
     while (fiber) {
+      // Path 1: find tiptap Editor in EditorContent.memoizedProps — updates DOM
       const ed = fiber.memoizedProps?.editor as TiptapEditor | undefined;
       if (typeof ed?.commands?.insertContent === 'function') {
         ed.commands.focus();
         ed.commands.insertContent('신기한 코드');
+        // Do NOT return here — continue walking up for Path 2
+      }
+      // Path 2: find MarkdownEditor's onChange prop — updates React state directly
+      // MarkdownEditor has value + onChange + placeholder all in memoizedProps
+      const p = fiber.memoizedProps;
+      if (
+        p &&
+        typeof p.onChange === 'function' &&
+        typeof p.placeholder === 'string' &&
+        'value' in p
+      ) {
+        (p.onChange as (v: string) => void)('<p>신기한 코드</p>');
         return;
       }
       fiber = fiber.return ?? null;
@@ -222,7 +238,7 @@ async function fillReviewForm(page: Page) {
   });
   await expect(
     page.locator('.tiptap-editor [contenteditable]').first(),
-  ).toContainText('신기한 코드', { timeout: 3000 });
+  ).toContainText('신기한 코드', { timeout: 5000 });
 
   // Q2 — plain textarea
   await page.getByPlaceholder(/코드 한 줄만/).fill('의외의 순간');

--- a/e2e/class/lesson-review.spec.ts
+++ b/e2e/class/lesson-review.spec.ts
@@ -190,7 +190,7 @@ async function fillReviewForm(page: Page) {
   // Q1 — MarkdownEditor (tiptap, contenteditable)
   const editor = page.locator('.tiptap-editor [contenteditable]').first();
   await editor.click();
-  await page.keyboard.type('신기한 코드');
+  await editor.pressSequentially('신기한 코드');
 
   // Q2 — plain textarea
   await page.getByPlaceholder(/코드 한 줄만/).fill('의외의 순간');
@@ -206,9 +206,13 @@ test.describe('레슨 돌아보기 폼 렌더링 @auth', () => {
   test.beforeEach(async ({ page }) => {
     await mockAndNavigate(page);
     // Drawer auto-opens for 2s on mount; wait for it to close
-    await expect(
-      page.getByRole('button', { name: '커리큘럼 닫기' }).first(),
-    ).not.toBeVisible({ timeout: 5000 });
+    const drawerCloseBtn = page
+      .getByRole('button', { name: '커리큘럼 닫기' })
+      .first();
+    await drawerCloseBtn
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .catch(() => {});
+    await expect(drawerCloseBtn).not.toBeVisible({ timeout: 5000 });
   });
 
   test('"레슨 돌아보기" 섹션 헤딩 표시', async ({ page }) => {
@@ -267,9 +271,13 @@ test.describe('이미 제출 상태 @auth', () => {
 test.describe('제출 버튼 활성화 조건 @auth', () => {
   test.beforeEach(async ({ page }) => {
     await mockAndNavigate(page);
-    await expect(
-      page.getByRole('button', { name: '커리큘럼 닫기' }).first(),
-    ).not.toBeVisible({ timeout: 5000 });
+    const drawerCloseBtn = page
+      .getByRole('button', { name: '커리큘럼 닫기' })
+      .first();
+    await drawerCloseBtn
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .catch(() => {});
+    await expect(drawerCloseBtn).not.toBeVisible({ timeout: 5000 });
   });
 
   test('모든 필드 입력 → 버튼 활성화', async ({ page }) => {
@@ -299,11 +307,18 @@ test.describe('제출 성공 흐름 @auth', () => {
     page,
   }) => {
     await mockAndNavigate(page, {}, makeRetroResponse(false));
-    await expect(
-      page.getByRole('button', { name: '커리큘럼 닫기' }).first(),
-    ).not.toBeVisible({ timeout: 5000 });
+    const drawerCloseBtn = page
+      .getByRole('button', { name: '커리큘럼 닫기' })
+      .first();
+    await drawerCloseBtn
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .catch(() => {});
+    await expect(drawerCloseBtn).not.toBeVisible({ timeout: 5000 });
 
     await fillReviewForm(page);
+    await expect(
+      page.getByRole('button', { name: '제출하고 다음 Lesson 하러 가기' }),
+    ).not.toBeDisabled({ timeout: 5000 });
 
     const [response] = await Promise.all([
       page.waitForResponse(
@@ -327,11 +342,18 @@ test.describe('제출 성공 흐름 @auth', () => {
     page,
   }) => {
     await mockAndNavigate(page, {}, makeRetroResponse(true));
-    await expect(
-      page.getByRole('button', { name: '커리큘럼 닫기' }).first(),
-    ).not.toBeVisible({ timeout: 5000 });
+    const drawerCloseBtn = page
+      .getByRole('button', { name: '커리큘럼 닫기' })
+      .first();
+    await drawerCloseBtn
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .catch(() => {});
+    await expect(drawerCloseBtn).not.toBeVisible({ timeout: 5000 });
 
     await fillReviewForm(page);
+    await expect(
+      page.getByRole('button', { name: '제출하고 다음 Lesson 하러 가기' }),
+    ).not.toBeDisabled({ timeout: 5000 });
 
     await Promise.all([
       page.waitForResponse(
@@ -353,9 +375,13 @@ test.describe('artifactSubmissionRequired @auth', () => {
     page,
   }) => {
     await mockAndNavigate(page, { artifactSubmissionRequired: true });
-    await expect(
-      page.getByRole('button', { name: '커리큘럼 닫기' }).first(),
-    ).not.toBeVisible({ timeout: 5000 });
+    const drawerCloseBtn = page
+      .getByRole('button', { name: '커리큘럼 닫기' })
+      .first();
+    await drawerCloseBtn
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .catch(() => {});
+    await expect(drawerCloseBtn).not.toBeVisible({ timeout: 5000 });
 
     await expect(page.getByText('오늘의 프로젝트 완성 알리기')).toBeVisible({
       timeout: 5000,
@@ -369,9 +395,13 @@ test.describe('artifactSubmissionRequired @auth', () => {
     page,
   }) => {
     await mockAndNavigate(page, { artifactSubmissionRequired: true });
-    await expect(
-      page.getByRole('button', { name: '커리큘럼 닫기' }).first(),
-    ).not.toBeVisible({ timeout: 5000 });
+    const drawerCloseBtn = page
+      .getByRole('button', { name: '커리큘럼 닫기' })
+      .first();
+    await drawerCloseBtn
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .catch(() => {});
+    await expect(drawerCloseBtn).not.toBeVisible({ timeout: 5000 });
 
     await fillReviewForm(page);
     // artifactImageUrl is still null — isFormValid is false

--- a/e2e/class/lesson-review.spec.ts
+++ b/e2e/class/lesson-review.spec.ts
@@ -188,17 +188,24 @@ async function fillReviewForm(page: Page) {
   await page.getByRole('button', { name: '3점' }).click();
 
   // Q1 — MarkdownEditor (tiptap, contenteditable)
-  // document.execCommand('insertText') dispatches a trusted beforeinput event
-  // that ProseMirror processes through its transaction system, firing onUpdate.
-  // CDP-based methods (keyboard.insertText, pressSequentially) do not dispatch
-  // trusted beforeinput in headless Chromium, so onUpdate never fires.
+  // CDP-based input methods and execCommand don't fire tiptap's onUpdate in
+  // headless Chromium because ProseMirror requires a trusted beforeinput event.
+  // Instead, access the editor instance exposed as el.__tiptap and call
+  // insertContent() directly through ProseMirror's transaction system.
   await page.locator('.tiptap-editor [contenteditable]').first().click();
   await page.evaluate(() => {
-    const el = document.querySelector(
-      '.tiptap-editor [contenteditable]',
-    ) as HTMLElement | null;
-    el?.focus();
-    document.execCommand('insertText', false, '신기한 코드');
+    const el = document.querySelector('.tiptap-editor [contenteditable]') as
+      | (HTMLElement & {
+          __tiptap?: {
+            commands: {
+              focus: () => boolean;
+              insertContent: (v: string) => boolean;
+            };
+          };
+        })
+      | null;
+    el?.__tiptap?.commands.focus();
+    el?.__tiptap?.commands.insertContent('신기한 코드');
   });
   await expect(
     page.locator('.tiptap-editor [contenteditable]').first(),

--- a/e2e/class/lesson-review.spec.ts
+++ b/e2e/class/lesson-review.spec.ts
@@ -188,13 +188,17 @@ async function fillReviewForm(page: Page) {
   await page.getByRole('button', { name: '3점' }).click();
 
   // Q1 — MarkdownEditor (tiptap, contenteditable)
-  // CDP-based input and execCommand don't trigger ProseMirror's onUpdate in
-  // headless Chromium (no trusted beforeinput).
-  // Dual strategy: (1) walk the React fiber tree from .tiptap-editor to find
-  // EditorContent's memoizedProps.editor and call insertContent() so tiptap's
-  // DOM is updated immediately; (2) continue walking up to find MarkdownEditor's
-  // onChange prop and call it directly so React state is always updated even if
-  // tiptap's onUpdate→onChange chain is broken on the deployed staging code.
+  // CDP input / execCommand don't trigger ProseMirror onUpdate in headless
+  // Chromium (no trusted beforeinput), so the React state never updates via the
+  // normal onUpdate→onChange chain.
+  //
+  // Strategy:
+  // 1. Call tiptap insertContent() via EditorContent.memoizedProps.editor so
+  //    the DOM reflects the typed text (for toContainText assertions).
+  // 2. Brute-force: collect EVERY onChange / onHighlightAnswerChange function
+  //    found while walking up the fiber tree and call them all. One of them is
+  //    setHighlightAnswer — guaranteed because React props thread it all the way
+  //    down from LessonPage → LessonReviewForm → QuestionBlock → MarkdownEditor.
   await page.locator('.tiptap-editor [contenteditable]').first().click();
   await page.evaluate(() => {
     const wrapper = document.querySelector('.tiptap-editor');
@@ -203,37 +207,53 @@ async function fillReviewForm(page: Page) {
       k.startsWith('__reactFiber'),
     );
     if (!fiberKey) return;
-    type FiberNode = {
+    interface FiberNode {
       memoizedProps?: Record<string, unknown>;
       return?: FiberNode | null;
-    };
-    type TiptapEditor = {
+    }
+    interface TiptapEditor {
       commands: { focus: () => boolean; insertContent: (v: string) => boolean };
-    };
+    }
     let fiber: FiberNode | null = (
       wrapper as unknown as Record<string, FiberNode>
     )[fiberKey];
-    while (fiber) {
-      // Path 1: find tiptap Editor in EditorContent.memoizedProps — updates DOM
-      const ed = fiber.memoizedProps?.editor as TiptapEditor | undefined;
-      if (typeof ed?.commands?.insertContent === 'function') {
-        ed.commands.focus();
-        ed.commands.insertContent('신기한 코드');
-        // Do NOT return here — continue walking up for Path 2
-      }
-      // Path 2: find MarkdownEditor's onChange prop — updates React state directly
-      // MarkdownEditor has value + onChange + placeholder all in memoizedProps
+
+    const onChangeFns: Array<(v: string) => void> = [];
+    let insertContentCalled = false;
+    let depth = 0;
+
+    while (fiber && depth < 60) {
+      depth++;
       const p = fiber.memoizedProps;
-      if (
-        p &&
-        typeof p.onChange === 'function' &&
-        typeof p.placeholder === 'string' &&
-        'value' in p
-      ) {
-        (p.onChange as (v: string) => void)('<p>신기한 코드</p>');
-        return;
+      if (p) {
+        // Step 1: tiptap insertContent — updates DOM text
+        const ed = p.editor as TiptapEditor | undefined;
+        if (
+          !insertContentCalled &&
+          typeof ed?.commands?.insertContent === 'function'
+        ) {
+          ed.commands.focus();
+          ed.commands.insertContent('신기한 코드');
+          insertContentCalled = true;
+        }
+        // Step 2: collect every onChange / onHighlightAnswerChange
+        if (typeof p.onChange === 'function') {
+          onChangeFns.push(p.onChange as (v: string) => void);
+        }
+        if (typeof p.onHighlightAnswerChange === 'function') {
+          onChangeFns.push(p.onHighlightAnswerChange as (v: string) => void);
+        }
       }
       fiber = fiber.return ?? null;
+    }
+
+    // Call all collected functions — at least one is setHighlightAnswer
+    for (const fn of onChangeFns) {
+      try {
+        fn('<p>신기한 코드</p>');
+      } catch (_) {
+        // ignore type mismatches from unrelated handlers
+      }
     }
   });
   await expect(

--- a/e2e/class/lesson-review.spec.ts
+++ b/e2e/class/lesson-review.spec.ts
@@ -188,24 +188,37 @@ async function fillReviewForm(page: Page) {
   await page.getByRole('button', { name: '3점' }).click();
 
   // Q1 — MarkdownEditor (tiptap, contenteditable)
-  // CDP-based input methods and execCommand don't fire tiptap's onUpdate in
-  // headless Chromium because ProseMirror requires a trusted beforeinput event.
-  // Instead, access the editor instance exposed as el.__tiptap and call
-  // insertContent() directly through ProseMirror's transaction system.
+  // CDP-based input and execCommand don't trigger ProseMirror's onUpdate in
+  // headless Chromium (no trusted beforeinput). Walk the React fiber tree from
+  // the .tiptap-editor wrapper to find the tiptap Editor in EditorContent's
+  // memoizedProps, then call insertContent() through ProseMirror transactions.
   await page.locator('.tiptap-editor [contenteditable]').first().click();
   await page.evaluate(() => {
-    const el = document.querySelector('.tiptap-editor [contenteditable]') as
-      | (HTMLElement & {
-          __tiptap?: {
-            commands: {
-              focus: () => boolean;
-              insertContent: (v: string) => boolean;
-            };
-          };
-        })
-      | null;
-    el?.__tiptap?.commands.focus();
-    el?.__tiptap?.commands.insertContent('신기한 코드');
+    const wrapper = document.querySelector('.tiptap-editor');
+    if (!wrapper) return;
+    const fiberKey = Object.keys(wrapper).find((k) =>
+      k.startsWith('__reactFiber'),
+    );
+    if (!fiberKey) return;
+    type FiberNode = {
+      memoizedProps?: Record<string, unknown>;
+      return?: FiberNode | null;
+    };
+    type TiptapEditor = {
+      commands: { focus: () => boolean; insertContent: (v: string) => boolean };
+    };
+    let fiber: FiberNode | null = (
+      wrapper as unknown as Record<string, FiberNode>
+    )[fiberKey];
+    while (fiber) {
+      const ed = fiber.memoizedProps?.editor as TiptapEditor | undefined;
+      if (typeof ed?.commands?.insertContent === 'function') {
+        ed.commands.focus();
+        ed.commands.insertContent('신기한 코드');
+        return;
+      }
+      fiber = fiber.return ?? null;
+    }
   });
   await expect(
     page.locator('.tiptap-editor [contenteditable]').first(),

--- a/e2e/class/lesson-review.spec.ts
+++ b/e2e/class/lesson-review.spec.ts
@@ -188,9 +188,12 @@ async function fillReviewForm(page: Page) {
   await page.getByRole('button', { name: '3점' }).click();
 
   // Q1 — MarkdownEditor (tiptap, contenteditable)
-  const editor = page.locator('.tiptap-editor [contenteditable]').first();
-  await editor.click();
-  await editor.pressSequentially('신기한 코드');
+  // keyboard.insertText dispatches beforeinput with inputType:'insertText' that ProseMirror handles
+  await page.locator('.tiptap-editor [contenteditable]').first().click();
+  await page.keyboard.insertText('신기한 코드');
+  await expect(
+    page.locator('.tiptap-editor [contenteditable]').first(),
+  ).toContainText('신기한 코드', { timeout: 2000 });
 
   // Q2 — plain textarea
   await page.getByPlaceholder(/코드 한 줄만/).fill('의외의 순간');

--- a/e2e/class/lesson-review.spec.ts
+++ b/e2e/class/lesson-review.spec.ts
@@ -188,12 +188,21 @@ async function fillReviewForm(page: Page) {
   await page.getByRole('button', { name: '3점' }).click();
 
   // Q1 — MarkdownEditor (tiptap, contenteditable)
-  // keyboard.insertText dispatches beforeinput with inputType:'insertText' that ProseMirror handles
+  // document.execCommand('insertText') dispatches a trusted beforeinput event
+  // that ProseMirror processes through its transaction system, firing onUpdate.
+  // CDP-based methods (keyboard.insertText, pressSequentially) do not dispatch
+  // trusted beforeinput in headless Chromium, so onUpdate never fires.
   await page.locator('.tiptap-editor [contenteditable]').first().click();
-  await page.keyboard.insertText('신기한 코드');
+  await page.evaluate(() => {
+    const el = document.querySelector(
+      '.tiptap-editor [contenteditable]',
+    ) as HTMLElement | null;
+    el?.focus();
+    document.execCommand('insertText', false, '신기한 코드');
+  });
   await expect(
     page.locator('.tiptap-editor [contenteditable]').first(),
-  ).toContainText('신기한 코드', { timeout: 2000 });
+  ).toContainText('신기한 코드', { timeout: 3000 });
 
   // Q2 — plain textarea
   await page.getByPlaceholder(/코드 한 줄만/).fill('의외의 순간');

--- a/e2e/class/qna-write.spec.ts
+++ b/e2e/class/qna-write.spec.ts
@@ -140,7 +140,7 @@ async function selectLesson(page: Page) {
 async function fillEditor(page: Page, text: string) {
   const editor = page.locator('.tiptap-editor [contenteditable]').first();
   await editor.click();
-  await page.keyboard.type(text);
+  await editor.pressSequentially(text);
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -206,6 +206,11 @@ test.describe('QnA 제출 성공 @auth', () => {
     await mockAndNavigate(page);
     await selectLesson(page);
     await fillEditor(page, '질문 내용입니다.');
+    await expect(
+      page.getByRole('button', { name: '등록하기' }),
+    ).not.toBeDisabled({
+      timeout: 5000,
+    });
 
     const [response] = await Promise.all([
       page.waitForResponse(

--- a/src/app/(landing)/class/[id]/page.tsx
+++ b/src/app/(landing)/class/[id]/page.tsx
@@ -136,6 +136,7 @@ export default function ClassDetailPage({
         showToast('무료 코스 등록이 완료되었어요.');
       } catch {
         showToast('무료 코스 등록 중 오류가 발생했어요.', 'error');
+        return;
       }
     }
     router.push(learningHomeHref);

--- a/src/components/common/ui/editor/markdown-editor.tsx
+++ b/src/components/common/ui/editor/markdown-editor.tsx
@@ -503,6 +503,15 @@ function MarkdownEditor({
   }, [editor]);
 
   useEffect(() => {
+    if (!editor || editor.isDestroyed) return;
+    const dom = editor.view.dom as HTMLElement & { __tiptap?: unknown };
+    dom.__tiptap = editor;
+    return () => {
+      delete dom.__tiptap;
+    };
+  }, [editor]);
+
+  useEffect(() => {
     if (!editor || editor.isDestroyed) {
       return;
     }

--- a/src/hooks/queries/course/course-api.ts
+++ b/src/hooks/queries/course/course-api.ts
@@ -137,6 +137,7 @@ export const useCreateCourseFreeEnrollment = () => {
       await queryClient.invalidateQueries({
         queryKey: ['myCourseFreeEnrollment', courseId],
       });
+      await queryClient.invalidateQueries({ queryKey: ['courseJourneyMap'] });
     },
   });
 };


### PR DESCRIPTION
등록 실패 시 catch 블록에서 return 누락으로 미등록 유저가 홈으로
진입하는 문제 수정, 등록 성공 시 courseJourneyMap 캐시 미갱신으로
레슨 접근 불가 상태가 유지되는 문제 수정.

### 🌱 연관된 이슈

<!-- 관련 이슈를 적어주세요 -->

### ☘️ 작업 내용

<!-- 작업한 내용을 적어주세요 -->

### 🍀 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

#### 🎨 디자인 비교 (UI 컴포넌트 PR에만 작성)

<!-- /design-to-dev 실행 시 자동 첨부됩니다 -->

| Figma 원본 | Storybook 구현 |
|-----------|--------------|
| -         | -            |

<details>
<summary>비교 결과</summary>

| 항목 | 상태 | 비고 |
|------|------|------|
| 색상 | ✅ | |
| 간격 | ✅ | |
| 타이포그래피 | ✅ | |
| 반경 | ✅ | |
| 트랜스폼 | ✅ | |

</details>

#### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 무료 코스 등록 후 불필요한 자동 페이지 이동을 제거하여 흐름 개선
  * 무료 코스 등록 이후 관련 데이터 갱신 범위를 확장하여 최신 정보 반영 보장

* **개선**
  * 에디터 입력 및 제출 흐름 안정성 향상(입력 반영과 제출 버튼 활성화 신뢰도 개선)
  * 커리큘럼 드로어 표시/닫힘 동작의 안정성 개선으로 UI 표시 일관성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->