### PR TITLE
[cherry-pick] 레슨 목록 UX 버그 수정 + 도장 텍스트/자물쇠 수정

### DIFF
--- a/e2e/class/journey-map.spec.ts
+++ b/e2e/class/journey-map.spec.ts
@@ -532,7 +532,7 @@ test.describe('레슨 스탬프 인터랙션 @auth', () => {
     await expect(page.getByRole('dialog')).toContainText(LESSON_FREE_TITLE);
   });
 
-  test('Option bonus 레슨 모달 → 건너뛰기 visible, 일반 레슨에서는 없음', async ({
+  test.skip('Option bonus 레슨 모달 → 건너뛰기 visible, 일반 레슨에서는 없음', async ({
     page,
   }) => {
     const accessibleStamps = page
@@ -683,7 +683,9 @@ test.describe('커리큘럼 레슨 카드 배지 렌더링 @auth', () => {
 });
 
 test.describe('건너뛰기 내비게이션 @auth', () => {
-  test('Option bonus 건너뛰기 → 맵 유지 및 토스트 표시', async ({ page }) => {
+  test.skip('Option bonus 건너뛰기 → 맵 유지 및 토스트 표시', async ({
+    page,
+  }) => {
     await mockApis(page, {
       journey: makeJourneyMap([
         {

--- a/src/app/(service)/(my)/my-class/page.tsx
+++ b/src/app/(service)/(my)/my-class/page.tsx
@@ -203,7 +203,7 @@ function AlarmCard({
             : 'bg-border-subtle text-text-subtlest',
         )}
       >
-        시간 수정하기
+        {hasTime ? '시간 수정하기' : '시간 등록하기'}
       </button>
     </div>
   );

--- a/src/components/pages/class/home-constants.ts
+++ b/src/components/pages/class/home-constants.ts
@@ -164,6 +164,7 @@ export interface LessonDisplayInfo {
   accessible: boolean;
   estimatedMinutes: number;
   isCurrent: boolean;
+  lockReason: 'retrospective' | 'access' | 'none';
 }
 
 export function buildLessonMap(
@@ -180,19 +181,29 @@ export function mergeLessons(
 ): LessonDisplayInfo[] {
   return chapter.lessons.map((l) => {
     const journeyLesson = journeyMap.get(l.lessonId);
+    const status =
+      journeyLesson?.status ?? (l.isLocked ? 'LOCKED' : 'IN_PROGRESS');
+    const accessible = journeyLesson?.isAccessible ?? !l.isLocked;
+
+    let lockReason: LessonDisplayInfo['lockReason'] = 'none';
+    if (status === 'LOCKED') {
+      lockReason = accessible ? 'retrospective' : 'access';
+    }
+
     return {
       lessonId: l.lessonId,
       order: l.order,
       title: l.title,
       description: l.description,
       isFree: l.isFree,
-      status: journeyLesson?.status ?? (l.isLocked ? 'LOCKED' : 'IN_PROGRESS'),
-      accessible: journeyLesson?.isAccessible ?? !l.isLocked,
+      status,
+      accessible,
       estimatedMinutes: l.estimatedMinutes,
       isCurrent:
         journeyLesson !== undefined &&
         journeyLesson.status === 'IN_PROGRESS' &&
         journeyLesson.isAccessible,
+      lockReason,
     };
   });
 }

--- a/src/components/pages/class/lesson-preview-modal.tsx
+++ b/src/components/pages/class/lesson-preview-modal.tsx
@@ -17,7 +17,6 @@ interface LessonPreviewModalProps {
   chapter: CourseCurriculumChapterResponse;
   learnerCount: number;
   onStart: () => void;
-  onSkip: () => void;
 }
 
 export function LessonPreviewModal({
@@ -27,10 +26,7 @@ export function LessonPreviewModal({
   chapter,
   learnerCount,
   onStart,
-  onSkip,
 }: LessonPreviewModalProps) {
-  const isOptionBonus = lesson.title.toLowerCase().includes('option');
-
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
       <DialogContent className="max-w-10500 sm:max-w-10500 gap-0 overflow-hidden rounded-200 border-0 bg-background-default p-0">
@@ -55,13 +51,9 @@ export function LessonPreviewModal({
         <div className="flex w-full items-start justify-between px-875 pt-375">
           <div className="flex flex-col gap-150">
             <p className="whitespace-nowrap font-designer-24b text-text-brand">
-              {isOptionBonus
-                ? 'Option Bonus'
-                : `Lesson ${String(lesson.order).padStart(2, '0')}`}
+              {`Lesson ${String(lesson.order).padStart(2, '0')}`}
             </p>
-            <p className="whitespace-nowrap font-designer-24b text-gray-800">
-              {lesson.title}
-            </p>
+            <p className="font-designer-24b text-gray-800">{lesson.title}</p>
           </div>
           <div className="flex shrink-0 items-center gap-50 rounded-full border border-gray-200 text-gray-0 px-375 py-150">
             <div className="flex items-center">
@@ -91,22 +83,13 @@ export function LessonPreviewModal({
         {/* 학습 목표 */}
         <div className="flex flex-col gap-75 px-875 pt-375">
           <p className="font-designer-18b text-gray-800">학습 목표</p>
-          <p className="font-designer-15r text-gray-800">
+          <p className="line-clamp-3 font-designer-15r text-gray-800">
             {lesson.description ??
               '이 레슨에서 무엇을 배우는지 확인하고 시작해요.'}
           </p>
         </div>
         {/* CTAs */}
         <div className="flex flex-col gap-150 px-875 pb-875 pt-375">
-          {isOptionBonus && (
-            <button
-              type="button"
-              onClick={onSkip}
-              className="h-625 w-full rounded-100 border border-background-brand-default font-designer-14b text-text-brand"
-            >
-              건너뛰기
-            </button>
-          )}
           <button
             type="button"
             onClick={onStart}

--- a/src/components/pages/class/lesson-stamp.tsx
+++ b/src/components/pages/class/lesson-stamp.tsx
@@ -66,16 +66,12 @@ export function LessonStamp({
         )}
         {isLocked && <Lock className="mb-25 size-300 text-gray-500" />}
         {isCompleted && (
-          <p className="mb-25 font-designer-12b text-text-brand">완료</p>
+          <p className="mb-25 font-designer-12b text-gray-0">완료</p>
         )}
         <p
           className={cn(
             'font-designer-18b',
-            isCompleted
-              ? 'text-text-brand'
-              : isActive
-                ? 'text-gray-0'
-                : 'text-gray-500',
+            isCompleted || isActive ? 'text-gray-0' : 'text-gray-500',
           )}
         >
           Lesson
@@ -83,11 +79,7 @@ export function LessonStamp({
         <p
           className={cn(
             'font-designer-18b',
-            isCompleted
-              ? 'text-text-brand'
-              : isActive
-                ? 'text-gray-0'
-                : 'text-gray-500',
+            isCompleted || isActive ? 'text-gray-0' : 'text-gray-500',
           )}
         >
           {String(lesson.order).padStart(2, '0')}

--- a/src/components/pages/class/lesson-stamp.tsx
+++ b/src/components/pages/class/lesson-stamp.tsx
@@ -28,13 +28,17 @@ export function LessonStamp({
 }: LessonStampProps) {
   const [showTooltip, setShowTooltip] = useState(false);
   const isCompleted = lesson.status === 'COMPLETED';
-  const isLocked = lesson.status === 'LOCKED' && !lesson.accessible;
+  const isLocked = lesson.status === 'LOCKED';
   const isActive = lesson.isCurrent || shouldBlink;
 
   const stampContent = (
     <div
       className="relative flex size-1650 shrink-0 flex-col items-center justify-center"
-      onMouseEnter={() => !isCompleted && setShowTooltip(true)}
+      onMouseEnter={() =>
+        ((!isLocked && !isCompleted) ||
+          (isLocked && lesson.lockReason === 'retrospective')) &&
+        setShowTooltip(true)
+      }
       onMouseLeave={() => setShowTooltip(false)}
     >
       <Image
@@ -85,14 +89,22 @@ export function LessonStamp({
           {String(lesson.order).padStart(2, '0')}
         </p>
       </div>
-      {showTooltip && (
-        <div className="absolute -top-400 left-1/2 flex -translate-x-1/2 items-center gap-75 whitespace-nowrap rounded-100 bg-gray-900 px-150 py-75">
-          <Users className="size-200 text-gray-0" />
-          <span className="font-designer-12r text-gray-0">
-            {learnerCount}명이 함께 달리는 중
-          </span>
-        </div>
-      )}
+      {showTooltip &&
+        (isLocked && lesson.lockReason === 'retrospective' ? (
+          <div className="absolute -top-400 left-1/2 flex -translate-x-1/2 items-center gap-75 whitespace-nowrap rounded-100 bg-gray-900 px-150 py-75">
+            <Lock className="size-200 text-gray-0" />
+            <span className="font-designer-12r text-gray-0">
+              이전 레슨을 완료해야 진입할 수 있어요
+            </span>
+          </div>
+        ) : (
+          <div className="absolute -top-400 left-1/2 flex -translate-x-1/2 items-center gap-75 whitespace-nowrap rounded-100 bg-gray-900 px-150 py-75">
+            <Users className="size-200 text-gray-0" />
+            <span className="font-designer-12r text-gray-0">
+              {learnerCount}명이 함께 달리는 중
+            </span>
+          </div>
+        ))}
     </div>
   );
 

--- a/src/components/pages/class/roadmap-tab.tsx
+++ b/src/components/pages/class/roadmap-tab.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import {
   LockIcon,
@@ -18,7 +18,6 @@ import {
   useGetCourseJourneyMap,
   useGetCourseProgress,
 } from '@/hooks/queries/course/course-api';
-import { useToastStore } from '@/stores/use-toast-store';
 import type { CourseCurriculumChapterResponse } from '@/types/api/course.types';
 import { ChapterHeader } from './chapter-header';
 import {
@@ -44,16 +43,8 @@ export function RoadmapTab({ slug }: { slug: string }) {
   const { data: journeyMap } = useGetCourseJourneyMap(courseId);
   const { data: progress } = useGetCourseProgress(courseId);
   const router = useRouter();
-  const showToast = useToastStore((s) => s.showToast);
-  const [blinkLessonId, setBlinkLessonId] = useState<number | null>(null);
   const [showPlanModal, setShowPlanModal] = useState(false);
   const [visibleChapterCount, setVisibleChapterCount] = useState(1);
-
-  useEffect(() => {
-    if (!blinkLessonId) return;
-    const t = setTimeout(() => setBlinkLessonId(null), 5000);
-    return () => clearTimeout(t);
-  }, [blinkLessonId]);
   const [visibleLessonCount, setVisibleLessonCount] = useState(5);
   const [selectedLesson, setSelectedLesson] = useState<{
     lesson: LessonDisplayInfo;
@@ -311,11 +302,11 @@ export function RoadmapTab({ slug }: { slug: string }) {
                                   })
                                 }
                                 shouldBlink={
-                                  (completedLessons === 0 &&
-                                    index === 0 &&
-                                    ri === 0 &&
-                                    li === 0) ||
-                                  lesson.lessonId === blinkLessonId
+                                  progress !== undefined &&
+                                  completedLessons === 0 &&
+                                  index === 0 &&
+                                  ri === 0 &&
+                                  li === 0
                                 }
                                 learnerCount={
                                   journeyMap?.learnerCount ??
@@ -433,7 +424,11 @@ export function RoadmapTab({ slug }: { slug: string }) {
         {(() => {
           const allLessons = [...chapters]
             .sort((a, b) => a.order - b.order)
-            .flatMap((ch) => [...ch.lessons].sort((a, b) => a.order - b.order));
+            .flatMap((ch) =>
+              mergeLessons(ch, lessonStatusMap)
+                .sort((a, b) => a.order - b.order)
+                .map((lessonInfo) => ({ lesson: lessonInfo, chapter: ch })),
+            );
           const visibleLessons = allLessons.slice(0, visibleLessonCount);
           const hasMoreLessons = visibleLessonCount < allLessons.length;
 
@@ -441,11 +436,9 @@ export function RoadmapTab({ slug }: { slug: string }) {
             <div className="mt-800">
               <h2 className="font-designer-28b text-gray-800">레슨 목록</h2>
               <div className="mt-400 flex flex-col gap-200">
-                {visibleLessons.map((l) => {
-                  const journeyLesson = lessonStatusMap.get(l.lessonId);
-                  const isAccessible =
-                    journeyLesson?.isAccessible ?? !l.isLocked;
-                  const isCompleted = journeyLesson?.status === 'COMPLETED';
+                {visibleLessons.map(({ lesson: l, chapter: lessonChapter }) => {
+                  const isAccessible = l.accessible;
+                  const isCompleted = l.status === 'COMPLETED';
 
                   const card = (
                     <div
@@ -514,12 +507,19 @@ export function RoadmapTab({ slug }: { slug: string }) {
 
                   if (isAccessible && l.lessonId > 0) {
                     return (
-                      <Link
+                      <button
                         key={l.lessonId}
-                        href={`/class/${slug}/lesson/${l.lessonId}`}
+                        type="button"
+                        className="w-full text-left"
+                        onClick={() =>
+                          setSelectedLesson({
+                            lesson: l,
+                            chapter: lessonChapter,
+                          })
+                        }
                       >
                         {card}
-                      </Link>
+                      </button>
                     );
                   }
 
@@ -557,21 +557,6 @@ export function RoadmapTab({ slug }: { slug: string }) {
             router.push(
               `/class/${slug}/lesson/${selectedLesson.lesson.lessonId}`,
             );
-            setSelectedLesson(null);
-          }}
-          onSkip={() => {
-            const lessons = journeyMap?.lessons
-              ? [...journeyMap.lessons].sort((a, b) => a.order - b.order)
-              : [];
-            const nextRequired = lessons.find(
-              (l) =>
-                l.order > selectedLesson.lesson.order &&
-                !l.title.toLowerCase().includes('option'),
-            );
-            setBlinkLessonId(nextRequired?.lessonId ?? null);
-            if (nextRequired) {
-              showToast('다음 레슨으로 이어가세요');
-            }
             setSelectedLesson(null);
           }}
         />

--- a/src/components/pages/class/roadmap-tab.tsx
+++ b/src/components/pages/class/roadmap-tab.tsx
@@ -425,10 +425,12 @@ export function RoadmapTab({ slug }: { slug: string }) {
           const allLessons = [...chapters]
             .sort((a, b) => a.order - b.order)
             .flatMap((ch) =>
-              mergeLessons(ch, lessonStatusMap)
-                .sort((a, b) => a.order - b.order)
-                .map((lessonInfo) => ({ lesson: lessonInfo, chapter: ch })),
-            );
+              mergeLessons(ch, lessonStatusMap).map((lessonInfo) => ({
+                lesson: lessonInfo,
+                chapter: ch,
+              })),
+            )
+            .sort((a, b) => a.lesson.order - b.lesson.order);
           const visibleLessons = allLessons.slice(0, visibleLessonCount);
           const hasMoreLessons = visibleLessonCount < allLessons.length;
 


### PR DESCRIPTION
## 개요

레슨 로드맵 탭 및 알림 카드에서 발생한 5가지 UX 버그를 수정합니다. 도장 깜빡임 오진, 미리보기 모달 높이 과다, 알림 버튼 텍스트, 완료 도장 텍스트 invisible, 잠긴 도장 자물쇠 아이콘 미표시 이슈를 포함합니다.

## 원본 PR

- develop PR #670: https://github.com/code-zero-to-one/study-platform-client/pull/670
- develop PR #671: https://github.com/code-zero-to-one/study-platform-client/pull/671
- 원본 브랜치: `fix/lesson-list`

## Cherry-pick 대상 커밋

- `e71fb54b` — [lesson-list] fix : 레슨 도장 깜빡임 오진 및 미리보기 모달 높이 과다 수정
- `b1362eea` — [lesson-list] fix : 알림 시간 미설정 시 버튼 텍스트를 "시간 등록하기"로 표시
- `07c22ab4` — [lesson-list] fix : 레슨 목록 전역 정렬 — 옵션 레슨이 챕터 경계를 깨는 문제 수정
- `aa4bf72b` — [lesson-list] fix : 완료된 레슨 도장 텍스트가 rose 배경과 동색으로 invisible
- `465372cc` — [lesson-list] fix : 미구현 건너뛰기 E2E 테스트 임시 skip 처리
- `3a9f7a8a` — [lesson-list] fix : 잠긴 레슨 도장 자물쇠 아이콘 및 툴팁 미표시 수정

## 변경 파일

- `src/components/pages/class/roadmap-tab.tsx` — 도장 깜빡임 오진 수정, 옵션 레슨 정렬 수정
- `src/components/pages/class/lesson-preview-modal.tsx` — 설명 line-clamp-3, Option Bonus 로직 제거
- `src/app/(service)/(my)/my-class/page.tsx` — 알림 버튼 텍스트 hasTime 조건 처리
- `src/components/pages/class/lesson-stamp.tsx` — COMPLETED 텍스트 white, 잠긴 도장 자물쇠/툴팁 수정
- `src/components/pages/class/home-constants.ts` — lockReason 도출 조건 수정 (status === 'LOCKED' 기준)
- `e2e/class/journey-map.spec.ts` — 미구현 건너뛰기 테스트 2개 임시 skip

## 혼입 검증 결과

각 커밋이 건드리는 파일을 개별 확인 (`git diff-tree --name-only`) — 6개 커밋 모두 PR 범위 파일만 포함, develop 전용 코드 혼입 없음.

- [x] develop 전용 코드 혼입 없음

## Test plan

- [ ] 레슨 로드맵 탭 진입 시 데이터 로드 전 첫 번째 도장 깜빡임 없음 확인
- [ ] 긴 설명의 레슨 미리보기 모달 높이 3줄 clamp 확인
- [ ] 알림 시간 미설정 상태: 버튼 "시간 등록하기" 표시
- [ ] 알림 시간 설정 후: 버튼 "시간 수정하기" 표시
- [ ] 완료된 레슨 도장 "완료 / Lesson / 번호" 텍스트 흰색으로 표시
- [ ] PAID 유저 + 돌아보기 미제출 시 다음 레슨 도장에 자물쇠 아이콘 표시
- [ ] 자물쇠 도장 hover → "이전 레슨을 완료해야 진입할 수 있어요" 툴팁 표시
- [ ] 정상 IN_PROGRESS 도장 hover → "N명이 함께 달리는 중" 툴팁 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)