### PR TITLE
[cherry-pick] HTML 태그 포함 마크다운 콘텐츠의 줄바꿈 소실 버그 수정

### DIFF
--- a/src/components/common/ui/rich-text/markdown-content-core.tsx
+++ b/src/components/common/ui/rich-text/markdown-content-core.tsx
@@ -27,7 +27,6 @@ import {
   applyYouTubeIframeAttributes,
   replaceStandaloneYouTubeLinksWithEmbeds,
 } from '@/components/common/ui/editor/youtube-utils';
-import { isHtmlContent } from '@/lib/rich-text/markdown-utils';
 
 hljs.registerLanguage('kotlin', kotlin);
 hljs.registerLanguage('sql', sql);
@@ -207,20 +206,13 @@ export default function MarkdownContentCore({
       return '';
     }
 
-    const isOriginalHtml = isHtmlContent(content);
     const contentWithEmbeds = replaceStandaloneYouTubeLinksWithEmbeds(content);
 
-    let html: string;
-
-    if (isOriginalHtml) {
-      html = contentWithEmbeds;
-    } else {
-      const rendered = marked.parse(contentWithEmbeds, {
-        breaks: true,
-        gfm: true,
-      });
-      html = typeof rendered === 'string' ? rendered : '';
-    }
+    const rendered = marked.parse(contentWithEmbeds, {
+      breaks: true,
+      gfm: true,
+    });
+    const html = typeof rendered === 'string' ? rendered : '';
 
     const sanitized = DOMPurify.sanitize(html, SANITIZE_OPTIONS);
 


### PR DESCRIPTION
## 개요

HTML 태그가 포함된 마크다운 콘텐츠에서 줄바꿈이 소실되는 버그를 수정합니다. 마크다운 렌더링 파이프라인에서 YouTube 링크 임베드 처리를 포함한 콘텐츠 보안 및 형식 표준화 절차가 일관되게 적용되도록 개선되었습니다.

## 원본 PR

- develop PR: #654 (https://github.com/code-zero-to-one/study-platform-client/pull/654)
- 원본 브랜치: `fix/markdown`

## Cherry-pick 대상 커밋

- `ae34165` — [markdown] fix : HTML 태그 포함 마크다운 콘텐츠의 줄바꿈 소실 버그 수정

## 변경 파일

- `src/components/common/ui/rich-text/markdown-content-core.tsx` — HTML 태그 포함 마크다운의 줄바꿈 처리 로직 수정 (5 추가 / 13 삭제)

## 혼입 검증 결과

`git show ae34165 --stat` 결과: 1개 파일만 변경.
`git diff main...fix/markdown --stat` 상의 나머지 176개 파일은 develop 브랜치 전체 누적 변경분으로, cherry-pick 커밋에 혼입되지 않음.

- [x] develop 전용 코드 혼입 없음 (변경 파일이 원본 PR 범위와 일치)

## Test plan

- [ ] HTML 태그(`<br>`, `<strong>` 등)가 포함된 마크다운 콘텐츠에서 줄바꿈이 정상 렌더링되는지 확인
- [ ] 일반 마크다운 줄바꿈(빈 줄, `\n\n`)이 기존대로 동작하는지 확인
- [ ] YouTube 링크가 포함된 콘텐츠에서 임베드 처리가 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)