### PR TITLE
FloatingClassActionButtons 전체 레이아웃 적용

### DIFF
--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx
@@ -4,7 +4,6 @@ import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { use, useEffect, useMemo, useRef, useState } from 'react';
-import FloatingClassActionButtons from '@/components/common/ui/floating-class-action-buttons';
 import MarkdownContentCore from '@/components/common/ui/rich-text/markdown-content-core';
 import {
   useGetCourseDrawer,
@@ -274,7 +273,6 @@ export default function LessonPage({
         feedId={selectedFeedId}
         onClose={() => setSelectedFeedId(null)}
       />
-      <FloatingClassActionButtons />
     </div>
   );
 }

--- a/src/app/(class-lesson)/layout.tsx
+++ b/src/app/(class-lesson)/layout.tsx
@@ -1,4 +1,5 @@
 import { GoogleTagManager } from '@next/third-parties/google';
+import FloatingClassActionButtons from '@/components/common/ui/floating-class-action-buttons';
 import GlobalToast from '@/components/common/ui/global-toast';
 import { createAuthHydrationSession } from '@/features/auth/model/auth-hydration-session';
 import { readServerAuthSession } from '@/features/auth/model/server-auth-session';
@@ -20,6 +21,7 @@ export default async function ClassLessonLayout({
       <MainProvider initialSession={initialHydrationSession}>
         {children}
         <GlobalToast />
+        <FloatingClassActionButtons />
       </MainProvider>
     </>
   );

--- a/src/app/(landing)/class/[slug]/complete/page.tsx
+++ b/src/app/(landing)/class/[slug]/complete/page.tsx
@@ -7,7 +7,6 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
-import FloatingClassActionButtons from '@/components/common/ui/floating-class-action-buttons';
 import {
   useGetCourseCompletionRecap,
   useGetCourseDetail,
@@ -215,8 +214,6 @@ export default function CourseCompletePage() {
           </Link>
         </div>
       </div>
-
-      <FloatingClassActionButtons />
     </>
   );
 }

--- a/src/app/(landing)/class/[slug]/page.tsx
+++ b/src/app/(landing)/class/[slug]/page.tsx
@@ -3,7 +3,6 @@
 import { Flame, History, ThumbsUp } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { use, useMemo, useState } from 'react';
-import FloatingClassActionButtons from '@/components/common/ui/floating-class-action-buttons';
 import { ClassDetailBenefitsSection } from '@/components/pages/class/class-detail-benefits-section';
 import { ClassDetailBuilderFeedSection } from '@/components/pages/class/class-detail-builder-feed-section';
 import {
@@ -274,7 +273,6 @@ export default function ClassDetailPage({
           />
         </div>
       </div>
-      <FloatingClassActionButtons />
     </div>
   );
 }

--- a/src/app/(service)/layout.tsx
+++ b/src/app/(service)/layout.tsx
@@ -7,6 +7,7 @@ import ClarityInit from '@/components/common/analytics/clarity-init';
 import PageViewTracker from '@/components/common/analytics/page-view-tracker';
 import Header from '@/components/common/layout/home-header';
 import SentryInit from '@/components/common/sentry-init';
+import FloatingClassActionButtons from '@/components/common/ui/floating-class-action-buttons';
 import FloatingInquiryButton from '@/components/common/ui/floating-inquiry-button';
 import GlobalToast from '@/components/common/ui/global-toast';
 import { createAuthHydrationSession } from '@/features/auth/model/auth-hydration-session';
@@ -45,6 +46,7 @@ export default async function ServiceLayout({
           <main className="w-full flex-1">{children}</main>
           <FloatingInquiryButton />
         </div>
+        <FloatingClassActionButtons />
       </MainProvider>
     </>
   );

--- a/src/components/pages/class/roadmap-tab.tsx
+++ b/src/components/pages/class/roadmap-tab.tsx
@@ -6,7 +6,6 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
-import FloatingClassActionButtons from '@/components/common/ui/floating-class-action-buttons';
 import {
   LockIcon,
   LockOpenIcon,
@@ -557,8 +556,6 @@ export function RoadmapTab({ slug }: { slug: string }) {
           }}
         />
       )}
-
-      <FloatingClassActionButtons />
 
       {showPlanModal && course?.plans?.[0] && (
         <PlanSelectionModal


### PR DESCRIPTION
## Problem

`FloatingClassActionButtons`(카카오 채널 상담 + TOP 버튼)가 일부 페이지에만 개별적으로 추가되어 있어, 미등록 페이지에서는 버튼이 노출되지 않는 문제가 있었습니다.

또한 같은 레이아웃(`(landing)`) 하위 페이지에서 레이아웃과 개별 페이지 양쪽에 중복 렌더링되는 버그도 존재했습니다.

## Solution

각 route group의 layout 파일에서 일괄 렌더링하는 방식으로 전환했습니다.

- `(landing)/layout.tsx` — 이미 적용되어 있었으므로 유지
- `(service)/layout.tsx` — 추가
- `(class-lesson)/layout.tsx` — 추가
- `(admin)/layout.tsx` — 관리자 UI이므로 제외

레이아웃으로 커버되는 기존 개별 페이지·컴포넌트의 중복 사용은 제거했습니다.

## Changes

### Refactoring
| File | Description |
|------|-------------|
| `src/app/(service)/layout.tsx` | `FloatingClassActionButtons` 추가 |
| `src/app/(class-lesson)/layout.tsx` | `FloatingClassActionButtons` 추가 |
| `src/app/(landing)/class/[slug]/page.tsx` | 중복 사용 제거 |
| `src/app/(landing)/class/[slug]/complete/page.tsx` | 중복 사용 제거 |
| `src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx` | 중복 사용 제거 |
| `src/components/pages/class/roadmap-tab.tsx` | 중복 사용 제거 |

## Result

- 서비스 전체 페이지(`(service)`, `(landing)`, `(class-lesson)`)에서 FloatingClassActionButtons가 일관되게 노출됩니다.
- 개별 페이지에서 중복 렌더링되던 문제가 해결됩니다.
- 이후 신규 페이지 추가 시 별도 작업 없이 자동 적용됩니다.

## Test plan

- [ ] `/` (landing) — 카카오 채널 버튼 · TOP 버튼 노출 확인
- [ ] `/class/[slug]` — 노출 확인 (이전: 개별 렌더링, 현재: 레이아웃)
- [ ] `/class/[slug]/complete` — 노출 확인
- [ ] `/class/[slug]/home` (roadmap-tab) — 노출 확인, 중복 없음 확인
- [ ] `/class/[slug]/lesson/[id]` — 노출 확인 (이전: 개별 렌더링, 현재: 레이아웃)
- [ ] 서비스 페이지 (예: `/home`, `/my-page`) — 신규 노출 확인
- [ ] TOP 버튼 클릭 → 페이지 상단 이동 동작 확인
- [ ] 카카오 채널 링크 → 새 탭으로 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 플로팅 액션 버튼의 렌더링 구조를 재구성하여 개별 페이지에서 상위 레이아웃 레벨로 이동시켰습니다. 이를 통해 여러 섹션에서 일관되게 버튼이 표시되도록 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->