### PR TITLE
fix(class-lesson): lesson 상세에서 :name: shortcode 치환 누락 보강

### DIFF
--- a/src/components/common/ui/rich-text/markdown-content-core.tsx
+++ b/src/components/common/ui/rich-text/markdown-content-core.tsx
@@ -23,6 +23,7 @@ import xml from 'highlight.js/lib/languages/xml';
 import { marked } from 'marked';
 import { useEffect, useMemo, useRef } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import { replaceEmoticonShortcodes } from '@/components/common/ui/editor/emoticon-shortcode';
 import {
   applyYouTubeIframeAttributes,
   replaceStandaloneYouTubeLinksWithEmbeds,
@@ -95,7 +96,8 @@ const SANITIZE_OPTIONS: DOMPurifyConfig = {
     'width',
   ],
   ALLOW_DATA_ATTR: false,
-  ALLOWED_URI_REGEXP: /^(?:https?:\/\/|mailto:|tel:|\/images\/|#)/i,
+  ALLOWED_URI_REGEXP:
+    /^(?:https?:\/\/|mailto:|tel:|\/images\/|\/emoticon\/|#)/i,
 };
 
 const IMAGE_WIDTH_MIN = 80;
@@ -208,7 +210,9 @@ export default function MarkdownContentCore({
     }
 
     const isOriginalHtml = isHtmlContent(content);
-    const contentWithEmbeds = replaceStandaloneYouTubeLinksWithEmbeds(content);
+    const contentWithEmbeds = replaceEmoticonShortcodes(
+      replaceStandaloneYouTubeLinksWithEmbeds(content),
+    );
 
     let html: string;
 
@@ -267,6 +271,10 @@ export default function MarkdownContentCore({
         '[&_a]:text-text-brand [&_a]:underline',
         '[&_iframe.youtube-embed]:mb-150 [&_iframe.youtube-embed]:block [&_iframe.youtube-embed]:aspect-video [&_iframe.youtube-embed]:w-full [&_iframe.youtube-embed]:max-w-full [&_iframe.youtube-embed]:rounded-100 [&_iframe.youtube-embed]:border [&_iframe.youtube-embed]:border-border-subtle',
         '[&_img]:rounded-100 [&_img]:border-border-subtle [&_img]:mb-150 [&_img]:block [&_img]:h-auto [&_img]:max-h-rich-text-image [&_img]:max-w-rich-text-image [&_img]:border [&_img]:object-contain',
+        '[&_img.emoticon-inline]:!inline-block [&_img.emoticon-inline]:!h-[24px] [&_img.emoticon-inline]:!w-auto [&_img.emoticon-inline]:!max-h-[24px] [&_img.emoticon-inline]:!max-w-none [&_img.emoticon-inline]:!border-0 [&_img.emoticon-inline]:!rounded-none [&_img.emoticon-inline]:!my-0 [&_img.emoticon-inline]:!mb-0 [&_img.emoticon-inline]:!align-middle',
+        '[&_img.emoticon-lg]:!inline-block [&_img.emoticon-lg]:!h-[48px] [&_img.emoticon-lg]:!w-auto [&_img.emoticon-lg]:!max-h-[48px] [&_img.emoticon-lg]:!max-w-none [&_img.emoticon-lg]:!border-0 [&_img.emoticon-lg]:!rounded-none [&_img.emoticon-lg]:!my-0 [&_img.emoticon-lg]:!mb-0 [&_img.emoticon-lg]:!align-middle',
+        '[&_img.emoticon-xl]:!inline-block [&_img.emoticon-xl]:!h-[96px] [&_img.emoticon-xl]:!w-auto [&_img.emoticon-xl]:!max-h-[96px] [&_img.emoticon-xl]:!max-w-none [&_img.emoticon-xl]:!border-0 [&_img.emoticon-xl]:!rounded-none [&_img.emoticon-xl]:!my-0 [&_img.emoticon-xl]:!mb-0 [&_img.emoticon-xl]:!align-middle',
+        '[&_img.emoticon-xxl]:!inline-block [&_img.emoticon-xxl]:!h-[150px] [&_img.emoticon-xxl]:!w-auto [&_img.emoticon-xxl]:!max-h-[150px] [&_img.emoticon-xxl]:!max-w-none [&_img.emoticon-xxl]:!border-0 [&_img.emoticon-xxl]:!rounded-none [&_img.emoticon-xxl]:!my-0 [&_img.emoticon-xxl]:!mb-0 [&_img.emoticon-xxl]:!align-middle',
         '[&_code]:rounded-50 [&_code]:bg-background-alternative [&_code]:font-designer-13r [&_code]:px-75 [&_code]:py-25',
         '[&_pre]:rounded-100 [&_pre]:bg-background-alternative [&_pre]:mb-150 [&_pre]:overflow-x-auto [&_pre]:px-125 [&_pre]:py-100',
         '[&_pre_code]:bg-transparent [&_pre_code]:px-0 [&_pre_code]:py-0',


### PR DESCRIPTION
## 작업 내용
- `MarkdownContentCore`(lesson 상세 페이지가 쓰는 컴포넌트)에 `replaceEmoticonShortcodes` 호출 추가
- `SANITIZE_OPTIONS.ALLOWED_URI_REGEXP`에 `/emoticon/` prefix 허용
- size variant CSS 4단(`emoticon-inline / lg / xl / xxl`) 추가

## 변경 이유
- 이전 PR #659는 `MarkdownContent`(에디터/미리보기용)에만 치환을 추가했음.
- 사이트의 lesson 상세 페이지 `src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx`는 **`MarkdownContentCore`** 라는 별도 컴포넌트로 본문을 렌더링하기 때문에, 운영 사이트에서 `:aha_xxl:` 같은 토큰이 텍스트 그대로 노출되는 회귀가 발생.
- 같은 카탈로그(`emoticon-shortcode.ts`)를 공유해 동일하게 풀리도록 보강.

## dev/QA 검증 evidence
- [x] PR #659 머지 후 운영 lesson 상세에서 raw 토큰이 그대로 노출되는 회귀 확인 — 본 PR로 수정 대상 확정.
- [ ] 로컬 dev에서 lesson 상세 페이지 spot check 권장 (배포 직전).

## production 영향
- 영향 범위: lesson 상세 페이지(`/class/{slug}/lesson/{id}`)와 `MarkdownContentCore`를 쓰는 다른 화면.
- 카탈로그 미스 토큰은 텍스트 그대로 노출되어 안전. backend/DB 정책·스키마 변경 없음.

## release contract 영향
- backend prod release / version management / release record workflow와 무관.
- frontend-only 회귀 수정.

## 검증 방법
- [ ] 운영 `https://www.zeroone.it.kr/class/vibe-intro-claude-code/lesson/{1~8}` 접속 → 각 lesson 본문의 `:aha_xxl:`, `:okay_xxl:`, `:joyful_xxl:`, `:medallion_xxl:`, `:expect_xxl:`, `:hustle_xxl:`, `:what_xxl:` 가 150px 캐릭터 이미지로 정상 렌더되는지 확인

## 브랜치 정보
- base: main
- head: feat/emoticon-shortcode-core
- 기준 range: origin/main..HEAD (1 commit)

## 롤백 계획
- 회귀 발견 시 본 PR의 revert PR 생성 → main 머지로 즉시 원복.
- 본문 데이터 롤백 필요 없음(shortcode가 풀리지 않을 뿐 raw 텍스트로 노출됨).

## known risk / not-tested
- `MarkdownContent`와 `MarkdownContentCore`가 별도 컴포넌트로 존재해 같은 정책을 두 군데 유지하는 구조가 됨. 향후 두 컴포넌트 통합 또는 공통 치환 유틸 추출을 검토 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 마크다운 콘텐츠에서 이모티콘 쇼트코드를 적절하게 처리하고 표시하도록 지원 추가
* 이모티콘 리소스 URL이 콘텐츠 보안 필터링에서 차단되지 않도록 개선
* 마크다운 렌더링 시 이모티콘 이미지의 크기 및 표시 동작을 위한 스타일링 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->