### PR TITLE
마이페이지 사이드바 탭 구조 재편 및 아이콘 추가

### DIFF
--- a/src/app/(service)/(my)/my-class/page.tsx
+++ b/src/app/(service)/(my)/my-class/page.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import {
+  useGetCourseList,
+  useGetMyGiftEmail,
+} from '@/hooks/queries/course/course-api';
+import type { CourseSummaryResponse } from '@/types/api/course.types';
+
+export default function MyClassPage() {
+  const { data: courses = [] } = useGetCourseList();
+  const { data: giftEmail } = useGetMyGiftEmail();
+
+  return (
+    <div className="flex flex-col gap-600">
+      <h1 className="font-designer-24b text-text-default">마이 클래스</h1>
+
+      <div className="grid grid-cols-1 gap-400 md:grid-cols-2">
+        <AlarmCard />
+        <GiftEmailCard
+          isRegistered={giftEmail?.isRegistered ?? false}
+          email={giftEmail?.email}
+        />
+      </div>
+
+      <section className="flex flex-col gap-400">
+        <h2 className="font-designer-20b text-text-default">
+          참여 중인 클래스
+        </h2>
+        {courses.length > 0 ? (
+          <div className="grid grid-cols-1 gap-400 md:grid-cols-2">
+            {courses.map((course) => (
+              <CourseCard key={course.courseId} course={course} />
+            ))}
+          </div>
+        ) : (
+          <p className="font-designer-14r text-text-subtle">
+            참여 중인 클래스가 없습니다.
+          </p>
+        )}
+      </section>
+
+      <hr className="border-border-subtle" />
+
+      <section className="flex flex-col gap-400">
+        <h2 className="font-designer-20b text-text-default">완주한 클래스</h2>
+        {/* TODO: completed courses API not yet available */}
+        <p className="font-designer-14r text-text-subtle">
+          완주한 클래스가 없습니다.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+function AlarmCard() {
+  return (
+    <div className="flex flex-col gap-200 rounded-200 border border-border-subtle p-400">
+      <div className="flex flex-col gap-100">
+        <h3 className="font-designer-16b text-text-default">
+          매일 학습 알림톡 시간
+        </h3>
+        <p className="font-designer-14r text-text-subtle">
+          학습이 가장 잘 챙겨지는 시간으로 알림톡을 받아보세요.
+        </p>
+      </div>
+      <p className="font-designer-14m text-text-subtle">
+        현재 지정된 시간이 없습니다.
+      </p>
+      {/* TODO: alarm time API not yet available */}
+      <button
+        type="button"
+        disabled
+        className={cn(
+          'mt-100 w-fit rounded-100 px-300 py-150',
+          'font-designer-14m cursor-not-allowed bg-gray-200 text-text-subtle opacity-50',
+        )}
+      >
+        시간 수정하기
+      </button>
+    </div>
+  );
+}
+
+function GiftEmailCard({
+  isRegistered,
+  email,
+}: {
+  isRegistered: boolean;
+  email?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-200 rounded-200 border border-rose-200 bg-rose-50 p-400">
+      <div className="flex flex-col gap-100">
+        <h3 className="font-designer-16b text-text-default">
+          Claude Pro Gift 메일
+        </h3>
+        <p className="font-designer-14r text-text-subtle">
+          {isRegistered
+            ? `Gift 메일 발송이 완료되었습니다.${email ? ` (${email})` : ''}`
+            : '현재 등록된 메일이 없습니다.'}
+        </p>
+      </div>
+      <Link
+        href="/class"
+        className={cn(
+          'mt-100 w-fit rounded-100 px-300 py-150',
+          'font-designer-14m bg-primary-500 text-white',
+        )}
+      >
+        메일 확인 하러가기
+      </Link>
+    </div>
+  );
+}
+
+function CourseCard({ course }: { course: CourseSummaryResponse }) {
+  return (
+    <Link
+      href={`/class/${course.slug}`}
+      className="overflow-hidden rounded-200 border border-border-subtle"
+    >
+      <div className="relative aspect-[2/1] w-full bg-gray-200">
+        {course.thumbnailUrl && (
+          <Image
+            src={course.thumbnailUrl}
+            alt={course.title}
+            fill
+            className="object-cover"
+          />
+        )}
+      </div>
+      <div className="p-300">
+        <h3 className="font-designer-18b text-text-default">{course.title}</h3>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/common/layout/sidebar/my-page-mobile-nav.tsx
+++ b/src/components/common/layout/sidebar/my-page-mobile-nav.tsx
@@ -6,10 +6,10 @@ import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 
 const NAV_ITEMS = [
   { href: '/my-page', label: '프로필' },
-  { href: '/notification', label: '알림' },
-  { href: '/my-activity', label: '내 활동' },
-  { href: '/my-study', label: '마이스터디' },
-  { href: '/my-study-review', label: '스터디 후기', prefixMatch: true },
+  { href: '/my-class', label: '마이 클래스' },
+  { href: '/my-posts', label: '내가 작성한 글', prefixMatch: true },
+  { href: '/my-inquiry', label: '1:1 문의', prefixMatch: true },
+  { href: '/builder-letter', label: '빌더 레터', prefixMatch: true },
   { href: '/payment-management', label: '결제 관리' },
 ];
 

--- a/src/components/common/layout/sidebar/my-page-sidebar.tsx
+++ b/src/components/common/layout/sidebar/my-page-sidebar.tsx
@@ -1,72 +1,66 @@
 'use client';
 
+import {
+  BookOpen,
+  CreditCard,
+  FileEdit,
+  LogOut,
+  Mail,
+  PenLine,
+  User,
+  type LucideIcon,
+} from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
-import { useAuthReady } from '@/features/auth/model/use-auth';
 import { useLogoutMutation } from '@/hooks/queries/auth/use-auth-mutation';
-import { useUserProfileQuery } from '@/hooks/queries/user/use-user-profile-query';
+
+const NAV_ITEMS: {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  prefixMatch?: boolean;
+}[] = [
+  { href: '/my-page', label: '프로필', icon: User },
+  { href: '/my-class', label: '마이 클래스', icon: BookOpen },
+  {
+    href: '/my-posts',
+    label: '내가 작성한 글',
+    icon: PenLine,
+    prefixMatch: true,
+  },
+  { href: '/my-inquiry', label: '1:1 문의', icon: FileEdit, prefixMatch: true },
+  {
+    href: '/builder-letter',
+    label: '빌더 레터',
+    icon: Mail,
+    prefixMatch: true,
+  },
+  { href: '/payment-management', label: '결제 관리', icon: CreditCard },
+];
 
 export default function Sidebar() {
   const router = useRouter();
   const pathname = usePathname();
-
-  const { memberId } = useAuthReady();
   const { mutateAsync: logout } = useLogoutMutation();
-
-  const { data: profile } = useUserProfileQuery(memberId ?? 0);
-
-  const handleLogout = async () => {
-    await logout();
-  };
 
   return (
     <div className="border-border-subtle box-border hidden w-[300px] flex-col gap-150 border-x-1 px-300 pt-500 lg:flex">
-      <SidebarItem
-        onClick={() => router.push('/my-page')}
-        isActive={pathname === '/my-page'}
-      >
-        프로필
-      </SidebarItem>
-      <SidebarItem
-        onClick={() => router.push('/notification')}
-        isActive={pathname === '/notification'}
-      >
-        알림
-      </SidebarItem>
-      <SidebarItem
-        onClick={() => router.push('/my-activity')}
-        isActive={pathname === '/my-activity'}
-      >
-        내 활동
-      </SidebarItem>
-      <SidebarItem
-        onClick={() => router.push('/my-study')}
-        isActive={pathname === '/my-study'}
-      >
-        마이스터디
-      </SidebarItem>
-      <SidebarItem
-        onClick={() => router.push('/my-study-review')}
-        isActive={pathname.startsWith('/my-study-review')}
-      >
-        스터디 후기
-      </SidebarItem>
-      <SidebarItem
-        onClick={() => router.push('/payment-management')}
-        isActive={pathname === '/payment-management'}
-      >
-        결제 관리
-      </SidebarItem>
-      {profile?.premiumCreator && (
+      {NAV_ITEMS.map((item) => (
         <SidebarItem
-          onClick={() => router.push('/settlement-management')}
-          isActive={pathname === '/settlement-management'}
+          key={item.href}
+          onClick={() => router.push(item.href)}
+          isActive={
+            item.prefixMatch
+              ? pathname.startsWith(item.href)
+              : pathname === item.href
+          }
+          icon={item.icon}
         >
-          정산 관리
+          {item.label}
         </SidebarItem>
-      )}
+      ))}
       <div className="bg-border-subtlest h-[1px]" />
-      <SidebarItem onClick={handleLogout} isActive={false}>
+      <SidebarItem onClick={() => logout()} isActive={false} icon={LogOut}>
         로그아웃
       </SidebarItem>
     </div>
@@ -77,21 +71,26 @@ function SidebarItem({
   children,
   isActive,
   onClick,
+  icon: Icon,
 }: {
   children: React.ReactNode;
   isActive: boolean;
   onClick: () => void;
+  icon: LucideIcon;
 }) {
   return (
-    <div className="flex py-[14px] pr-150 pl-150">
+    <div className="flex py-175 pr-150 pl-150">
       <button
         type="button"
         onClick={onClick}
         className={cn(
-          'font-designer-18m text-text-default cursor-pointer',
-          isActive && 'font-designer-18b text-text-default',
+          'flex cursor-pointer items-center gap-250',
+          isActive
+            ? 'font-designer-18b text-text-default'
+            : 'font-designer-18m text-text-subtle',
         )}
       >
+        <Icon size={24} />
         {children}
       </button>
     </div>


### PR DESCRIPTION
알림/내 활동/마이스터디/스터디 후기/정산관리 탭 제거,
마이 클래스/내가 작성한 글/1:1 문의/빌더 레터로 교체.
SidebarItem에 lucide-react 아이콘 추가 및 py-[14px] → py-175 토큰 수정.

### 🌱 연관된 이슈

<!-- 관련 이슈를 적어주세요 -->

### ☘️ 작업 내용

<!-- 작업한 내용을 적어주세요 -->

### 🍀 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

#### 🎨 디자인 비교 (UI 컴포넌트 PR에만 작성)

<!-- /design-to-dev 실행 시 자동 첨부됩니다 -->

| Figma 원본 | Storybook 구현 |
|-----------|--------------|
| -         | -            |

<details>
<summary>비교 결과</summary>

| 항목 | 상태 | 비고 |
|------|------|------|
| 색상 | ✅ | |
| 간격 | ✅ | |
| 타이포그래피 | ✅ | |
| 반경 | ✅ | |
| 트랜스폼 | ✅ | |

</details>

#### 스크린샷 (선택)
