### PR TITLE
[cherry-pick] FloatingClassActionButtons 전체 레이아웃 적용

### DIFF
--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx
@@ -4,7 +4,6 @@ import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { use, useEffect, useMemo, useRef, useState } from 'react';
-import FloatingClassActionButtons from '@/components/common/ui/floating-class-action-buttons';
 import MarkdownContentCore from '@/components/common/ui/rich-text/markdown-content-core';
 import {
   useGetCourseDrawer,
@@ -324,7 +323,6 @@ export default function LessonPage({
         onClose={() => setLinkModalOpen(false)}
         onConfirm={(url) => setArtifactLink(url)}
       />
-      <FloatingClassActionButtons />
     </div>
   );
 }

--- a/src/app/(class-lesson)/layout.tsx
+++ b/src/app/(class-lesson)/layout.tsx
@@ -1,4 +1,5 @@
 import { GoogleTagManager } from '@next/third-parties/google';
+import FloatingClassActionButtons from '@/components/common/ui/floating-class-action-buttons';
 import GlobalToast from '@/components/common/ui/global-toast';
 import { createAuthHydrationSession } from '@/features/auth/model/auth-hydration-session';
 import { readServerAuthSession } from '@/features/auth/model/server-auth-session';
@@ -20,6 +21,7 @@ export default async function ClassLessonLayout({
       <MainProvider initialSession={initialHydrationSession}>
         {children}
         <GlobalToast />
+        <FloatingClassActionButtons />
       </MainProvider>
     </>
   );

--- a/src/app/(landing)/class/[slug]/complete/page.tsx
+++ b/src/app/(landing)/class/[slug]/complete/page.tsx
@@ -7,7 +7,6 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
-import FloatingClassActionButtons from '@/components/common/ui/floating-class-action-buttons';
 import {
   useGetCourseCompletionRecap,
   useGetCourseDetail,
@@ -215,8 +214,6 @@ export default function CourseCompletePage() {
           </Link>
         </div>
       </div>
-
-      <FloatingClassActionButtons />
     </>
   );
 }

--- a/src/app/(landing)/class/[slug]/page.tsx
+++ b/src/app/(landing)/class/[slug]/page.tsx
@@ -3,7 +3,6 @@
 import { Flame, History, ThumbsUp } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { use, useMemo, useState } from 'react';
-import FloatingClassActionButtons from '@/components/common/ui/floating-class-action-buttons';
 import { ClassDetailBenefitsSection } from '@/components/pages/class/class-detail-benefits-section';
 import { ClassDetailBuilderFeedSection } from '@/components/pages/class/class-detail-builder-feed-section';
 import {
@@ -274,7 +273,6 @@ export default function ClassDetailPage({
           />
         </div>
       </div>
-      <FloatingClassActionButtons />
     </div>
   );
 }

--- a/src/app/(service)/layout.tsx
+++ b/src/app/(service)/layout.tsx
@@ -7,6 +7,7 @@ import ClarityInit from '@/components/common/analytics/clarity-init';
 import PageViewTracker from '@/components/common/analytics/page-view-tracker';
 import Header from '@/components/common/layout/home-header';
 import SentryInit from '@/components/common/sentry-init';
+import FloatingClassActionButtons from '@/components/common/ui/floating-class-action-buttons';
 import FloatingInquiryButton from '@/components/common/ui/floating-inquiry-button';
 import GlobalToast from '@/components/common/ui/global-toast';
 import { createAuthHydrationSession } from '@/features/auth/model/auth-hydration-session';
@@ -45,6 +46,7 @@ export default async function ServiceLayout({
           <main className="w-full flex-1">{children}</main>
           <FloatingInquiryButton />
         </div>
+        <FloatingClassActionButtons />
       </MainProvider>
     </>
   );

--- a/src/components/pages/class/roadmap-tab.tsx
+++ b/src/components/pages/class/roadmap-tab.tsx
@@ -6,7 +6,6 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
-import FloatingClassActionButtons from '@/components/common/ui/floating-class-action-buttons';
 import {
   LockIcon,
   LockOpenIcon,
@@ -557,8 +556,6 @@ export function RoadmapTab({ slug }: { slug: string }) {
           }}
         />
       )}
-
-      <FloatingClassActionButtons />
 
       {showPlanModal && course?.plans?.[0] && (
         <PlanSelectionModal


### PR DESCRIPTION
## 개요

개별 페이지 컴포넌트에 분산되어 있던 \`FloatingClassActionButtons\`를 \`(service)\`·\`(class-lesson)\` 레이아웃으로 이동해 DRY 원칙을 적용했습니다. 레이아웃 이동 후 각 페이지의 중복 import/렌더링을 제거했습니다.

## 원본 PR

- develop PR: #650 (https://github.com/code-zero-to-one/study-platform-client/pull/650)
- 원본 브랜치: \`fix/floating-button\`

## Cherry-pick 대상 커밋

- \`556a742\` — [floating-button] refactor : FloatingClassActionButtons를 service·class-lesson 레이아웃으로 이동
- \`fef42ca\` — [floating-button] refactor : 레이아웃으로 이동된 FloatingClassActionButtons 중복 제거

## 변경 파일

- \`src/app/(service)/layout.tsx\` — FloatingClassActionButtons 추가
- \`src/app/(class-lesson)/layout.tsx\` — FloatingClassActionButtons 추가
- \`src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx\` — 중복 import/렌더링 제거
- \`src/app/(landing)/class/[slug]/page.tsx\` — 중복 import/렌더링 제거
- \`src/app/(landing)/class/[slug]/complete/page.tsx\` — 중복 import/렌더링 제거
- \`src/components/pages/class/roadmap-tab.tsx\` — 중복 import/렌더링 제거

## 혼입 검증 결과

\`\`\`
src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx | 2 --
src/app/(class-lesson)/layout.tsx                        | 2 ++
src/app/(landing)/class/[slug]/complete/page.tsx         | 3 ---
src/app/(landing)/class/[slug]/page.tsx                  | 2 --
src/app/(service)/layout.tsx                             | 2 ++
src/components/pages/class/roadmap-tab.tsx               | 3 ---
6 files changed, 4 insertions(+), 10 deletions(-)
\`\`\`

- [x] develop 전용 코드 혼입 없음 (변경 파일이 원본 PR 범위와 일치)

## Test plan

- [ ] \`(service)/layout.tsx\` 하위 페이지(홈, 마이페이지 등)에서 FloatingClassActionButtons 렌더링 확인
- [ ] \`(class-lesson)/layout.tsx\` 하위 레슨 페이지에서 FloatingClassActionButtons 렌더링 확인
- [ ] 중복 제거된 \`class/[slug]/page.tsx\`, \`roadmap-tab.tsx\`에서 버튼 여전히 노출되는지 확인
- [ ] FloatingClassActionButtons · FloatingInquiryButton 두 버튼 간 겹침 없음 (우측 하단 시각 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)