### PR TITLE
fix: 노션 ZIP 마크다운 렌더링 복구

### DIFF
--- a/src/components/admin/courses/admin-lesson-management-page-client.tsx
+++ b/src/components/admin/courses/admin-lesson-management-page-client.tsx
@@ -735,8 +735,6 @@ export default function AdminLessonManagementPageClient({
                           'border-border-default flex items-start justify-between gap-100 border-b p-125',
                           editingLessonId === lesson.lessonId &&
                             'bg-fill-brand-subtle-default',
-                          recentlyImportedLessonIds.includes(lesson.lessonId) &&
-                            'bg-fill-success-subtle-default',
                         )}
                       >
                         <button
@@ -750,6 +748,9 @@ export default function AdminLessonManagementPageClient({
                           </span>
                           <div className="flex flex-wrap gap-50">
                             <LessonStatusBadges lesson={lesson} />
+                            {recentlyImportedLessonIds.includes(
+                              lesson.lessonId,
+                            ) && <Badge color="green">방금 생성</Badge>}
                             {dirtyLessonIdSet.has(lesson.lessonId) && (
                               <Badge color="orange">수정됨</Badge>
                             )}

--- a/src/components/common/ui/editor/markdown-content.tsx
+++ b/src/components/common/ui/editor/markdown-content.tsx
@@ -7,6 +7,7 @@ import { memo, useEffect, useMemo, useRef } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import { normalizeMarkdownContent } from '@/utils/markdown-content-normalize';
 import { isHtmlContent } from '@/utils/markdown-content-shared';
+import { normalizeMarkdownForRichRendering } from '@/utils/markdown-rendering-utils';
 import hljs from './hljs-setup';
 import {
   applyPostSanitizeAttributes,
@@ -62,9 +63,11 @@ function MarkdownContent({
       return '';
     }
 
-    const isOriginalHtml = isHtmlContent(normalizedContent);
+    const renderableContent =
+      normalizeMarkdownForRichRendering(normalizedContent);
+    const isOriginalHtml = isHtmlContent(renderableContent);
     const normalizedContentWithEmbeds =
-      replaceStandaloneYouTubeLinksWithEmbeds(normalizedContent);
+      replaceStandaloneYouTubeLinksWithEmbeds(renderableContent);
 
     let html: string;
 

--- a/src/components/common/ui/editor/markdown-editor.tsx
+++ b/src/components/common/ui/editor/markdown-editor.tsx
@@ -36,6 +36,10 @@ import { extractImageUrls } from '@/utils/markdown-content-images';
 import { normalizeMarkdownContent } from '@/utils/markdown-content-normalize';
 import { getRichContentVisibleTextLength } from '@/utils/markdown-content-text';
 import {
+  hasRenderableMarkdownSyntax,
+  renderMarkdownToHtml,
+} from '@/utils/markdown-rendering-utils';
+import {
   extractClipboardImageFiles,
   hasClipboardImageHint,
   isClipboardImageOnly,
@@ -406,6 +410,20 @@ function MarkdownEditor({
         if (markdownTable) {
           event.preventDefault();
           insertMarkdownTable(editorInstance, markdownTable);
+          return true;
+        }
+
+        if (
+          !pastedHtml.trim() &&
+          !editorInstance.isActive('codeBlock') &&
+          hasRenderableMarkdownSyntax(pastedText)
+        ) {
+          event.preventDefault();
+          editorInstance
+            .chain()
+            .focus()
+            .insertContent(renderMarkdownToHtml(pastedText))
+            .run();
           return true;
         }
 

--- a/src/components/common/ui/rich-text/markdown-content-core.tsx
+++ b/src/components/common/ui/rich-text/markdown-content-core.tsx
@@ -28,6 +28,7 @@ import {
   replaceStandaloneYouTubeLinksWithEmbeds,
 } from '@/components/common/ui/editor/youtube-utils';
 import { isHtmlContent } from '@/lib/rich-text/markdown-utils';
+import { normalizeMarkdownForRichRendering } from '@/utils/markdown-rendering-utils';
 
 hljs.registerLanguage('kotlin', kotlin);
 hljs.registerLanguage('sql', sql);
@@ -207,8 +208,10 @@ export default function MarkdownContentCore({
       return '';
     }
 
-    const isOriginalHtml = isHtmlContent(content);
-    const contentWithEmbeds = replaceStandaloneYouTubeLinksWithEmbeds(content);
+    const renderableContent = normalizeMarkdownForRichRendering(content);
+    const isOriginalHtml = isHtmlContent(renderableContent);
+    const contentWithEmbeds =
+      replaceStandaloneYouTubeLinksWithEmbeds(renderableContent);
 
     let html: string;
 

--- a/src/features/admin/course-management/model/admin-course-markdown.test.ts
+++ b/src/features/admin/course-management/model/admin-course-markdown.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeAdminCourseMarkdownContent } from './admin-course-markdown';
+
+const signedImageUrl =
+  'https://uploaded-files-qa.32cd2fa416bea795bf67cbf65411103b.r2.cloudflarestorage.com/images/lesson-content/a9e80c53.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc123';
+
+describe('normalizeAdminCourseMarkdownContent', () => {
+  it('converts imported raw markdown into editor-safe HTML', () => {
+    const normalized = normalizeAdminCourseMarkdownContent(
+      [`### 제목`, '', `![image.png](${signedImageUrl})`].join('\n'),
+    );
+
+    expect(normalized).toContain('<h3>');
+    expect(normalized).toContain('<img');
+    expect(normalized).toContain(signedImageUrl);
+  });
+
+  it('repairs TipTap-degraded markdown paragraph HTML', () => {
+    const normalized = normalizeAdminCourseMarkdownContent(
+      `<p>### 제목</p><p>![image.png](${signedImageUrl})</p>`,
+    );
+
+    expect(normalized).toContain('<h3>');
+    expect(normalized).toContain('<img');
+    expect(normalized).toContain(signedImageUrl);
+  });
+
+  it('keeps normal editor HTML as HTML while stripping unsafe attributes', () => {
+    const normalized = normalizeAdminCourseMarkdownContent(
+      '<p class="external" onclick="alert(1)">본문</p><img src="https://example.com/a.png" style="width:100px">',
+    );
+
+    expect(normalized).toBe('<p>본문</p><img src="https://example.com/a.png">');
+  });
+});

--- a/src/features/admin/course-management/model/admin-course-markdown.ts
+++ b/src/features/admin/course-management/model/admin-course-markdown.ts
@@ -1,6 +1,11 @@
 import { COMMUNITY_MARKDOWN_MAX_IMAGE_FILE_SIZE } from '@/types/community/markdown';
 import { normalizeMarkdownContent } from '@/utils/markdown-content-normalize';
 import { isHtmlContent } from '@/utils/markdown-content-shared';
+import {
+  hasRenderableMarkdownSyntax,
+  recoverMarkdownTextFromTextOnlyHtml,
+  renderMarkdownToHtml,
+} from '@/utils/markdown-rendering-utils';
 
 export const ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS = [
   'jpg',
@@ -58,9 +63,49 @@ const ATTRIBUTE_ALLOWLIST_BY_TAG: Record<string, Set<string>> = {
   ul: new Set(),
 };
 
+const HTML_OPEN_TAG_PATTERN = /<([a-z][a-z0-9-]*)(\s[^<>]*?)?>/gi;
+const HTML_ATTRIBUTE_PATTERN =
+  /([^\s=/'"`<>]+)(?:\s*=\s*("[^"]*"|'[^']*'|[^\s"'=<>`]+))?/g;
+
+const stripAttributesFromOpeningTag = (tagName: string, attributes = '') => {
+  const normalizedTagName = tagName.toLowerCase();
+  const allowedAttributes =
+    ATTRIBUTE_ALLOWLIST_BY_TAG[normalizedTagName] ?? new Set();
+  const keptAttributes: string[] = [];
+
+  attributes.replace(
+    HTML_ATTRIBUTE_PATTERN,
+    (match: string, attributeName: string) => {
+      const normalizedAttributeName = attributeName.toLowerCase();
+      if (
+        !GLOBAL_DISALLOWED_ATTRIBUTES.has(normalizedAttributeName) &&
+        !normalizedAttributeName.startsWith('data-') &&
+        !normalizedAttributeName.startsWith('on') &&
+        allowedAttributes.has(normalizedAttributeName)
+      ) {
+        keptAttributes.push(match);
+      }
+
+      return '';
+    },
+  );
+
+  return keptAttributes.length > 0
+    ? `<${normalizedTagName} ${keptAttributes.join(' ')}>`
+    : `<${normalizedTagName}>`;
+};
+
+const stripEditorBreakingAttributesWithoutDom = (html: string) => {
+  return html.replace(
+    HTML_OPEN_TAG_PATTERN,
+    (_match, tagName: string, attributes: string | undefined) =>
+      stripAttributesFromOpeningTag(tagName, attributes),
+  );
+};
+
 const stripEditorBreakingAttributes = (html: string) => {
   if (typeof window === 'undefined') {
-    return html;
+    return stripEditorBreakingAttributesWithoutDom(html);
   }
 
   const document = new window.DOMParser().parseFromString(html, 'text/html');
@@ -89,8 +134,20 @@ const stripEditorBreakingAttributes = (html: string) => {
 export const normalizeAdminCourseMarkdownContent = (content: unknown) => {
   const normalizedContent = normalizeMarkdownContent(content);
 
-  if (!normalizedContent || !isHtmlContent(normalizedContent)) {
+  if (!normalizedContent) {
     return normalizedContent;
+  }
+
+  if (!isHtmlContent(normalizedContent)) {
+    return hasRenderableMarkdownSyntax(normalizedContent)
+      ? renderMarkdownToHtml(normalizedContent)
+      : normalizedContent;
+  }
+
+  const recoveredMarkdown =
+    recoverMarkdownTextFromTextOnlyHtml(normalizedContent);
+  if (recoveredMarkdown) {
+    return renderMarkdownToHtml(recoveredMarkdown);
   }
 
   return stripEditorBreakingAttributes(normalizedContent);

--- a/src/utils/markdown-rendering-utils.test.ts
+++ b/src/utils/markdown-rendering-utils.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasRenderableMarkdownSyntax,
+  recoverMarkdownTextFromTextOnlyHtml,
+  renderMarkdownToHtml,
+} from './markdown-rendering-utils';
+
+const signedImageUrl =
+  'https://uploaded-files-qa.32cd2fa416bea795bf67cbf65411103b.r2.cloudflarestorage.com/images/lesson-content/a9e80c53.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc123';
+
+describe('markdown-rendering-utils', () => {
+  it('signed URL markdown images become HTML images without losing the URL', () => {
+    const html = renderMarkdownToHtml(`![image.png](${signedImageUrl})`);
+
+    expect(html).toContain('<img');
+    expect(html).toContain('alt="image.png"');
+    expect(html).toContain(
+      'src="https://uploaded-files-qa.32cd2fa416bea795bf67cbf65411103b.r2.cloudflarestorage.com/images/lesson-content/a9e80c53.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc123"',
+    );
+  });
+
+  it('detects the markdown structures used by lesson clipboard content', () => {
+    const markdown = [
+      '### 1단계. Live Server 확장',
+      '',
+      '> localhost — 내 컴퓨터를 가리키는 임시 주소.',
+      '',
+      '1. Cursor 좌측 아이콘 클릭',
+      '',
+      '```markdown',
+      '내 index.html을 정리해줘.',
+      '```',
+      '',
+      `![image.png](${signedImageUrl})`,
+      '',
+      '| 일반 코딩 | 바이브코딩 |',
+      '| --- | --- |',
+      '| deterministic | non-deterministic |',
+    ].join('\n');
+
+    expect(hasRenderableMarkdownSyntax(markdown)).toBe(true);
+
+    const html = renderMarkdownToHtml(markdown);
+
+    expect(html).toContain('<h3>');
+    expect(html).toContain('<blockquote>');
+    expect(html).toContain('<ol>');
+    expect(html).toContain('<pre><code class="language-markdown">');
+    expect(html).toContain('<img');
+    expect(html).toContain('<table>');
+  });
+
+  it('recovers markdown text from TipTap-degraded paragraph HTML', () => {
+    const recovered = recoverMarkdownTextFromTextOnlyHtml(
+      `<p>### 제목</p><p>![image.png](${signedImageUrl})</p>`,
+    );
+
+    expect(recovered).toBe(`### 제목\n\n![image.png](${signedImageUrl})`);
+  });
+
+  it('does not treat real rich HTML as degraded markdown text', () => {
+    expect(
+      recoverMarkdownTextFromTextOnlyHtml(
+        `<p>본문</p><img src="${signedImageUrl}">`,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/src/utils/markdown-rendering-utils.ts
+++ b/src/utils/markdown-rendering-utils.ts
@@ -1,0 +1,79 @@
+import { marked } from 'marked';
+import {
+  decodeHtmlEntities,
+  isHtmlContent,
+  toNonEmptyTrimmedString,
+} from '@/utils/markdown-content-shared';
+
+const MARKDOWN_IMAGE_PATTERN = /!\[[^\]]*]\([^)]+\)/;
+const MARKDOWN_HEADING_PATTERN = /^#{1,6}\s+\S/m;
+const MARKDOWN_BLOCKQUOTE_PATTERN = /^>\s?\S/m;
+const MARKDOWN_LIST_PATTERN = /^\s*(?:[-*+]\s+\S|\d+\.\s+\S)/m;
+const MARKDOWN_FENCE_PATTERN = /^```/m;
+const MARKDOWN_TABLE_PATTERN = /^\s*\|?.+\|.+\r?\n\s*\|?\s*:?-{3,}:?\s*\|/m;
+
+const TEXT_ONLY_HTML_TAGS = new Set(['p', 'br']);
+const HTML_TAG_PATTERN = /<\/?([a-z][a-z0-9-]*)\b[^>]*>/gi;
+
+export const hasRenderableMarkdownSyntax = (content: unknown) => {
+  const value = toNonEmptyTrimmedString(content);
+  if (!value) {
+    return false;
+  }
+
+  return (
+    MARKDOWN_IMAGE_PATTERN.test(value) ||
+    MARKDOWN_HEADING_PATTERN.test(value) ||
+    MARKDOWN_BLOCKQUOTE_PATTERN.test(value) ||
+    MARKDOWN_LIST_PATTERN.test(value) ||
+    MARKDOWN_FENCE_PATTERN.test(value) ||
+    MARKDOWN_TABLE_PATTERN.test(value)
+  );
+};
+
+export const renderMarkdownToHtml = (content: string) => {
+  const rendered = marked.parse(content, {
+    breaks: true,
+    gfm: true,
+  });
+
+  return typeof rendered === 'string' ? rendered.trim() : '';
+};
+
+export const recoverMarkdownTextFromTextOnlyHtml = (
+  content: unknown,
+): string | undefined => {
+  const value = toNonEmptyTrimmedString(content);
+  if (!value || !isHtmlContent(value)) {
+    return undefined;
+  }
+
+  const tagNames = Array.from(value.matchAll(HTML_TAG_PATTERN)).map((match) =>
+    (match[1] ?? '').toLowerCase(),
+  );
+  if (
+    tagNames.length === 0 ||
+    tagNames.some((tagName) => !TEXT_ONLY_HTML_TAGS.has(tagName))
+  ) {
+    return undefined;
+  }
+
+  const recoveredText = decodeHtmlEntities(
+    value
+      .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+      .replace(/<\s*\/p\s*>\s*<\s*p\b[^>]*>/gi, '\n\n')
+      .replace(/<\s*\/?p\b[^>]*>/gi, '')
+      .replace(/<[^>]+>/g, ''),
+  ).trim();
+
+  return hasRenderableMarkdownSyntax(recoveredText) ? recoveredText : undefined;
+};
+
+export const normalizeMarkdownForRichRendering = (content: unknown) => {
+  const value = toNonEmptyTrimmedString(content);
+  if (!value) {
+    return '';
+  }
+
+  return recoverMarkdownTextFromTextOnlyHtml(value) ?? value;
+};


### PR DESCRIPTION
## 요약
- Notion ZIP/imported raw markdown을 에디터 진입 전에 editor-safe HTML로 변환해 이미지/목록/인용/코드블록이 깨지지 않게 했습니다.
- 이미 TipTap paragraph HTML로 오염된 markdown도 관리자 미리보기와 수강생 레슨 렌더러에서 복구 렌더링합니다.
- plain markdown 클립보드 붙여넣기 시 markdown 구조를 유지해 삽입하고, ZIP import 직후 레슨 row 전체 초록 배경은 작은 배지로 축소했습니다.

## 검증
- yarn lint:fix (0 errors, existing warnings only)
- yarn prettier:fix (exit 0, existing .codex symlink warning)
- yarn typecheck
- yarn test:unit src/features/admin/course-management/model/admin-course-markdown.test.ts src/utils/markdown-rendering-utils.test.ts src/components/common/ui/editor src/features/admin/course-management
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 레슨 목록의 "방금 생성" 항목 표시 방식 개선 (배경색 강조에서 배지 표시로 변경)
  * 마크다운 콘텐츠 렌더링 전처리 과정 강화로 더 안정적인 변환 제공
  * 마크다운 에디터 클립보드 붙여넣기 기능 개선으로 마크다운 문법 자동 감지 및 처리

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->