### PR TITLE
유저 프로필 모달 전체 연결 main 반영

### DIFF
--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-builder-feed-card.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-builder-feed-card.tsx
@@ -94,6 +94,7 @@ export function LessonBuilderFeedCard({ feeds, onSelectFeed }: Props) {
                   type="button"
                   className="cursor-pointer"
                   aria-label={`${current.author.nickname} 프로필 보기`}
+                  onClick={(e) => e.stopPropagation()}
                 >
                   <AuthorAvatar nickname={current.author.nickname} />
                 </button>

--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-builder-feed-card.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-builder-feed-card.tsx
@@ -1,8 +1,14 @@
 'use client';
 
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import { useState } from 'react';
+
+const UserProfileModal = dynamic(
+  () => import('@/components/common/modals/user-profile-modal'),
+  { ssr: false },
+);
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import {
   FeedCommentIcon,
@@ -81,7 +87,18 @@ export function LessonBuilderFeedCard({ feeds, onSelectFeed }: Props) {
           className="flex flex-col gap-150 text-left disabled:cursor-default"
         >
           <div className="flex items-center gap-125">
-            <AuthorAvatar nickname={current.author.nickname} />
+            <UserProfileModal
+              memberId={current.author.memberId}
+              trigger={
+                <button
+                  type="button"
+                  className="cursor-pointer"
+                  aria-label={`${current.author.nickname} 프로필 보기`}
+                >
+                  <AuthorAvatar nickname={current.author.nickname} />
+                </button>
+              }
+            />
             <div className="flex flex-col">
               <div className="flex items-center gap-50">
                 <p className="font-designer-14b text-gray-800">

--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-builder-feed-detail-modal.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-builder-feed-detail-modal.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { Heart, MessageCircle, X } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
+
+const UserProfileModal = dynamic(
+  () => import('@/components/common/modals/user-profile-modal'),
+  { ssr: false },
+);
 import MarkdownContentCore from '@/components/common/ui/rich-text/markdown-content-core';
 import {
   AuthorAvatar,
@@ -54,7 +60,18 @@ export function LessonBuilderFeedDetailModal({ feedId, onClose }: Props) {
               {/* Author row */}
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-150">
-                  <AuthorAvatar nickname={feed.author.nickname} />
+                  <UserProfileModal
+                    memberId={feed.author.memberId}
+                    trigger={
+                      <button
+                        type="button"
+                        className="cursor-pointer"
+                        aria-label={`${feed.author.nickname} 프로필 보기`}
+                      >
+                        <AuthorAvatar nickname={feed.author.nickname} />
+                      </button>
+                    }
+                  />
                   <div className="flex flex-col">
                     <div className="flex items-center gap-50">
                       <p className="font-designer-14b text-gray-800">

--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-qna-detail-modal.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-qna-detail-modal.tsx
@@ -8,6 +8,7 @@ import {
   ThumbsUp,
   X,
 } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import { useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
@@ -30,6 +31,11 @@ import type {
   LessonQnaDetailResponse,
 } from '@/types/api/course.types';
 import { analyzeError } from '@/utils/error-handler';
+
+const UserProfileModal = dynamic(
+  () => import('@/components/common/modals/user-profile-modal'),
+  { ssr: false },
+);
 
 interface Props {
   qnaId: number | null;
@@ -218,7 +224,22 @@ function QuestionSection({ qna, onDeleted }: QuestionSectionProps) {
 
       {/* Author row */}
       <div className="mb-300 flex items-center gap-150">
-        <UserAvatar image={undefined} size={34} alt={qna.author.nickname} />
+        <UserProfileModal
+          memberId={qna.author.memberId}
+          trigger={
+            <button
+              type="button"
+              className="cursor-pointer"
+              aria-label={`${qna.author.nickname} 프로필 보기`}
+            >
+              <UserAvatar
+                image={undefined}
+                size={34}
+                alt={qna.author.nickname}
+              />
+            </button>
+          }
+        />
         <div className="flex flex-1 items-center gap-50">
           <p className="font-designer-14m text-gray-800">
             {qna.author.nickname}
@@ -510,7 +531,22 @@ function AnswerItem({ answer, qnaId }: AnswerItemProps) {
 
       {/* Answerer row */}
       <div className="flex items-center gap-150">
-        <UserAvatar image={undefined} size={34} alt={answer.author.nickname} />
+        <UserProfileModal
+          memberId={answer.author.memberId}
+          trigger={
+            <button
+              type="button"
+              className="cursor-pointer"
+              aria-label={`${answer.author.nickname} 프로필 보기`}
+            >
+              <UserAvatar
+                image={undefined}
+                size={34}
+                alt={answer.author.nickname}
+              />
+            </button>
+          }
+        />
         <div className="flex flex-1 items-center gap-50">
           <p className="font-designer-14m text-gray-800">
             {answer.author.nickname}

--- a/src/components/common/modals/user-profile-modal.tsx
+++ b/src/components/common/modals/user-profile-modal.tsx
@@ -1,26 +1,10 @@
 'use client';
 
 import { XIcon } from 'lucide-react';
-import { useParams } from 'next/navigation';
-import { useState, useMemo } from 'react';
-import KeywordReview from '@/components/common/cards/keyword-review';
-import ProfileInfoCard from '@/components/common/cards/profile-info-card';
+import { useState } from 'react';
 import UserAvatar from '@/components/common/ui/avatar';
-import Badge from '@/components/common/ui/badge';
 import { Modal } from '@/components/common/ui/modal';
-import CakeIcon from '@/components/my-page/icon/cake.svg';
-import GithubIcon from '@/components/my-page/icon/github-logo.svg';
-import GlobeIcon from '@/components/my-page/icon/globe-simple.svg';
-import PhoneIcon from '@/components/my-page/icon/phone.svg';
-import TechStackIcon from '@/components/my-page/icon/tech-stack.svg';
-import VerifiedCheckIcon from '@/components/my-page/icon/verified-check.svg';
-import { getSincerityPresetByLevelName } from '@/config/sincerity-temp-presets';
-import { useAuthReady } from '@/features/auth/model/use-auth';
-import { useApplicantsByStatusQuery } from '@/hooks/queries/group-study/use-applicant-query';
-import { useUserPositiveKeywordsQuery } from '@/hooks/queries/group-study/use-review-query';
 import { useUserProfileQuery } from '@/hooks/queries/user/use-user-profile-query';
-import { AUTH_ROLE_IDS } from '@/types/auth/domain';
-import { formatPhoneNumber } from '@/utils/format';
 
 interface UserProfileModalProps {
   memberId: number;
@@ -60,46 +44,6 @@ function UserProfileBody({
   onClose: () => void;
 }) {
   const { data: profile, isLoading, isError } = useUserProfileQuery(memberId);
-  const { data: positiveKeywordsData } = useUserPositiveKeywordsQuery({
-    memberId,
-  });
-  const {
-    data: authData,
-    isAuthReady,
-    memberId: authMemberId,
-  } = useAuthReady();
-  const isAdmin =
-    isAuthReady && authData?.roleIds.includes(AUTH_ROLE_IDS.ADMIN) === true;
-  const isMe = isAuthReady && authMemberId === memberId;
-
-  //  같은 스터디 참가자 여부 확인
-  const params = useParams();
-  const groupStudyId = params?.id ? Number(params.id) : undefined;
-
-  const { data: approvedApplicantsData } = useApplicantsByStatusQuery({
-    groupStudyId: groupStudyId ?? 0,
-    status: 'APPROVED',
-  });
-
-  const isSameStudyMember = useMemo(() => {
-    // 열람자(currentMemberId)가 이 스터디의 승인된 멤버인지 확인
-    if (
-      !groupStudyId ||
-      !approvedApplicantsData?.pages ||
-      typeof authMemberId !== 'number'
-    )
-      return false;
-    const approvedApplicants = approvedApplicantsData.pages.flatMap(
-      (page) => page.content,
-    );
-
-    return approvedApplicants.some(
-      (apply) => apply.applicantInfo.memberId === authMemberId,
-    );
-  }, [authMemberId, groupStudyId, approvedApplicantsData]);
-
-  // 최종 이름, 전화번호 표시 가능 여부
-  const canSeePhoneNumber = isMe || isAdmin || isSameStudyMember;
 
   if (isLoading) {
     return (
@@ -110,7 +54,7 @@ function UserProfileBody({
     );
   }
 
-  if (isError || !profile || !positiveKeywordsData) {
+  if (isError || !profile) {
     return (
       <>
         <Header title="프로필" onClose={onClose} />
@@ -119,200 +63,72 @@ function UserProfileBody({
     );
   }
 
-  const positiveKeywords = positiveKeywordsData.keywords ?? [];
-  const temperPreset = getSincerityPresetByLevelName(
-    profile.sincerityTemp.levelName,
-  );
+  const nickname = profile.memberProfile.nickname ?? '익명';
+  const avatarImage =
+    profile.memberProfile.profileImage?.resizedImages[0]?.resizedImageUrl;
+  const isBuilder = profile.premiumCreator === true;
+  const jobDescription = profile.memberInfo.jobs?.[0]?.description;
+  const careerDescription = profile.memberInfo.career?.description;
+  const subtitle = [jobDescription, careerDescription]
+    .filter(Boolean)
+    .join(' · ');
 
   return (
     <>
-      <Header
-        title={`${profile.memberProfile.nickname ?? '익명'}님의 프로필`}
-        onClose={onClose}
-      />
+      <Header title={`${nickname}님의 프로필`} onClose={onClose} />
 
       <Modal.Body className="flex flex-col gap-400 p-400">
-        <div className="flex flex-col gap-300 px-200 sm:flex-row">
-          <UserAvatar
-            image={
-              profile.memberProfile.profileImage?.resizedImages[0]
-                .resizedImageUrl
-            }
-            size={80}
-          />
-
-          <div className="min-w-0 w-full">
-            <div className="flex flex-wrap gap-75 pb-75">
-              {profile.memberProfile.mbti && (
-                <Badge color="orange">{profile.memberProfile.mbti}</Badge>
-              )}
-              {profile.memberProfile.interests.slice(0, 4).map((interest) => (
-                <Badge key={interest.id} color="purple">
-                  {interest.name}
-                </Badge>
-              ))}
-            </div>
-
-            <div className="flex items-center justify-start">
-              <div className="font-designer-28b flex items-center gap-50 pb-50">
-                {profile.memberProfile.nickname}
-                {/* 본인 인증 배지 (인증된 경우에만 표시) */}
-                {profile.isVerified && (
-                  <VerifiedCheckIcon className="shrink-0" />
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-300">
+            <UserAvatar image={avatarImage} size={64} className="shrink-0" />
+            <div className="min-w-0">
+              <div className="flex items-center gap-100">
+                <span className="font-designer-14b text-text-strong">
+                  {nickname}
+                </span>
+                {isBuilder && (
+                  <span className="font-designer-12b bg-brand-primary-500 inline-flex h-250 w-250 shrink-0 items-center justify-center rounded-full text-white">
+                    B
+                  </span>
                 )}
               </div>
-
-              <span
-                className="bg-border-default mx-150 block h-[12px] w-[1px]"
-                aria-hidden="true"
-              />
-
-              <div className="flex items-center">
-                <temperPreset.Icon className="h-400 w-400" />
-                <span
-                  className={`${temperPreset.textClass} font-designer-14b pl-[2px]`}
-                >
-                  {profile.sincerityTemp.temperature.toFixed(1)} ℃
-                </span>
-              </div>
-            </div>
-
-            <div className="font-designer-15m pb-300">
-              {profile.memberProfile.simpleIntroduction}
-            </div>
-
-            <div className="grid grid-cols-2 gap-x-250 gap-y-100">
-              <Field
-                icon={<CakeIcon />}
-                value={profile.memberProfile.birthDate}
-              />
-              <Field
-                icon={<TechStackIcon />}
-                value={
-                  profile.memberProfile.techStacks?.length > 0
-                    ? profile.memberProfile.techStacks
-                        .map((tech) => tech.techStackName)
-                        .join(', ')
-                    : undefined
-                }
-              />
-              <Field
-                icon={<GithubIcon />}
-                value={profile.memberProfile.githubLink?.url}
-              />
-              <Field
-                icon={<GlobeIcon />}
-                value={profile.memberProfile.blogOrSnsLink?.url}
-              />
-              {/* 본인, 운영진, 스터디 참가자에게 노출 */}
-              {canSeePhoneNumber && profile.isVerified && (
-                <div className="flex items-center gap-100">
-                  <Field
-                    icon={<PhoneIcon />}
-                    value={formatPhoneNumber(profile.memberProfile.tel)}
-                  />
-                  <Badge color="green" shape="rectangle">
-                    인증완료
-                  </Badge>
-                </div>
+              {subtitle && (
+                <p className="font-designer-12m text-text-subtle mt-50">
+                  {subtitle}
+                </p>
               )}
             </div>
           </div>
-        </div>
 
-        <div className="flex flex-col gap-200">
-          <ProfileInfoCard
-            title="자기소개"
-            content={profile.memberInfo.selfIntroduction ?? '없음'}
-          />
-          <ProfileInfoCard
-            title="공부 주제 및 계획"
-            content={profile.memberInfo.studyPlan ?? '없음'}
-          />
-          <ProfileInfoCard
-            title="선호하는 스터디 주제"
-            content={profile.memberInfo.preferredStudySubject?.name ?? '없음'}
-          />
-          <ProfileInfoCard
-            title="가능 시간대"
-            content={
-              profile.memberInfo.availableStudyTimes &&
-              profile.memberInfo.availableStudyTimes.length > 0
-                ? profile.memberInfo.availableStudyTimes
-                    .map((time) => time.fullLabel)
-                    .join(', ')
-                : '없음'
-            }
-          />
-          <ProfileInfoCard
-            title="직무"
-            content={
-              profile.memberInfo.jobs && profile.memberInfo.jobs.length > 0
-                ? profile.memberInfo.jobs
-                    .map((job) => job.description || job.job || '')
-                    .filter(Boolean)
-                    .join(', ')
-                : '없음'
-            }
-          />
-          <ProfileInfoCard
-            title="경력"
-            content={
-              profile.memberInfo.career
-                ? profile.memberInfo.career.description ||
-                  profile.memberInfo.career.career ||
-                  '없음'
-                : '없음'
-            }
-          />
-          <ProfileInfoCard
-            title="스터디 형태"
-            content={
-              profile.memberInfo.studyFormatTypes &&
-              profile.memberInfo.studyFormatTypes.length > 0
-                ? profile.memberInfo.studyFormatTypes
-                    .map(
-                      (studyFormatType) =>
-                        studyFormatType.description ||
-                        studyFormatType.studyFormatType,
-                    )
-                    .join(', ')
-                : '없음'
-            }
-          />
-          <ProfileInfoCard
-            title="스터디 목표"
-            content={profile.memberInfo.goal ?? '없음'}
-          />
-        </div>
-
-        <div className="bg-border-subtle h-[2px] w-full flex-none" />
-
-        <div className="flex gap-400 pl-250">
-          <span className="font-designer-16b text-text-default w-[132px] shrink-0">
-            받은 평가
-          </span>
-
-          <div className="text-text-default font-designer-14r grow-1">
-            {/* todo: 기획 fix되면 수정 */}
-            {/* <span>n명의 유저들이 이런 점이 좋다고 했어요.</span> */}
-            <ul className="flex flex-col gap-100">
-              {positiveKeywords.length > 0 ? (
-                positiveKeywords.map((keyword) => (
-                  <KeywordReview
-                    key={keyword.id}
-                    content={keyword.content}
-                    count={keyword.count}
-                  />
-                ))
-              ) : (
-                <span className="text-text-subtle font-designer-14r">
-                  아직 받은 평가가 없습니다.
-                </span>
-              )}
-            </ul>
+          <div className="flex shrink-0 items-start gap-1125">
+            <StatItem label="빌더피드" count={0} />
+            <StatItem label="팔로워" count={0} />
+            <StatItem label="팔로잉" count={0} />
           </div>
         </div>
+
+        <button
+          type="button"
+          disabled
+          className="bg-brand-primary-500 font-designer-16b h-775 w-full cursor-not-allowed rounded-100 text-white opacity-60"
+        >
+          팔로우
+        </button>
+
+        {profile.memberProfile.simpleIntroduction && (
+          <p className="font-designer-15r text-text-default leading-300">
+            {profile.memberProfile.simpleIntroduction}
+          </p>
+        )}
+
+        {profile.memberInfo.goal && (
+          <p className="font-designer-15r text-text-default">
+            <span className="font-designer-15b text-text-strong">
+              만들어보고 싶은 것{' '}
+            </span>
+            {profile.memberInfo.goal}
+          </p>
+        )}
       </Modal.Body>
     </>
   );
@@ -331,17 +147,13 @@ function Header({ title, onClose }: { title: string; onClose: () => void }) {
   );
 }
 
-function Field({ icon, value }: { icon: React.ReactNode; value?: string }) {
-  const displayValue = value?.trim();
-
+function StatItem({ label, count }: { label: string; count: number }) {
   return (
-    <div className="flex items-center gap-100">
-      {icon}
-      {displayValue ? (
-        <span className="font-designer-14r text-text-subtle min-w-0 break-all leading-none">
-          {displayValue}
-        </span>
-      ) : null}
+    <div className="flex flex-col items-center gap-50">
+      <span className="font-designer-22m text-text-strong">
+        {count.toLocaleString()}
+      </span>
+      <span className="font-designer-14r text-text-subtle">{label}</span>
     </div>
   );
 }

--- a/src/components/common/modals/user-profile-modal.tsx
+++ b/src/components/common/modals/user-profile-modal.tsx
@@ -99,12 +99,6 @@ function UserProfileBody({
               )}
             </div>
           </div>
-
-          <div className="flex shrink-0 items-start gap-1125">
-            <StatItem label="빌더피드" count={0} />
-            <StatItem label="팔로워" count={0} />
-            <StatItem label="팔로잉" count={0} />
-          </div>
         </div>
 
         <button
@@ -144,16 +138,5 @@ function Header({ title, onClose }: { title: string; onClose: () => void }) {
         <XIcon />
       </Modal.Close>
     </Modal.Header>
-  );
-}
-
-function StatItem({ label, count }: { label: string; count: number }) {
-  return (
-    <div className="flex flex-col items-center gap-50">
-      <span className="font-designer-22m text-text-strong">
-        {count.toLocaleString()}
-      </span>
-      <span className="font-designer-14r text-text-subtle">{label}</span>
-    </div>
   );
 }

--- a/src/features/community/ui/community-author-name-trigger.tsx
+++ b/src/features/community/ui/community-author-name-trigger.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import UserAvatar from '@/components/common/ui/avatar';
 
 const UserProfileModal = dynamic(
   () => import('@/components/common/modals/user-profile-modal'),
@@ -12,32 +13,48 @@ interface CommunityAuthorNameTriggerProps {
   memberId?: number;
   name: string;
   className?: string;
+  image?: string;
+  imageSize?: number;
 }
 
 export default function CommunityAuthorNameTrigger({
   memberId,
   name,
   className,
+  image,
+  imageSize = 20,
 }: CommunityAuthorNameTriggerProps) {
   if (typeof memberId !== 'number') {
-    return <span className={cn(className)}>{name}</span>;
+    if (!image) return <span className={cn(className)}>{name}</span>;
+    return (
+      <span className="flex items-center gap-75">
+        <UserAvatar image={image} size={imageSize} />
+        <span className={cn(className)}>{name}</span>
+      </span>
+    );
   }
 
-  return (
-    <UserProfileModal
-      memberId={memberId}
-      trigger={
-        <button
-          type="button"
-          aria-label={`${name} 프로필 보기`}
-          className={cn(
-            'cursor-pointer rounded-50 text-left transition-colors hover:text-text-brand focus-visible:text-text-brand focus-visible:outline-none',
-            className,
-          )}
-        >
-          {name}
-        </button>
-      }
-    />
+  const trigger = image ? (
+    <button
+      type="button"
+      aria-label={`${name} 프로필 보기`}
+      className="flex cursor-pointer items-center gap-75 rounded-50 transition-colors hover:opacity-80 focus-visible:outline-none"
+    >
+      <UserAvatar image={image} size={imageSize} />
+      <span className={cn(className)}>{name}</span>
+    </button>
+  ) : (
+    <button
+      type="button"
+      aria-label={`${name} 프로필 보기`}
+      className={cn(
+        'cursor-pointer rounded-50 text-left transition-colors hover:text-text-brand focus-visible:text-text-brand focus-visible:outline-none',
+        className,
+      )}
+    >
+      {name}
+    </button>
   );
+
+  return <UserProfileModal memberId={memberId} trigger={trigger} />;
 }

--- a/src/features/community/ui/community-author-name-trigger.tsx
+++ b/src/features/community/ui/community-author-name-trigger.tsx
@@ -38,7 +38,7 @@ export default function CommunityAuthorNameTrigger({
     <button
       type="button"
       aria-label={`${name} 프로필 보기`}
-      className="flex cursor-pointer items-center gap-75 rounded-50 transition-colors hover:opacity-80 focus-visible:outline-none"
+      className="flex cursor-pointer items-center gap-75 rounded-50 transition-colors hover:opacity-80 focus-visible:text-text-brand focus-visible:outline-none"
     >
       <UserAvatar image={image} size={imageSize} />
       <span className={cn(className)}>{name}</span>

--- a/src/features/community/ui/community-author-profile-card.tsx
+++ b/src/features/community/ui/community-author-profile-card.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Avatar from '@/components/common/ui/avatar';
 import type { CommunityPost } from '@/types/community/domain';
 import CommunityAuthorNameTrigger from './community-author-name-trigger';
 import { CommunityMemberRoleBadge } from './community-meta-badge';
@@ -16,13 +15,13 @@ export default function CommunityAuthorProfileCard({
 
   return (
     <section className="flex items-start gap-200">
-      <Avatar image={post.authorImage} alt={post.authorName} size={56} />
-
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-100">
           <CommunityAuthorNameTrigger
             memberId={post.authorMemberId}
             name={post.authorName}
+            image={post.authorImage}
+            imageSize={56}
             className="font-designer-20b text-text-strong"
           />
           <CommunityMemberRoleBadge role={post.role} />

--- a/src/features/community/ui/community-comment-item.tsx
+++ b/src/features/community/ui/community-comment-item.tsx
@@ -12,7 +12,6 @@ import {
 } from 'lucide-react';
 import { useEffect, useState, type ReactNode } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
-import Avatar from '@/components/common/ui/avatar';
 import type {
   CommunityComment,
   CommunityCommentReactionSelection,
@@ -121,12 +120,6 @@ export default function CommunityCommentItem({
   return (
     <article className="flex flex-col gap-150">
       <div className="flex items-start gap-150">
-        <Avatar
-          image={comment.authorImage}
-          alt={comment.authorName}
-          size={36}
-        />
-
         <div className="min-w-0 flex-1">
           <div className="relative flex items-start gap-150">
             <div
@@ -139,6 +132,8 @@ export default function CommunityCommentItem({
                 <CommunityAuthorNameTrigger
                   memberId={comment.authorMemberId}
                   name={comment.authorName}
+                  image={comment.authorImage}
+                  imageSize={36}
                   className="font-designer-14b text-text-strong"
                 />
                 <CommunityMemberRoleBadge role={comment.authorRole} />

--- a/src/features/community/ui/community-feed-author-meta.tsx
+++ b/src/features/community/ui/community-feed-author-meta.tsx
@@ -2,7 +2,6 @@
 
 import type { ReactNode } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
-import Avatar from '@/components/common/ui/avatar';
 import type { CommunityMemberRole } from '@/types/community/domain';
 import CommunityAuthorNameTrigger from './community-author-name-trigger';
 import { CommunityMemberRoleBadge } from './community-meta-badge';
@@ -28,14 +27,13 @@ export default function CommunityFeedAuthorMeta({
 }: CommunityFeedAuthorMetaProps) {
   return (
     <div className={cn('flex flex-wrap items-center gap-100', className)}>
-      <span className="flex items-center gap-75">
-        <Avatar image={authorImage} alt={authorName} size={20} />
-        <CommunityAuthorNameTrigger
-          memberId={memberId}
-          name={authorName}
-          className="font-designer-13r text-text-default"
-        />
-      </span>
+      <CommunityAuthorNameTrigger
+        memberId={memberId}
+        name={authorName}
+        image={authorImage}
+        imageSize={20}
+        className="font-designer-13r text-text-default"
+      />
       <CommunityMemberRoleBadge role={role} />
       <span className="font-designer-13r text-text-subtlest">{createdAt}</span>
       {afterDate}

--- a/src/features/community/ui/community-post-card.tsx
+++ b/src/features/community/ui/community-post-card.tsx
@@ -3,7 +3,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import type { MouseEvent } from 'react';
-import Avatar from '@/components/common/ui/avatar';
 import { buildCommunityFeedItemDetailHref } from '@/features/community/model/community-feed-item';
 import { getCommunityPostPreviewText } from '@/features/community/model/community-rich-content';
 import type { CommunityPost } from '@/types/community/domain';
@@ -64,18 +63,13 @@ export default function CommunityPostCard({
             {showBoardBadge ? (
               <CommunityBoardBadge board={post.board} showIcon={false} />
             ) : null}
-            <span className="flex items-center gap-75">
-              <Avatar
-                image={post.authorImage}
-                alt={post.authorName}
-                size={20}
-              />
-              <CommunityAuthorNameTrigger
-                memberId={post.authorMemberId}
-                name={post.authorName}
-                className="font-designer-13r text-text-default"
-              />
-            </span>
+            <CommunityAuthorNameTrigger
+              memberId={post.authorMemberId}
+              name={post.authorName}
+              image={post.authorImage}
+              imageSize={20}
+              className="font-designer-13r text-text-default"
+            />
             <CommunityMemberRoleBadge role={post.role} />
             <span className="font-designer-13r text-text-subtlest">
               {post.createdAt}

--- a/src/features/community/ui/community-qna-author-summary.tsx
+++ b/src/features/community/ui/community-qna-author-summary.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Avatar from '@/components/common/ui/avatar';
 import type { CommunityQnaAuthor } from '@/types/community/qna-domain';
 import CommunityAuthorNameTrigger from './community-author-name-trigger';
 import { CommunityMemberRoleBadge } from './community-meta-badge';
@@ -16,13 +15,13 @@ export default function CommunityQnaAuthorSummary({
 }: CommunityQnaAuthorSummaryProps) {
   return (
     <section className="flex items-center gap-200">
-      <Avatar image={author.profileImageUrl} alt={author.name} size={56} />
-
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-100">
           <CommunityAuthorNameTrigger
             memberId={author.memberId}
             name={author.name}
+            image={author.profileImageUrl}
+            imageSize={56}
             className={nameClassName}
           />
           <CommunityMemberRoleBadge role={author.role} />

--- a/src/features/community/ui/community-qna-comment-item.tsx
+++ b/src/features/community/ui/community-qna-comment-item.tsx
@@ -3,7 +3,6 @@
 import { MoreVertical, PencilLine, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
-import Avatar from '@/components/common/ui/avatar';
 import FieldErrorText from '@/components/common/ui/form/field-error-text';
 import type { CommunityQnaComment } from '@/types/community/qna-domain';
 import CommunityAuthorNameTrigger from './community-author-name-trigger';
@@ -50,12 +49,6 @@ export default function CommunityQnaCommentItem({
   return (
     <article className="flex flex-col gap-150">
       <div className="flex items-start gap-150">
-        <Avatar
-          image={comment.author.profileImageUrl}
-          alt={comment.author.name}
-          size={36}
-        />
-
         <div className="min-w-0 flex-1">
           <div className="relative flex items-start gap-150">
             <div
@@ -69,6 +62,8 @@ export default function CommunityQnaCommentItem({
                 <CommunityAuthorNameTrigger
                   memberId={comment.author.memberId}
                   name={comment.author.name}
+                  image={comment.author.profileImageUrl}
+                  imageSize={36}
                   className="font-designer-14b text-text-strong"
                 />
                 <CommunityMemberRoleBadge role={comment.author.role} />

--- a/src/features/community/ui/community-qna-question-card.tsx
+++ b/src/features/community/ui/community-qna-question-card.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState, type MouseEvent } from 'react';
-import Avatar from '@/components/common/ui/avatar';
 import { buildCommunityQuestionHref } from '@/features/community/model/community-route';
 import {
   COMMUNITY_BOARD,
@@ -123,18 +122,13 @@ export default function CommunityQnaQuestionCard({
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-100">
             <CommunityBoardBadge board={COMMUNITY_BOARD.QNA} showIcon={false} />
-            <span className="flex items-center gap-75">
-              <Avatar
-                image={question.author.profileImageUrl}
-                alt={question.author.name}
-                size={20}
-              />
-              <CommunityAuthorNameTrigger
-                memberId={question.author.memberId}
-                name={question.author.name}
-                className="font-designer-13r text-text-default"
-              />
-            </span>
+            <CommunityAuthorNameTrigger
+              memberId={question.author.memberId}
+              name={question.author.name}
+              image={question.author.profileImageUrl}
+              imageSize={20}
+              className="font-designer-13r text-text-default"
+            />
             <CommunityMemberRoleBadge role={question.author.role} />
             <span className="font-designer-13r text-text-subtlest">
               {question.createdAt}


### PR DESCRIPTION
## Summary

- 커뮤니티(게시글/댓글/QnA), 레슨 빌더피드·QnA 아바타/닉네임 클릭 시 유저 프로필 모달 연결
- 프로필 모달 Figma 디자인 반영 (아바타, 닉네임, 직업/경력, 소개, 목표)
- CodeRabbit 리뷰 반영: 중첩 button 이벤트 충돌 수정, API 미지원 stat(0) 섹션 제거, 포커스 스타일 보완

## Changes

- `lesson-builder-feed-card.tsx` — 아바타 trigger button에 `stopPropagation` 추가 (중첩 button 클릭 충돌 방지)
- `user-profile-modal.tsx` — `GetUserProfileResponse`에 미지원 stat 필드(빌더피드/팔로워/팔로잉) 섹션 제거
- `community-author-name-trigger.tsx` — 이미지 버튼 변형에 `focus-visible:text-text-brand` 추가

## Cherry-pick source

`feat/profile-modal` → PR #647 (develop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)