### PR TITLE
[cherry-pick] 레슨 QnA 빌더 질문 카운트 추가 + 탭 스크롤 오프셋 수정

### DIFF
--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-qna-card.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-qna-card.tsx
@@ -136,7 +136,12 @@ export function LessonQnaCard({
       </div>
 
       <div className="flex flex-col gap-150">
-        <p className="font-designer-14b text-gray-1000">빌더들의 질문</p>
+        <div className="flex items-center gap-125">
+          <p className="font-designer-14b text-gray-1000">빌더들의 질문</p>
+          <span className="rounded-100 bg-gray-200 px-100 font-designer-14b text-gray-600">
+            {builderQnas.length}
+          </span>
+        </div>
 
         {builderQnas.length > 0 ? (
           <div className="flex flex-col gap-125">

--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx
@@ -3,7 +3,14 @@
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { use, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type RefObject,
+  use,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import MarkdownContentCore from '@/components/common/ui/rich-text/markdown-content-core';
 import {
   useGetCourseDrawer,
@@ -41,15 +48,24 @@ export default function LessonPage({
 
   const [tab, setTab] = useState<LessonTabValue>('follow');
   const reviewRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const topBarRef = useRef<HTMLDivElement>(null);
+
+  function scrollToRef(ref: RefObject<HTMLDivElement | null>) {
+    if (!ref.current) return;
+    const headerHeight = topBarRef.current?.offsetHeight ?? 64;
+    const top =
+      ref.current.getBoundingClientRect().top +
+      window.scrollY -
+      headerHeight -
+      16;
+    window.scrollTo({ top, behavior: 'smooth' });
+  }
 
   function handleTabChange(next: LessonTabValue) {
     setTab(next);
-    if (next === 'review') {
-      reviewRef.current?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      });
-    }
+    if (next === 'review') scrollToRef(reviewRef);
+    else if (next === 'follow') scrollToRef(contentRef);
   }
   const [starRating, setStarRating] = useState(0);
   const [highlightAnswer, setHighlightAnswer] = useState('');
@@ -184,13 +200,15 @@ export default function LessonPage({
         courseSlug={lesson?.courseSlug ?? slug}
       />
 
-      <LessonTopBar
-        onToggleCurriculum={() => setCurriculumOpen((v) => !v)}
-        curriculumOpen={curriculumOpen}
-        currentLesson={lessonId}
-        totalLessons={totalLessons}
-        courseTitle={courseTitle}
-      />
+      <div ref={topBarRef}>
+        <LessonTopBar
+          onToggleCurriculum={() => setCurriculumOpen((v) => !v)}
+          curriculumOpen={curriculumOpen}
+          currentLesson={lessonId}
+          totalLessons={totalLessons}
+          courseTitle={courseTitle}
+        />
+      </div>
 
       <div className="mx-auto w-full max-w-[1236px] px-300">
         <div className="grid grid-cols-content-sidebar-360 items-start gap-250 pt-500">
@@ -232,7 +250,10 @@ export default function LessonPage({
               <LessonTabs value={tab} onChange={handleTabChange} />
             </div>
 
-            <div className="mt-300 min-h-[964px] rounded-150 bg-background-default p-500">
+            <div
+              ref={contentRef}
+              className="mt-300 min-h-[964px] rounded-150 bg-background-default p-500"
+            >
               {lesson?.contentMarkdown ? (
                 <MarkdownContentCore content={lesson.contentMarkdown} />
               ) : (


### PR DESCRIPTION
## 개요

레슨 QnA 카드에 빌더 질문 개수 배지를 추가하고, 탭 전환 시 sticky 헤더(LessonTopBar)에 콘텐츠가 가려지는 스크롤 오프셋 문제를 수정합니다. \`scrollIntoView\` 대신 \`window.scrollTo\` + 실제 헤더 높이 기반 오프셋 계산으로 교체했습니다.

## 원본 PR

- develop PR: #652 (https://github.com/code-zero-to-one/study-platform-client/pull/652)
- 원본 브랜치: \`fix/lesson-detail\`

## Cherry-pick 대상 커밋

- \`004e227\` — [lesson-detail] feat : 빌더들의 질문 개수 카운트 추가
- \`9e28692\` — [lesson-detail] fix : 탭 클릭 시 sticky 헤더에 가려지는 스크롤 오프셋 수정

## 변경 파일

- \`src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-qna-card.tsx\` — 빌더 질문 개수 배지 렌더링 추가
- \`src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx\` — topBarRef 추가, scrollIntoView → window.scrollTo 오프셋 방식으로 교체

## 혼입 검증 결과

```
git diff main...fix/lesson-detail --stat
→ 171개 파일 (develop 누적 변경)
```

- [x] cherry-pick 커밋 2개는 위 2개 파일만 변경 (`git show --stat` 확인)
- [x] develop 전용 코드 혼입 없음

## Test plan

- [ ] 레슨 상세 페이지(`/class/[slug]/lesson/[id]`) 접속 후 "레슨 돌아보기" 탭 클릭 → 폼 제목이 헤더 아래 여유 있게 표시되는지 확인
- [ ] "따라해보기" 탭 클릭 → 본문 영역으로 헤더 오프셋 포함 스크롤되는지 확인
- [ ] QnA 카드의 "빌더들의 질문" 영역에 질문 개수 배지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)