### PR TITLE
어드민 레슨 일괄 저장 UX를 연결합니다

### DIFF
--- a/src/components/admin/courses/admin-lesson-detail-page-client.tsx
+++ b/src/components/admin/courses/admin-lesson-detail-page-client.tsx
@@ -4,9 +4,8 @@ import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import AdminCourseField from '@/components/admin/courses/admin-course-field';
 import AdminCourseMarkdownField from '@/components/admin/courses/admin-course-markdown-field';
-import AdminNotionZipImportButton, {
-  ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE,
-} from '@/components/admin/courses/admin-notion-zip-import-button';
+import AdminNotionZipActionCard from '@/components/admin/courses/admin-notion-zip-action-card';
+import { ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE } from '@/components/admin/courses/admin-notion-zip-import-button';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import Badge from '@/components/common/ui/badge';
 import Button from '@/components/common/ui/button';
@@ -404,14 +403,6 @@ export default function AdminLessonDetailPageClient({
           </div>
         </div>
         <div className="flex gap-75">
-          <AdminNotionZipImportButton
-            confirmMessage={ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE}
-            disabled={isLessonFormLocked}
-            loading={importLessonContentZipMutation.isPending}
-            onSelectFiles={handleImportNotionZip}
-          >
-            Notion ZIP import
-          </AdminNotionZipImportButton>
           <Button
             size="small"
             disabled={isLessonFormLocked}
@@ -539,6 +530,22 @@ export default function AdminLessonDetailPageClient({
               </NativeSelect>
             </AdminCourseField>
           </div>
+          <AdminNotionZipActionCard
+            badgeLabel="본문 교체"
+            buttonLabel="Notion ZIP import"
+            confirmMessage={ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE}
+            description="Notion export ZIP 1개를 업로드하면 현재 레슨의 본문만 교체됩니다."
+            bullets={[
+              '제목, 설명, 챕터, 레슨 번호는 유지됩니다.',
+              'ZIP 기준 본문으로 에디터 값이 즉시 갱신됩니다.',
+              '일반 이미지 수동 업로드 기능은 기존처럼 그대로 사용할 수 있습니다.',
+            ]}
+            disabled={isLessonFormLocked}
+            loading={importLessonContentZipMutation.isPending}
+            title="현재 레슨 본문 교체"
+            tone="warning"
+            onSelectFiles={handleImportNotionZip}
+          />
           <AdminCourseMarkdownField
             editorStateKey={String(lessonId)}
             lessonId={lessonId}

--- a/src/components/admin/courses/admin-lesson-management-page-client.tsx
+++ b/src/components/admin/courses/admin-lesson-management-page-client.tsx
@@ -4,9 +4,8 @@ import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import AdminCourseField from '@/components/admin/courses/admin-course-field';
 import AdminCourseMarkdownEditor from '@/components/admin/courses/admin-course-markdown-editor';
-import AdminNotionZipImportButton, {
-  ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE,
-} from '@/components/admin/courses/admin-notion-zip-import-button';
+import AdminNotionZipActionCard from '@/components/admin/courses/admin-notion-zip-action-card';
+import { ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE } from '@/components/admin/courses/admin-notion-zip-import-button';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import Badge from '@/components/common/ui/badge';
 import Button from '@/components/common/ui/button';
@@ -14,6 +13,7 @@ import MarkdownContent from '@/components/common/ui/editor/markdown-content';
 import { BaseInput, NativeSelect } from '@/components/common/ui/input';
 import { CLASS_INPUT_LIMITS } from '@/features/admin/course-management/model/admin-class-input-policy';
 import type {
+  AdminLessonBatchUpdateItem,
   AdminLessonSummary,
   AdminLessonUpsertRequest,
   AdminRetrospectivePurpose,
@@ -24,6 +24,7 @@ import {
 } from '@/features/admin/course-management/model/admin-course-presentation';
 import {
   readAdminDraft,
+  removeAdminDraft,
   useAdminLocalDraft,
 } from '@/features/admin/course-management/model/admin-draft-storage';
 import { toAdminLessonForm } from '@/features/admin/course-management/model/admin-lesson-form-mapper';
@@ -35,6 +36,7 @@ import {
   useAdminLessonDetailQuery,
   useAdminLessonQnasQuery,
   useAdminLessonRetrospectivesQuery,
+  useBatchUpdateAdminLessonsMutation,
   useCreateAdminLessonMutation,
   useDeleteAdminLessonMutation,
   useCreateAdminLessonsFromNotionZipsMutation,
@@ -162,7 +164,7 @@ export default function AdminLessonManagementPageClient({
   courseId: number;
 }) {
   const lessonsQuery = useAdminCourseLessonsQuery(courseId);
-  const lessons = lessonsQuery.data ?? [];
+  const lessons = useMemo(() => lessonsQuery.data ?? [], [lessonsQuery.data]);
   const [lessonSearch, setLessonSearch] = useState('');
   const [chapterFilter, setChapterFilter] = useState<'ALL' | string>('ALL');
   const [publishedFilter, setPublishedFilter] = useState<
@@ -177,6 +179,10 @@ export default function AdminLessonManagementPageClient({
   );
   const [lessonForm, setLessonForm] =
     useState<AdminLessonUpsertRequest>(emptyLessonForm);
+  const [dirtyLessonFormsById, setDirtyLessonFormsById] = useState<
+    Record<number, AdminLessonUpsertRequest>
+  >({});
+  const [dirtyLessonIds, setDirtyLessonIds] = useState<number[]>([]);
   const [hydratedLessonId, setHydratedLessonId] = useState<
     number | undefined
   >();
@@ -200,6 +206,7 @@ export default function AdminLessonManagementPageClient({
     enabled: isLessonHydrated,
   });
 
+  const batchUpdateLessonsMutation = useBatchUpdateAdminLessonsMutation();
   const createLessonMutation = useCreateAdminLessonMutation();
   const createLessonsFromNotionZipsMutation =
     useCreateAdminLessonsFromNotionZipsMutation();
@@ -259,12 +266,50 @@ export default function AdminLessonManagementPageClient({
     createLessonsFromNotionZipsMutation.isPending ||
     importLessonContentZipMutation.isPending ||
     updateLessonMutation.isPending ||
+    batchUpdateLessonsMutation.isPending ||
     lessonDetailQuery.isFetching;
   const isListFiltered =
     Boolean(lessonSearch.trim()) ||
     chapterFilter !== 'ALL' ||
     publishedFilter !== 'ALL' ||
     accessFilter !== 'ALL';
+
+  const dirtyLessonIdSet = useMemo(
+    () => new Set(dirtyLessonIds),
+    [dirtyLessonIds],
+  );
+
+  const clearDirtyLessons = (lessonIds: number[]) => {
+    setDirtyLessonIds((prev) =>
+      prev.filter((lessonId) => !lessonIds.includes(lessonId)),
+    );
+    setDirtyLessonFormsById((prev) => {
+      const next = { ...prev };
+      lessonIds.forEach((lessonId) => {
+        delete next[lessonId];
+        removeAdminDraft(`lesson:${courseId}:edit:${lessonId}`);
+      });
+      return next;
+    });
+  };
+
+  const updateLessonForm = (patch: Partial<AdminLessonUpsertRequest>) => {
+    setLessonForm((prev) => {
+      const next = { ...prev, ...patch };
+      if (lessonFormMode === 'edit' && editingLessonId) {
+        setDirtyLessonFormsById((prevForms) => ({
+          ...prevForms,
+          [editingLessonId]: next,
+        }));
+        setDirtyLessonIds((prevIds) =>
+          prevIds.includes(editingLessonId)
+            ? prevIds
+            : [...prevIds, editingLessonId],
+        );
+      }
+      return next;
+    });
+  };
 
   useEffect(() => {
     if (
@@ -300,28 +345,40 @@ export default function AdminLessonManagementPageClient({
       return;
     }
 
+    const lessonId = lessonDetailQuery.data.lessonId;
     const serverLessonForm = toAdminLessonForm(lessonDetailQuery.data);
-    const draft = normalizeLessonDraft(
+    const memoryDraft = dirtyLessonFormsById[lessonId];
+    const localDraft = normalizeLessonDraft(
       readAdminDraft<AdminLessonUpsertRequest>(
-        `lesson:${courseId}:edit:${lessonDetailQuery.data.lessonId}`,
+        `lesson:${courseId}:edit:${lessonId}`,
       ),
     );
     // server에 본문이 있는데 draft의 본문이 비어 있으면 race condition으로 저장된 빈 form이므로
     // 무시하고 server data를 사용한다.
-    const isMeaningfulDraft =
-      draft !== undefined &&
-      (draft.content?.trim() ||
+    const isMeaningfulLocalDraft =
+      localDraft !== undefined &&
+      (localDraft.content?.trim() ||
         (!serverLessonForm.content?.trim() &&
-          (draft.title?.trim() || draft.lessonNumber !== undefined)));
+          (localDraft.title?.trim() || localDraft.lessonNumber !== undefined)));
+    const restoredDraft =
+      memoryDraft ?? (isMeaningfulLocalDraft ? localDraft : undefined);
 
-    setLessonForm(isMeaningfulDraft ? draft : serverLessonForm);
-    if (isMeaningfulDraft) {
+    setLessonForm(restoredDraft ?? serverLessonForm);
+    if (restoredDraft) {
       setLessonDraftStatus('restored');
+      setDirtyLessonFormsById((prev) => ({
+        ...prev,
+        [lessonId]: restoredDraft,
+      }));
+      setDirtyLessonIds((prev) =>
+        prev.includes(lessonId) ? prev : [...prev, lessonId],
+      );
     }
-    setHydratedLessonId(lessonDetailQuery.data.lessonId);
+    setHydratedLessonId(lessonId);
     setEditorVersion((prev) => prev + 1);
   }, [
     courseId,
+    dirtyLessonFormsById,
     hydratedLessonId,
     lessonDetailQuery.data,
     setLessonDraftStatus,
@@ -358,17 +415,19 @@ export default function AdminLessonManagementPageClient({
     setLessonFormMode('edit');
     setEditingLessonId(lesson.lessonId);
     setHydratedLessonId(undefined);
-    setLessonForm({
-      chapterNumber: lesson.chapterNumber,
-      lessonNumber: lesson.lessonNumber,
-      title: lesson.title,
-      description: '',
-      content: '',
-      estimatedMinutes: 30,
-      retrospectivePurpose: lesson.retrospectivePurpose,
-      isFree: lesson.isFree,
-      isPublished: lesson.isPublished,
-    });
+    setLessonForm(
+      dirtyLessonFormsById[lesson.lessonId] ?? {
+        chapterNumber: lesson.chapterNumber,
+        lessonNumber: lesson.lessonNumber,
+        title: lesson.title,
+        description: '',
+        content: '',
+        estimatedMinutes: 30,
+        retrospectivePurpose: lesson.retrospectivePurpose,
+        isFree: lesson.isFree,
+        isPublished: lesson.isPublished,
+      },
+    );
     setEditorVersion((prev) => prev + 1);
   };
 
@@ -402,7 +461,48 @@ export default function AdminLessonManagementPageClient({
         lessonId: editingLessonId,
         request: payload,
       },
-      { onSuccess: clearLessonDraft },
+      {
+        onSuccess: () => {
+          clearLessonDraft();
+          clearDirtyLessons([editingLessonId]);
+        },
+      },
+    );
+  };
+
+  const handleSubmitDirtyLessons = () => {
+    const lessonsToSave = dirtyLessonIds
+      .map((lessonId) => ({
+        lessonId,
+        form: dirtyLessonFormsById[lessonId],
+      }))
+      .filter(
+        (item): item is { lessonId: number; form: AdminLessonUpsertRequest } =>
+          item.form !== undefined,
+      );
+
+    if (lessonsToSave.length === 0) return;
+
+    const lessons: AdminLessonBatchUpdateItem[] = [];
+    for (const item of lessonsToSave) {
+      const payload = toAdminLessonPayload(item.form);
+      const validationError = getAdminLessonPayloadValidationError(payload);
+      if (validationError) {
+        useToastStore
+          .getState()
+          .showToast(`레슨 #${item.lessonId}: ${validationError}`, 'info');
+        return;
+      }
+      lessons.push({ lessonId: item.lessonId, ...payload });
+    }
+
+    batchUpdateLessonsMutation.mutate(
+      { courseId, request: { lessons } },
+      {
+        onSuccess: (response) => {
+          clearDirtyLessons(response.lessons.map((lesson) => lesson.lessonId));
+        },
+      },
     );
   };
 
@@ -437,6 +537,7 @@ export default function AdminLessonManagementPageClient({
         onSuccess: (lessonDetail) => {
           clearLessonDraft();
           setLessonForm(toAdminLessonForm(lessonDetail));
+          clearDirtyLessons([lessonDetail.lessonId]);
           setHydratedLessonId(lessonDetail.lessonId);
           setEditorVersion((prev) => prev + 1);
         },
@@ -463,7 +564,7 @@ export default function AdminLessonManagementPageClient({
             return;
           }
 
-          setLessonForm((prev) => ({ ...prev, isPublished: false }));
+          updateLessonForm({ isPublished: false });
         },
       },
     );
@@ -505,17 +606,20 @@ export default function AdminLessonManagementPageClient({
           </div>
         </div>
         <div className="flex gap-75">
-          <AdminNotionZipImportButton
-            multiple
-            disabled={isLessonFormLocked}
-            loading={createLessonsFromNotionZipsMutation.isPending}
-            onSelectFiles={handleCreateLessonsFromNotionZips}
-          >
-            Notion ZIP 다건 업로드
-          </AdminNotionZipImportButton>
           {lessonFormMode !== 'create' && (
             <Button color="secondary" size="small" onClick={startCreateLesson}>
               새 레슨 추가
+            </Button>
+          )}
+          {dirtyLessonIds.length > 0 && (
+            <Button
+              color="secondary"
+              size="small"
+              disabled={isLessonFormLocked}
+              loading={batchUpdateLessonsMutation.isPending}
+              onClick={handleSubmitDirtyLessons}
+            >
+              변경사항 모두 저장 {dirtyLessonIds.length}
             </Button>
           )}
           <Button
@@ -526,13 +630,32 @@ export default function AdminLessonManagementPageClient({
             }
             onClick={handleSubmitLesson}
           >
-            {lessonFormMode === 'create' ? '새 레슨 생성' : '변경사항 저장'}
+            {lessonFormMode === 'create' ? '새 레슨 생성' : '현재 레슨 저장'}
           </Button>
         </div>
       </header>
 
       <section className="grid min-h-screen grid-cols-2 gap-200">
         <div className="border-border-default bg-background-default rounded-150 min-h-screen overflow-auto border p-200">
+          <div className="mb-150">
+            <AdminNotionZipActionCard
+              multiple
+              badgeLabel="즉시 생성"
+              buttonLabel="Notion ZIP 업로드"
+              description="Notion export ZIP을 업로드하면 선택한 코스 아래에 레슨이 바로 생성됩니다."
+              bullets={[
+                'ZIP 1개당 레슨 1개가 생성됩니다.',
+                '파일 선택창에서 ZIP 1개 또는 여러 개를 한 번에 선택할 수 있습니다.',
+                '제목과 설명은 ZIP 내용에서 자동 추출됩니다.',
+                '챕터와 레슨 번호는 기존 마지막 레슨 뒤로 자동 배치됩니다.',
+              ]}
+              disabled={isLessonFormLocked}
+              loading={createLessonsFromNotionZipsMutation.isPending}
+              title="Notion ZIP으로 레슨 생성"
+              onSelectFiles={handleCreateLessonsFromNotionZips}
+            />
+          </div>
+
           <div className="mb-150 flex flex-wrap items-end gap-100">
             <AdminCourseField label="레슨 검색">
               <BaseInput
@@ -625,7 +748,12 @@ export default function AdminLessonManagementPageClient({
                             {lesson.chapterNumber}-{lesson.lessonNumber}.{' '}
                             {lesson.title}
                           </span>
-                          <LessonStatusBadges lesson={lesson} />
+                          <div className="flex flex-wrap gap-50">
+                            <LessonStatusBadges lesson={lesson} />
+                            {dirtyLessonIdSet.has(lesson.lessonId) && (
+                              <Badge color="orange">수정됨</Badge>
+                            )}
+                          </div>
                           <span className="font-designer-12r text-text-subtlest">
                             돌아보기 {lesson.retrospectiveCount}건 · 수정{' '}
                             {formatDateTime(lesson.updatedAt)}
@@ -700,6 +828,18 @@ export default function AdminLessonManagementPageClient({
             </div>
           )}
 
+          {dirtyLessonIds.length > 0 && (
+            <div className="border-border-warning bg-fill-warning-subtle-default mb-150 rounded-125 border px-150 py-125">
+              <p className="font-designer-14b text-text-warning">
+                저장되지 않은 레슨 {dirtyLessonIds.length}개가 있습니다.
+              </p>
+              <p className="font-designer-12r text-text-subtle mt-50">
+                레슨을 이동해도 수정분은 유지됩니다. 상단의 변경사항 모두 저장을
+                눌러야 서버에 반영됩니다.
+              </p>
+            </div>
+          )}
+
           <div className="grid grid-cols-3 gap-150">
             <AdminCourseField label="챕터" helper="필수 · 1 이상의 정수">
               <BaseInput
@@ -710,10 +850,7 @@ export default function AdminLessonManagementPageClient({
                 disabled={isLessonFormLocked}
                 value={String(lessonForm.chapterNumber)}
                 onValueChange={(chapterNumber) =>
-                  setLessonForm((prev) => ({
-                    ...prev,
-                    chapterNumber: Number(chapterNumber),
-                  }))
+                  updateLessonForm({ chapterNumber: Number(chapterNumber) })
                 }
               />
             </AdminCourseField>
@@ -729,10 +866,7 @@ export default function AdminLessonManagementPageClient({
                 disabled={isLessonFormLocked}
                 value={String(lessonForm.lessonNumber)}
                 onValueChange={(lessonNumber) =>
-                  setLessonForm((prev) => ({
-                    ...prev,
-                    lessonNumber: Number(lessonNumber),
-                  }))
+                  updateLessonForm({ lessonNumber: Number(lessonNumber) })
                 }
               />
             </AdminCourseField>
@@ -748,10 +882,9 @@ export default function AdminLessonManagementPageClient({
                 disabled={isLessonFormLocked}
                 value={String(lessonForm.estimatedMinutes)}
                 onValueChange={(estimatedMinutes) =>
-                  setLessonForm((prev) => ({
-                    ...prev,
+                  updateLessonForm({
                     estimatedMinutes: Number(estimatedMinutes),
-                  }))
+                  })
                 }
               />
             </AdminCourseField>
@@ -768,9 +901,7 @@ export default function AdminLessonManagementPageClient({
                 value={lessonForm.title}
                 placeholder="1일차 오리엔테이션"
                 maxLength={CLASS_INPUT_LIMITS.lesson.titleMax}
-                onValueChange={(title) =>
-                  setLessonForm((prev) => ({ ...prev, title }))
-                }
+                onValueChange={(title) => updateLessonForm({ title })}
               />
             </AdminCourseField>
             <AdminCourseField
@@ -783,10 +914,7 @@ export default function AdminLessonManagementPageClient({
                 placeholder="레슨 한 줄 소개와 핵심 모먼트를 2줄로 정리해주세요."
                 maxLength={CLASS_INPUT_LIMITS.lesson.descriptionMax}
                 onChange={(event) =>
-                  setLessonForm((prev) => ({
-                    ...prev,
-                    description: event.target.value,
-                  }))
+                  updateLessonForm({ description: event.target.value })
                 }
                 className="border-border-default focus:border-border-brand-default font-designer-14r text-text-default min-h-800 w-full rounded-100 border bg-background-default px-150 py-100 outline-none disabled:bg-background-disabled"
                 rows={2}
@@ -800,11 +928,10 @@ export default function AdminLessonManagementPageClient({
                 disabled={isLessonFormLocked}
                 value={lessonForm.retrospectivePurpose}
                 onChange={(event) =>
-                  setLessonForm((prev) => ({
-                    ...prev,
+                  updateLessonForm({
                     retrospectivePurpose: event.target
                       .value as AdminRetrospectivePurpose,
-                  }))
+                  })
                 }
               >
                 {ADMIN_RETROSPECTIVE_PURPOSE_OPTIONS.map((option) => (
@@ -823,10 +950,7 @@ export default function AdminLessonManagementPageClient({
                   disabled={isLessonFormLocked}
                   value={lessonForm.isFree ? 'true' : 'false'}
                   onChange={(event) =>
-                    setLessonForm((prev) => ({
-                      ...prev,
-                      isFree: event.target.value === 'true',
-                    }))
+                    updateLessonForm({ isFree: event.target.value === 'true' })
                   }
                 >
                   <option value="false">유료 레슨</option>
@@ -841,10 +965,9 @@ export default function AdminLessonManagementPageClient({
                   disabled={isLessonFormLocked}
                   value={lessonForm.isPublished ? 'true' : 'false'}
                   onChange={(event) =>
-                    setLessonForm((prev) => ({
-                      ...prev,
+                    updateLessonForm({
                       isPublished: event.target.value === 'true',
-                    }))
+                    })
                   }
                 >
                   <option value="false">비게시</option>
@@ -883,7 +1006,7 @@ export default function AdminLessonManagementPageClient({
       </section>
 
       <section className="min-h-screen">
-        <div className="mb-125 flex items-center justify-between gap-100">
+        <div className="mb-125 flex items-start justify-between gap-100">
           <div>
             <h2 className="font-designer-24b text-text-default">본문 작성</h2>
             <p className="font-designer-14r text-text-subtle mt-50">
@@ -891,20 +1014,7 @@ export default function AdminLessonManagementPageClient({
               미리보기입니다. unsafe HTML/script와 외부 이미지 scheme은 저장
               정책에서 허용되지 않습니다.
             </p>
-            <p className="font-designer-13r text-text-subtle mt-50">
-              Notion export ZIP 1개를 업로드하면 현재 레슨의 본문만 교체됩니다.
-            </p>
           </div>
-          {lessonFormMode === 'edit' && (
-            <AdminNotionZipImportButton
-              confirmMessage={ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE}
-              disabled={isLessonFormLocked || !editingLessonId}
-              loading={importLessonContentZipMutation.isPending}
-              onSelectFiles={handleImportNotionZip}
-            >
-              Notion ZIP import
-            </AdminNotionZipImportButton>
-          )}
           <div className="font-designer-13r text-text-subtle flex gap-125">
             <span>
               자동 임시저장:{' '}
@@ -921,6 +1031,27 @@ export default function AdminLessonManagementPageClient({
             <span>라인 {getLineCount(lessonForm.content)}</span>
           </div>
         </div>
+
+        {lessonFormMode === 'edit' && (
+          <div className="mb-125">
+            <AdminNotionZipActionCard
+              badgeLabel="본문 교체"
+              buttonLabel="Notion ZIP import"
+              confirmMessage={ADMIN_NOTION_ZIP_SINGLE_IMPORT_CONFIRM_MESSAGE}
+              description="Notion export ZIP 1개를 업로드하면 현재 레슨의 본문만 교체됩니다."
+              bullets={[
+                '제목, 설명, 챕터, 레슨 번호는 유지됩니다.',
+                'ZIP 기준 본문으로 에디터 값이 즉시 갱신됩니다.',
+                '일반 이미지 수동 업로드 기능은 기존처럼 그대로 사용할 수 있습니다.',
+              ]}
+              disabled={isLessonFormLocked || !editingLessonId}
+              loading={importLessonContentZipMutation.isPending}
+              title="현재 레슨 본문 교체"
+              tone="warning"
+              onSelectFiles={handleImportNotionZip}
+            />
+          </div>
+        )}
 
         <div className="grid min-h-screen grid-cols-2 gap-200">
           <div className="border-border-default bg-background-default rounded-150 min-h-screen overflow-hidden border">
@@ -971,9 +1102,7 @@ export default function AdminLessonManagementPageClient({
                     lessonId={editingLessonId}
                     value={lessonForm.content}
                     placeholder="레슨 본문을 작성하세요. 이미지, 코드블록, 표, 링크를 사용할 수 있습니다."
-                    onChange={(content) =>
-                      setLessonForm((prev) => ({ ...prev, content }))
-                    }
+                    onChange={(content) => updateLessonForm({ content })}
                   />
                 )}
               </div>

--- a/src/components/admin/courses/admin-notion-zip-action-card.tsx
+++ b/src/components/admin/courses/admin-notion-zip-action-card.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import AdminNotionZipImportButton from '@/components/admin/courses/admin-notion-zip-import-button';
+import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import Badge from '@/components/common/ui/badge';
+
+interface AdminNotionZipActionCardProps {
+  title: string;
+  description: string;
+  bullets: string[];
+  buttonLabel: string;
+  badgeLabel: string;
+  disabled?: boolean;
+  loading?: boolean;
+  multiple?: boolean;
+  confirmMessage?: string;
+  tone?: 'brand' | 'warning';
+  onSelectFiles: (files: File[]) => void;
+}
+
+export default function AdminNotionZipActionCard({
+  title,
+  description,
+  bullets,
+  buttonLabel,
+  badgeLabel,
+  disabled = false,
+  loading = false,
+  multiple = false,
+  confirmMessage,
+  tone = 'brand',
+  onSelectFiles,
+}: AdminNotionZipActionCardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-125 border px-150 py-125',
+        tone === 'brand' && 'border-border-brand bg-fill-brand-subtle-default',
+        tone === 'warning' &&
+          'border-border-warning bg-fill-warning-subtle-default',
+      )}
+    >
+      <div className="flex items-start justify-between gap-125">
+        <div className="min-w-0">
+          <div className="mb-50 flex flex-wrap items-center gap-50">
+            <Badge color={tone === 'brand' ? 'blue' : 'orange'}>
+              {badgeLabel}
+            </Badge>
+            <h3
+              className={cn(
+                'font-designer-15b',
+                tone === 'brand' ? 'text-text-brand' : 'text-text-warning',
+              )}
+            >
+              {title}
+            </h3>
+          </div>
+          <p className="font-designer-13r text-text-default">{description}</p>
+          <ul className="font-designer-12r text-text-subtle mt-75 flex flex-col gap-25">
+            {bullets.map((bullet) => (
+              <li key={bullet}>• {bullet}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="shrink-0">
+          <AdminNotionZipImportButton
+            multiple={multiple}
+            confirmMessage={confirmMessage}
+            disabled={disabled}
+            loading={loading}
+            onSelectFiles={onSelectFiles}
+          >
+            {buttonLabel}
+          </AdminNotionZipImportButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/course-management/api/admin-course-management-api.ts
+++ b/src/features/admin/course-management/api/admin-course-management-api.ts
@@ -5,6 +5,8 @@ import {
 import type {
   AdminBuilderFeedCurationRequest,
   AdminLessonBatchImportResponse,
+  AdminLessonBatchUpdateRequest,
+  AdminLessonBatchUpdateResponse,
   AdminCompletionMessageRequest,
   AdminCompletionMessageResponse,
   AdminCourseDetailResponse,
@@ -324,6 +326,20 @@ export const bulkUpdateAdminLessons = async ({
     `admin/courses/${courseId}/lessons/bulk`,
     request,
   );
+};
+
+export const batchUpdateAdminLessons = async ({
+  courseId,
+  request,
+}: {
+  courseId: number;
+  request: AdminLessonBatchUpdateRequest;
+}): Promise<AdminLessonBatchUpdateResponse> => {
+  const response = await axiosInstanceV5.patch<
+    ApiBaseResponse<AdminLessonBatchUpdateResponse>
+  >(`admin/courses/${courseId}/lessons/batch`, request);
+
+  return unwrap(response);
 };
 
 export const reorderAdminLessons = async ({

--- a/src/features/admin/course-management/model/admin-course-management-contract.ts
+++ b/src/features/admin/course-management/model/admin-course-management-contract.ts
@@ -277,3 +277,16 @@ export interface AdminLessonBulkUpdateRequest {
   isFree?: boolean;
   isPublished?: boolean;
 }
+
+export interface AdminLessonBatchUpdateItem extends AdminLessonUpdateRequest {
+  lessonId: number;
+}
+
+export interface AdminLessonBatchUpdateRequest {
+  lessons: AdminLessonBatchUpdateItem[];
+}
+
+export interface AdminLessonBatchUpdateResponse {
+  updatedCount: number;
+  lessons: Array<{ lessonId: number }>;
+}

--- a/src/features/admin/course-management/model/use-admin-course-management-query.ts
+++ b/src/features/admin/course-management/model/use-admin-course-management-query.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   createAdminCourse,
+  batchUpdateAdminLessons,
   bulkUpdateAdminLessons,
   createAdminLesson,
   createAdminLessonsFromNotionZips,
@@ -30,6 +31,7 @@ import type {
   AdminCourseListParams,
   AdminCourseUpdateRequest,
   AdminCourseUpsertRequest,
+  AdminLessonBatchUpdateRequest,
   AdminLessonUpsertRequest,
 } from '@/features/admin/course-management/model/admin-course-management-contract';
 import { parseAdminCourseCardTags } from '@/features/admin/course-management/model/admin-course-tag-utils';
@@ -297,6 +299,44 @@ export const useCreateAdminLessonsFromNotionZipsMutation = () => {
       });
     },
     onError: (error) => showNotionZipImportError(error, 'batch'),
+  });
+};
+
+export const useBatchUpdateAdminLessonsMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      courseId,
+      request,
+    }: {
+      courseId: number;
+      request: AdminLessonBatchUpdateRequest;
+    }) => batchUpdateAdminLessons({ courseId, request }),
+    onSuccess: async (response, variables) => {
+      useToastStore
+        .getState()
+        .showToast(
+          `${response.updatedCount}개 레슨을 저장했습니다.`,
+          'success',
+        );
+      await Promise.all(
+        response.lessons.map((lesson) =>
+          queryClient.invalidateQueries({
+            queryKey: adminCourseManagementQueryKeys.lessonDetail(
+              lesson.lessonId,
+            ),
+          }),
+        ),
+      );
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.lessons(variables.courseId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: showMutationError,
   });
 };
 


### PR DESCRIPTION
## 작업 내용
- 어드민 레슨 편집 화면에서 여러 레슨의 수정 draft를 유지하고 `변경사항 모두 저장`으로 일괄 저장할 수 있게 했습니다.
- 현재 레슨 단건 저장과 다건 저장의 dirty 상태를 분리해, 다른 레슨으로 이동해도 이전 레슨 수정분이 사라지지 않게 했습니다.
- Notion ZIP import UI를 공통 카드로 정리하고, 단건 본문 교체와 다건 레슨 추가의 목적/결과를 명확히 분리했습니다.
- 다건 Notion ZIP import 안내 문구를 기존 마지막 레슨 뒤 자동 배치 정책에 맞게 갱신했습니다.

## 변경 이유
- 기존에는 레슨을 하나씩 선택해 저장해야 해서, 여러 레슨을 수정한 뒤 한 번에 저장하면 먼저 수정한 레슨 변경분이 누락될 수 있었습니다.
- Notion ZIP import의 단건/다건 의미가 화면에서 헷갈릴 수 있어, 작업 위치와 안내 문구를 명확히 했습니다.

## 검증 방법
- [x] `yarn biome format --write <modified files>`
- [x] `yarn eslint <modified files> --fix` — 기존 `null` contract 경고만 남고 error 없음
- [x] `yarn typecheck`
- [x] `git diff --check`

## 브랜치 정보
- base: develop
- head: fix/admin-lesson-batch-save
- 기준 range: origin/develop..HEAD

## QA 확인 포인트
- `/admin/courses/{courseId}/lessons`에서 레슨 1 수정 → 레슨 2 수정 → `변경사항 모두 저장` 시 두 레슨 모두 저장되는지 확인합니다.
- 단건 저장(`현재 레슨 저장`)은 현재 선택된 레슨만 저장하고 dirty 표시가 정상 해제되는지 확인합니다.
- Notion ZIP 다건 import는 레슨 추가 영역에서 보이고, 단건 ZIP import는 현재 레슨 본문 교체 영역에서 보이는지 확인합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 여러 레슨의 변경사항을 한 번에 저장하는 일괄 저장 기능 추가
  * 수정된 레슨을 시각적으로 표시하는 배지 추가
  * 개선된 파일 임포트 UI로 더욱 명확한 안내 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->