### PR TITLE
잠긴 레슨 도장 클릭 차단 및 툴팁 통일

### DIFF
--- a/src/components/pages/class/lesson-stamp.tsx
+++ b/src/components/pages/class/lesson-stamp.tsx
@@ -34,11 +34,7 @@ export function LessonStamp({
   const stampContent = (
     <div
       className="relative flex size-1650 shrink-0 flex-col items-center justify-center"
-      onMouseEnter={() =>
-        ((!isLocked && !isCompleted) ||
-          (isLocked && lesson.lockReason === 'retrospective')) &&
-        setShowTooltip(true)
-      }
+      onMouseEnter={() => !isCompleted && setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
     >
       <Image
@@ -89,26 +85,18 @@ export function LessonStamp({
           {String(lesson.order).padStart(2, '0')}
         </p>
       </div>
-      {showTooltip &&
-        (isLocked && lesson.lockReason === 'retrospective' ? (
-          <div className="absolute -top-400 left-1/2 flex -translate-x-1/2 items-center gap-75 whitespace-nowrap rounded-100 bg-gray-900 px-150 py-75">
-            <Lock className="size-200 text-gray-0" />
-            <span className="font-designer-12r text-gray-0">
-              이전 레슨을 완료해야 진입할 수 있어요
-            </span>
-          </div>
-        ) : (
-          <div className="absolute -top-400 left-1/2 flex -translate-x-1/2 items-center gap-75 whitespace-nowrap rounded-100 bg-gray-900 px-150 py-75">
-            <Users className="size-200 text-gray-0" />
-            <span className="font-designer-12r text-gray-0">
-              {learnerCount}명이 함께 달리는 중
-            </span>
-          </div>
-        ))}
+      {showTooltip && (
+        <div className="absolute -top-400 left-1/2 flex -translate-x-1/2 items-center gap-75 whitespace-nowrap rounded-100 bg-gray-900 px-150 py-75">
+          <Users className="size-200 text-gray-0" />
+          <span className="font-designer-12r text-gray-0">
+            {learnerCount}명이 함께 달리는 중
+          </span>
+        </div>
+      )}
     </div>
   );
 
-  if (lesson.accessible) {
+  if (lesson.accessible && !isLocked) {
     if (!isAuthenticated) {
       return (
         <LoginModal


### PR DESCRIPTION
## Problem

이전 레슨을 완료하지 않아 잠긴 레슨 도장에 두 가지 문제가 있었음.

1. **클릭 차단 미작동**: `lockReason === 'retrospective'`인 레슨은 `accessible = true`로 설정되어 stamp가 button으로 렌더링됨 → 클릭 시 레슨 미리보기 모달이 열림 (cursor-not-allowed 의도 무색)
2. **툴팁 미표시**: `lockReason === 'access'`인 레슨은 `onMouseEnter` 조건에서 누락되어 hover 시 툴팁이 뜨지 않음

**Root cause:**
- `onMouseEnter` 조건이 `retrospective`만 허용 → `access` 케이스 툴팁 미표시
- 클릭 가능 조건이 `lesson.accessible`만 체크 → LOCKED 상태여도 accessible=true면 클릭 가능

## Solution

- `onMouseEnter` 조건을 `!isCompleted`로 단순화 → 모든 미완료 레슨에서 툴팁 표시
- 클릭 가능 조건에 `!isLocked` 추가 → LOCKED 레슨은 accessible 여부 무관하게 클릭 차단
- 툴팁 내용 분기 제거 → 모든 미완료 레슨에서 "n명이 함께 달리는 중" 단일 메시지

## Changes

### Bug Fixes
| File | Description |
|------|-------------|
| `src/components/pages/class/lesson-stamp.tsx` | LOCKED 레슨 클릭 차단, hover 툴팁 조건 및 내용 통일 |

## Result

- 이전 레슨 미완료 시 이후 모든 레슨 도장 → 클릭 불가 (cursor-not-allowed)
- 미완료 레슨 도장 hover → lockReason 무관하게 "n명이 함께 달리는 중" 툴팁 표시
- 완료된 레슨 → 툴팁 없음

## Screenshots

| Before | After |
|--------|-------|
| retrospective 잠긴 레슨 클릭 → 미리보기 모달 열림 | 클릭 차단, hover 시 툴팁만 표시 |
| access 잠긴 레슨 hover → 툴팁 미표시 | "n명이 함께 달리는 중" 툴팁 표시 |

## Test plan

- [ ] 이전 레슨 미완료 상태에서 이후 레슨 도장 클릭 → 모달 열리지 않음
- [ ] 잠긴 레슨 도장 hover → "n명이 함께 달리는 중" 툴팁 표시
- [ ] 완료된 레슨 도장 hover → 툴팁 미표시
- [ ] IN_PROGRESS 레슨 도장 hover → "n명이 함께 달리는 중" 툴팁 표시
- [ ] 인증되지 않은 사용자 accessible 레슨 클릭 → 로그인 모달 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩토링**
  * 레슨 스탐프의 마우스 호버 시 표시되는 툴팁 로직을 단순화했습니다. 함께 달리는 사용자 수 정보를 보다 일관되게 확인할 수 있게 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->