### PR TITLE
마이 페이지 탭 UI 및 기능 구현

### DIFF
--- a/e2e/class/payment-success.spec.ts
+++ b/e2e/class/payment-success.spec.ts
@@ -175,7 +175,9 @@ test.describe('결제 성공 — 가상계좌 입금 대기 @auth', () => {
     await expect(page.getByText('99,000원')).toBeVisible();
   });
 
-  test('"결제 관리로 가기" 링크 → /my-page?tab=payment', async ({ page }) => {
+  test('"결제 관리로 가기" 링크 → /class-payment-management', async ({
+    page,
+  }) => {
     await gotoSuccessPage(page);
     await expect(page.getByText('입금 대기 중입니다.')).toBeVisible({
       timeout: 10000,
@@ -183,7 +185,7 @@ test.describe('결제 성공 — 가상계좌 입금 대기 @auth', () => {
 
     const link = page.getByRole('link', { name: '결제 관리로 가기' });
     await expect(link).toBeVisible();
-    await expect(link).toHaveAttribute('href', '/my-page?tab=payment');
+    await expect(link).toHaveAttribute('href', '/class-payment-management');
   });
 
   test('"결제 취소" 클릭 → cancel API 호출 → /class/vibe-intro/home 이동', async ({

--- a/src/components/common/layout/sidebar/my-page-sidebar.tsx
+++ b/src/components/common/layout/sidebar/my-page-sidebar.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useRouter } from 'next/navigation';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import { useLogoutMutation } from '@/hooks/queries/auth/use-auth-mutation';
+import { useToastStore } from '@/stores/use-toast-store';
 
 interface IconProps {
   className?: string;
@@ -91,6 +92,7 @@ const NAV_ITEMS: {
   label: string;
   icon: React.FC<IconProps>;
   prefixMatch?: boolean;
+  comingSoon?: boolean;
 }[] = [
   { href: '/my-page', label: '프로필', icon: PersonOutlineIcon },
   { href: '/my-class', label: '마이 클래스', icon: ClassIcon },
@@ -107,10 +109,11 @@ const NAV_ITEMS: {
     prefixMatch: true,
   },
   {
-    href: '/builder-letter',
-    label: '빌더 레터',
+    href: '/builder-ticket',
+    label: '빌더 티켓',
     icon: MarkunreadIcon,
     prefixMatch: true,
+    comingSoon: true,
   },
   {
     href: '/class-payment-management',
@@ -123,13 +126,20 @@ export default function Sidebar() {
   const router = useRouter();
   const pathname = usePathname();
   const { mutateAsync: logout } = useLogoutMutation();
+  const showToast = useToastStore((state) => state.showToast);
 
   return (
     <div className="border-border-subtle box-border hidden w-3750 flex-col gap-150 border-x-1 px-300 pt-500 lg:flex">
       {NAV_ITEMS.map((item) => (
         <SidebarItem
           key={item.href}
-          onClick={() => router.push(item.href)}
+          onClick={() => {
+            if (item.comingSoon) {
+              showToast('준비중인 기능입니다.', 'info');
+              return;
+            }
+            router.push(item.href);
+          }}
           isActive={
             item.prefixMatch
               ? pathname.startsWith(item.href)


### PR DESCRIPTION
## Changes

- 마이 페이지 사이드바 '빌더 레터' → '빌더 티켓' 명칭 변경
- 빌더 티켓 탭 클릭 시 라우팅 없이 "준비중인 기능입니다." 토스트 노출

## Test plan

- [ ] 빌더 티켓 탭 클릭 시 토스트 확인
- [ ] 다른 탭 라우팅 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)