### PR TITLE
fix: 레슨 돌아보기 선택 artifact 제출 복구

### DIFF
--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-review-form.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-review-form.tsx
@@ -35,6 +35,7 @@ export interface LessonFormData {
 interface LessonFormProps {
   retrospectivePurpose: LessonRetrospectivePurpose;
   retrospectivePrompt?: string;
+  artifactSubmissionRequired: boolean;
   alreadySubmitted: boolean;
   submitting: boolean;
   onSubmit: (data: LessonFormData) => void;
@@ -96,6 +97,7 @@ function SectionTitle({ bold, suffix }: { bold: string; suffix: string }) {
 export function LessonReviewForm({
   retrospectivePurpose,
   retrospectivePrompt,
+  artifactSubmissionRequired,
   alreadySubmitted,
   submitting,
   onSubmit,
@@ -121,12 +123,13 @@ export function LessonReviewForm({
     };
   }, [artifactPreviewUrl]);
 
-  // Backend requires both answers non-blank for all types; artifact required for non-quiz
+  const requiresArtifact = artifactSubmissionRequired && !isQuiz;
+
   const isFormValid =
     starRating > 0 &&
     expectationAnswer.trim().length > 0 &&
     surpriseAnswer.trim().length > 0 &&
-    (isQuiz || !!artifactImageUrl) &&
+    (!requiresArtifact || !!artifactImageUrl) &&
     selectedChips.size >= 2;
 
   const submitDisabled = !isFormValid || submitting || alreadySubmitted;
@@ -212,12 +215,16 @@ export function LessonReviewForm({
         />
       </div>
 
-      {/* Artifact section — PRACTICE_PROOF and ARTIFACT_SHARE (backend requires artifact for !isQuiz) */}
+      {/* Artifact section — render for non-quiz, but require only when API says so */}
       {!isQuiz && (
         <div className="flex flex-col gap-350">
           <SectionTitle
             bold="오늘의 프로젝트 완성 알리기"
-            suffix="이미지는 필수로 등록해주세요(링크는 선택)"
+            suffix={
+              requiresArtifact
+                ? '이미지는 필수로 등록해주세요(링크는 선택)'
+                : '이미지는 선택으로 등록할 수 있어요(링크는 선택)'
+            }
           />
           <div className="flex flex-col gap-200">
             {artifactPreviewUrl ? (

--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx
@@ -105,6 +105,7 @@ export default function LessonPage({
 
   function handleSubmit(formData: LessonFormData) {
     const isQuiz = lesson?.retrospectivePurpose === 'SUBJECTIVE_QUIZ';
+    const requiresArtifact = !!lesson?.artifactSubmissionRequired && !isQuiz;
     submitRetrospective.mutate(
       {
         lessonId,
@@ -112,16 +113,22 @@ export default function LessonPage({
           starRating: formData.starRating || null,
           highlightAnswer: formData.expectationAnswer.trim(),
           unexpectedAnswer: formData.surpriseAnswer.trim(),
-          artifactType: !isQuiz
-            ? formData.artifactImageUrl
-              ? 'SCREENSHOT'
-              : formData.artifactLink
-                ? 'LINK'
-                : null
-            : null,
-          artifactValue: !isQuiz
-            ? (formData.artifactImageUrl ?? formData.artifactLink ?? null)
-            : null,
+          artifactType:
+            requiresArtifact ||
+            formData.artifactImageUrl ||
+            formData.artifactLink
+              ? formData.artifactImageUrl
+                ? 'SCREENSHOT'
+                : formData.artifactLink
+                  ? 'LINK'
+                  : null
+              : null,
+          artifactValue:
+            requiresArtifact ||
+            formData.artifactImageUrl ||
+            formData.artifactLink
+              ? (formData.artifactImageUrl ?? formData.artifactLink ?? null)
+              : null,
           feedback: {
             checklistFlags: formData.checklistFlags,
             freeText: formData.feedbackText,
@@ -224,6 +231,9 @@ export default function LessonPage({
                   lesson?.retrospectivePurpose ?? 'ARTIFACT_SHARE'
                 }
                 retrospectivePrompt={lesson?.retrospectivePrompt}
+                artifactSubmissionRequired={
+                  lesson?.artifactSubmissionRequired ?? false
+                }
                 alreadySubmitted={alreadySubmitted}
                 submitting={submitRetrospective.isPending}
                 onSubmit={handleSubmit}


### PR DESCRIPTION
## 요약
- `artifactSubmissionRequired=false` 인 non-quiz 레슨에서 이미지 첨부를 강제하던 회귀를 수정했습니다.
- backend의 `artifactSubmissionRequired` 계약에 맞춰 제출 버튼 활성화 조건과 제출 payload를 정리했습니다.

## 상세 변경
- `LessonReviewForm`에서 artifact 필수 여부를 `artifactSubmissionRequired && !isQuiz`로 계산
- 선택 artifact 레슨은 이미지 없이도 제출 버튼이 활성화되도록 수정
- 실제 artifact가 없으면 `artifactType`, `artifactValue`를 `null`로 전송하도록 정리

## 검증
- `yarn eslint 'src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-review-form.tsx' 'src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx' --fix`\n- `yarn biome format --write 'src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-review-form.tsx' 'src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx'`\n- `yarn typecheck`\n\n## 참고\n- 현재 Playwright E2E는 `https://test.zeroone.it.kr` 배포 번들을 기준으로 실행되어, 로컬 패치 반영 전에는 동일 실패가 재현됩니다.\n- 이 저장소의 대상 브랜치는 `dev`가 아니라 `develop`입니다.