### PR TITLE
[cherry-pick] fix: 잠긴 레슨 도장 클릭 차단 및 hover 툴팁 통일

### DIFF
--- a/src/components/pages/class/lesson-stamp.tsx
+++ b/src/components/pages/class/lesson-stamp.tsx
@@ -34,11 +34,7 @@ export function LessonStamp({
   const stampContent = (
     <div
       className="relative flex size-1650 shrink-0 flex-col items-center justify-center"
-      onMouseEnter={() =>
-        ((!isLocked && !isCompleted) ||
-          (isLocked && lesson.lockReason === 'retrospective')) &&
-        setShowTooltip(true)
-      }
+      onMouseEnter={() => !isCompleted && setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
     >
       <Image
@@ -89,26 +85,18 @@ export function LessonStamp({
           {String(lesson.order).padStart(2, '0')}
         </p>
       </div>
-      {showTooltip &&
-        (isLocked && lesson.lockReason === 'retrospective' ? (
-          <div className="absolute -top-400 left-1/2 flex -translate-x-1/2 items-center gap-75 whitespace-nowrap rounded-100 bg-gray-900 px-150 py-75">
-            <Lock className="size-200 text-gray-0" />
-            <span className="font-designer-12r text-gray-0">
-              이전 레슨을 완료해야 진입할 수 있어요
-            </span>
-          </div>
-        ) : (
-          <div className="absolute -top-400 left-1/2 flex -translate-x-1/2 items-center gap-75 whitespace-nowrap rounded-100 bg-gray-900 px-150 py-75">
-            <Users className="size-200 text-gray-0" />
-            <span className="font-designer-12r text-gray-0">
-              {learnerCount}명이 함께 달리는 중
-            </span>
-          </div>
-        ))}
+      {showTooltip && (
+        <div className="absolute -top-400 left-1/2 flex -translate-x-1/2 items-center gap-75 whitespace-nowrap rounded-100 bg-gray-900 px-150 py-75">
+          <Users className="size-200 text-gray-0" />
+          <span className="font-designer-12r text-gray-0">
+            {learnerCount}명이 함께 달리는 중
+          </span>
+        </div>
+      )}
     </div>
   );
 
-  if (lesson.accessible) {
+  if (lesson.accessible && !isLocked) {
     if (!isAuthenticated) {
       return (
         <LoginModal


### PR DESCRIPTION
## Summary

- Cherry-pick of `932d40dc` from `fix/stamp` → `main`
- 잠긴 레슨 도장 클릭 이벤트 차단 + hover 툴팁 통일

## Changed Files

- `src/components/pages/class/lesson-stamp.tsx` (1 file only)

## Verification

- [x] `yarn typecheck` — pass
- [x] `yarn lint` — pass
- [x] diff = `lesson-stamp.tsx` 단일 파일 확인

## Original PR

#673