### PR TITLE
fix: 코드블록 HTML 마크다운 판별 복구

### DIFF
--- a/src/components/common/ui/editor/markdown-content.tsx
+++ b/src/components/common/ui/editor/markdown-content.tsx
@@ -7,7 +7,10 @@ import { memo, useEffect, useMemo, useRef } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import { normalizeMarkdownContent } from '@/utils/markdown-content-normalize';
 import { isHtmlContent } from '@/utils/markdown-content-shared';
-import { normalizeMarkdownForRichRendering } from '@/utils/markdown-rendering-utils';
+import {
+  normalizeMarkdownForRichRendering,
+  shouldRenderMarkdownAsMarkdown,
+} from '@/utils/markdown-rendering-utils';
 import hljs from './hljs-setup';
 import {
   applyPostSanitizeAttributes,
@@ -65,7 +68,9 @@ function MarkdownContent({
 
     const renderableContent =
       normalizeMarkdownForRichRendering(normalizedContent);
-    const isOriginalHtml = isHtmlContent(renderableContent);
+    const isOriginalHtml =
+      isHtmlContent(renderableContent) &&
+      !shouldRenderMarkdownAsMarkdown(renderableContent);
     const normalizedContentWithEmbeds =
       replaceStandaloneYouTubeLinksWithEmbeds(renderableContent);
 

--- a/src/components/common/ui/rich-text/markdown-content-core.tsx
+++ b/src/components/common/ui/rich-text/markdown-content-core.tsx
@@ -27,7 +27,6 @@ import {
   applyYouTubeIframeAttributes,
   replaceStandaloneYouTubeLinksWithEmbeds,
 } from '@/components/common/ui/editor/youtube-utils';
-import { isHtmlContent } from '@/lib/rich-text/markdown-utils';
 import { normalizeMarkdownForRichRendering } from '@/utils/markdown-rendering-utils';
 
 hljs.registerLanguage('kotlin', kotlin);
@@ -209,7 +208,6 @@ export default function MarkdownContentCore({
     }
 
     const renderableContent = normalizeMarkdownForRichRendering(content);
-    const isOriginalHtml = isHtmlContent(renderableContent);
     const contentWithEmbeds =
       replaceStandaloneYouTubeLinksWithEmbeds(renderableContent);
 

--- a/src/features/admin/course-management/model/admin-course-markdown.test.ts
+++ b/src/features/admin/course-management/model/admin-course-markdown.test.ts
@@ -25,6 +25,30 @@ describe('normalizeAdminCourseMarkdownContent', () => {
     expect(normalized).toContain(signedImageUrl);
   });
 
+  it('keeps markdown parsing when lesson text includes HTML examples in code fences', () => {
+    const normalized = normalizeAdminCourseMarkdownContent(
+      [
+        '#IDE #Cursor #HTML',
+        '',
+        '### 5단계. 첫 웹페이지 띄우기',
+        '',
+        '```markdown',
+        '<h1>Hello, Zero-One!</h1>',
+        '<h2>I am a Vibe Coder</h2>',
+        '<h3>Future Frontier</h3>',
+        '```',
+        '',
+        `![image.png](${signedImageUrl})`,
+      ].join('\n'),
+    );
+
+    expect(normalized).toContain('<h3>');
+    expect(normalized).toContain('<pre><code class="language-markdown">');
+    expect(normalized).toContain('&lt;h1&gt;Hello, Zero-One!&lt;/h1&gt;');
+    expect(normalized).toContain('<img');
+    expect(normalized).toContain(signedImageUrl);
+  });
+
   it('keeps normal editor HTML as HTML while stripping unsafe attributes', () => {
     const normalized = normalizeAdminCourseMarkdownContent(
       '<p class="external" onclick="alert(1)">본문</p><img src="https://example.com/a.png" style="width:100px">',

--- a/src/features/admin/course-management/model/admin-course-markdown.ts
+++ b/src/features/admin/course-management/model/admin-course-markdown.ts
@@ -2,9 +2,9 @@ import { COMMUNITY_MARKDOWN_MAX_IMAGE_FILE_SIZE } from '@/types/community/markdo
 import { normalizeMarkdownContent } from '@/utils/markdown-content-normalize';
 import { isHtmlContent } from '@/utils/markdown-content-shared';
 import {
-  hasRenderableMarkdownSyntax,
   recoverMarkdownTextFromTextOnlyHtml,
   renderMarkdownToHtml,
+  shouldRenderMarkdownAsMarkdown,
 } from '@/utils/markdown-rendering-utils';
 
 export const ADMIN_COURSE_MARKDOWN_ALLOWED_IMAGE_EXTENSIONS = [
@@ -138,10 +138,12 @@ export const normalizeAdminCourseMarkdownContent = (content: unknown) => {
     return normalizedContent;
   }
 
+  if (shouldRenderMarkdownAsMarkdown(normalizedContent)) {
+    return renderMarkdownToHtml(normalizedContent);
+  }
+
   if (!isHtmlContent(normalizedContent)) {
-    return hasRenderableMarkdownSyntax(normalizedContent)
-      ? renderMarkdownToHtml(normalizedContent)
-      : normalizedContent;
+    return normalizedContent;
   }
 
   const recoveredMarkdown =

--- a/src/utils/markdown-rendering-utils.test.ts
+++ b/src/utils/markdown-rendering-utils.test.ts
@@ -3,6 +3,7 @@ import {
   hasRenderableMarkdownSyntax,
   recoverMarkdownTextFromTextOnlyHtml,
   renderMarkdownToHtml,
+  shouldRenderMarkdownAsMarkdown,
 } from './markdown-rendering-utils';
 
 const signedImageUrl =
@@ -64,5 +65,36 @@ describe('markdown-rendering-utils', () => {
         `<p>본문</p><img src="${signedImageUrl}">`,
       ),
     ).toBeUndefined();
+  });
+
+  it('treats HTML examples inside fenced code blocks as markdown content', () => {
+    const markdown = [
+      '#IDE #Cursor #HTML',
+      '',
+      '### 5단계. 첫 웹페이지 띄우기',
+      '',
+      '```markdown',
+      '<h1>Hello, Zero-One!</h1>',
+      '<h2>I am a Vibe Coder</h2>',
+      '<h3>Future Frontier</h3>',
+      '```',
+      '',
+      `![image.png](${signedImageUrl})`,
+    ].join('\n');
+
+    expect(shouldRenderMarkdownAsMarkdown(markdown)).toBe(true);
+
+    const html = renderMarkdownToHtml(markdown);
+
+    expect(html).toContain('<h3>');
+    expect(html).toContain('<pre><code class="language-markdown">');
+    expect(html).toContain('&lt;h1&gt;Hello, Zero-One!&lt;/h1&gt;');
+    expect(html).toContain('<img');
+  });
+
+  it('keeps normal editor HTML classified as HTML even if it has text', () => {
+    expect(
+      shouldRenderMarkdownAsMarkdown('<p>본문</p><img src="/images/a.png">'),
+    ).toBe(false);
   });
 });

--- a/src/utils/markdown-rendering-utils.ts
+++ b/src/utils/markdown-rendering-utils.ts
@@ -14,6 +14,8 @@ const MARKDOWN_TABLE_PATTERN = /^\s*\|?.+\|.+\r?\n\s*\|?\s*:?-{3,}:?\s*\|/m;
 
 const TEXT_ONLY_HTML_TAGS = new Set(['p', 'br']);
 const HTML_TAG_PATTERN = /<\/?([a-z][a-z0-9-]*)\b[^>]*>/gi;
+const HTML_LEADING_TAG_PATTERN = /^<[a-z][a-z0-9-]*(?:\s[^<>]*?)?>/i;
+const MARKDOWN_CODE_FENCE_BLOCK_PATTERN = /```[\s\S]*?```/g;
 
 export const hasRenderableMarkdownSyntax = (content: unknown) => {
   const value = toNonEmptyTrimmedString(content);
@@ -38,6 +40,27 @@ export const renderMarkdownToHtml = (content: string) => {
   });
 
   return typeof rendered === 'string' ? rendered.trim() : '';
+};
+
+export const shouldRenderMarkdownAsMarkdown = (content: unknown) => {
+  const value = toNonEmptyTrimmedString(content);
+  if (!value || !hasRenderableMarkdownSyntax(value)) {
+    return false;
+  }
+
+  if (!isHtmlContent(value)) {
+    return true;
+  }
+
+  const contentWithoutFencedCode = value.replace(
+    MARKDOWN_CODE_FENCE_BLOCK_PATTERN,
+    '',
+  );
+  if (!isHtmlContent(contentWithoutFencedCode)) {
+    return true;
+  }
+
+  return !HTML_LEADING_TAG_PATTERN.test(value);
 };
 
 export const recoverMarkdownTextFromTextOnlyHtml = (


### PR DESCRIPTION
## Summary
- Fix markdown/HTML classification so HTML examples inside fenced code blocks do not make the whole Notion ZIP lesson body render as raw HTML.
- Keep normal editor HTML fragments (`<p>...`) on the HTML path.
- Add regression coverage for the failing Cursor/HTML lesson shape with markdown heading, fenced HTML examples, and signed image markdown.

## Verification
- `yarn lint:fix` (0 errors, existing warnings only)
- `yarn prettier:fix` (exit 0; existing `.codex/skills/clarify.md` symlink warning)
- `yarn typecheck`
- `yarn test:unit src/features/admin/course-management/model/admin-course-markdown.test.ts src/utils/markdown-rendering-utils.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 코드 블록 내 HTML 예제가 올바르게 마크다운으로 렌더링되도록 개선
  * 콘텐츠 렌더링 경로 판별 로직 최적화로 정확도 향상

* **Refactor**
  * 마크다운 및 HTML 콘텐츠 렌더링 로직 개선

* **Tests**
  * 마크다운 콘텐츠 정규화 및 렌더링 검증 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->