### PR TITLE
feat: 어드민 알림톡 화면 추가

### DIFF
--- a/src/app/(admin)/admin/alerttalk/delivery-logs/[jobId]/page.tsx
+++ b/src/app/(admin)/admin/alerttalk/delivery-logs/[jobId]/page.tsx
@@ -1,0 +1,11 @@
+import { AdminAlerttalkDeliveryLogDetailPageClient } from '@/features/admin/alerttalk/ui/admin-alerttalk-pages';
+
+export default async function AdminAlerttalkDeliveryLogDetailPage({
+  params,
+}: {
+  params: Promise<{ jobId: string }>;
+}) {
+  const { jobId } = await params;
+
+  return <AdminAlerttalkDeliveryLogDetailPageClient jobId={Number(jobId)} />;
+}

--- a/src/app/(admin)/admin/alerttalk/delivery-logs/page.tsx
+++ b/src/app/(admin)/admin/alerttalk/delivery-logs/page.tsx
@@ -1,0 +1,5 @@
+import { AdminAlerttalkDeliveryLogListPageClient } from '@/features/admin/alerttalk/ui/admin-alerttalk-pages';
+
+export default function AdminAlerttalkDeliveryLogsPage() {
+  return <AdminAlerttalkDeliveryLogListPageClient />;
+}

--- a/src/app/(admin)/admin/alerttalk/schedules/dry-run/page.tsx
+++ b/src/app/(admin)/admin/alerttalk/schedules/dry-run/page.tsx
@@ -1,0 +1,5 @@
+import { AdminAlerttalkDryRunPageClient } from '@/features/admin/alerttalk/ui/admin-alerttalk-pages';
+
+export default function AdminAlerttalkDryRunPage() {
+  return <AdminAlerttalkDryRunPageClient />;
+}

--- a/src/app/(admin)/admin/alerttalk/templates/page.tsx
+++ b/src/app/(admin)/admin/alerttalk/templates/page.tsx
@@ -1,0 +1,5 @@
+import { AdminAlerttalkTemplatePageClient } from '@/features/admin/alerttalk/ui/admin-alerttalk-pages';
+
+export default function AdminAlerttalkTemplatesPage() {
+  return <AdminAlerttalkTemplatePageClient />;
+}

--- a/src/components/common/layout/sidebar/admin-sidebar.tsx
+++ b/src/components/common/layout/sidebar/admin-sidebar.tsx
@@ -17,6 +17,7 @@ export default function AdminSideBar() {
   const isMentoringManagementPath = pathname.startsWith('/admin/mentoring');
   const isMatchingManagementPath = pathname.startsWith('/admin/matching');
   const isCourseManagementPath = pathname.startsWith('/admin/courses');
+  const isAlerttalkManagementPath = pathname.startsWith('/admin/alerttalk');
 
   return (
     <aside className="border-border-subtle h-screen w-fit border-r p-200">
@@ -81,6 +82,14 @@ export default function AdminSideBar() {
           onClick={() => router.push('/admin/matching')}
         >
           <TabMenu active={isMatchingManagementPath}>1:1 매칭 관리</TabMenu>
+        </button>
+
+        <button
+          className="w-full text-left"
+          type="button"
+          onClick={() => router.push('/admin/alerttalk/templates')}
+        >
+          <TabMenu active={isAlerttalkManagementPath}>알림톡 관리</TabMenu>
         </button>
       </nav>
     </aside>

--- a/src/features/admin/alerttalk/api/admin-alerttalk-api.ts
+++ b/src/features/admin/alerttalk/api/admin-alerttalk-api.ts
@@ -1,0 +1,132 @@
+import { axiosInstanceV5 } from '@/api/client/axios';
+import type {
+  AdminAlerttalkDeliveryLog,
+  AdminAlerttalkDeliveryLogDetail,
+  AdminAlerttalkDeliveryLogFilters,
+  AdminAlerttalkDeliveryLogListResponse,
+  AdminAlerttalkDryRunRequest,
+  AdminAlerttalkDryRunResponse,
+  AdminAlerttalkRetryRequest,
+  AdminAlerttalkRetryResponse,
+  AdminAlerttalkTemplateListParams,
+  AdminAlerttalkTemplateListResponse,
+  AdminAlerttalkTemplateSyncRequest,
+  AdminAlerttalkTemplateSyncResponse,
+  AdminAlerttalkTemplateTestSendRequest,
+  AdminAlerttalkTemplateTestSendResponse,
+  ApiBaseResponse,
+} from '@/features/admin/alerttalk/model/admin-alerttalk-contract';
+
+type ApiEnvelope<T> = ApiBaseResponse<T> | { data?: ApiBaseResponse<T> };
+
+const isApiBaseResponse = <T>(value: unknown): value is ApiBaseResponse<T> => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'statusCode' in value &&
+    'timestamp' in value &&
+    'content' in value
+  );
+};
+
+const unwrap = <T>(response: ApiEnvelope<T>): T => {
+  if ('data' in response && isApiBaseResponse<T>(response.data)) {
+    return response.data.content;
+  }
+
+  if (isApiBaseResponse<T>(response)) {
+    return response.content;
+  }
+
+  throw new Error('API 응답 본문 형식이 올바르지 않습니다.');
+};
+
+const normalizeDeliveryLogs = (
+  response: AdminAlerttalkDeliveryLogListResponse | AdminAlerttalkDeliveryLog[],
+): AdminAlerttalkDeliveryLogListResponse => {
+  if (Array.isArray(response)) {
+    return { logs: response };
+  }
+
+  return response;
+};
+
+export const getAdminAlerttalkTemplates = async (
+  params: AdminAlerttalkTemplateListParams,
+): Promise<AdminAlerttalkTemplateListResponse> => {
+  const response = await axiosInstanceV5.get<
+    ApiBaseResponse<AdminAlerttalkTemplateListResponse>
+  >('admin/alerttalk/templates', { params });
+
+  return unwrap(response);
+};
+
+export const syncAdminAlerttalkTemplates = async (
+  request: AdminAlerttalkTemplateSyncRequest = {},
+): Promise<AdminAlerttalkTemplateSyncResponse> => {
+  const response = await axiosInstanceV5.post<
+    ApiBaseResponse<AdminAlerttalkTemplateSyncResponse>
+  >('admin/alerttalk/templates/sync', request);
+
+  return unwrap(response);
+};
+
+export const testSendAdminAlerttalkTemplate = async ({
+  templateKey,
+  request,
+}: {
+  templateKey: string;
+  request: AdminAlerttalkTemplateTestSendRequest;
+}): Promise<AdminAlerttalkTemplateTestSendResponse> => {
+  const response = await axiosInstanceV5.post<
+    ApiBaseResponse<AdminAlerttalkTemplateTestSendResponse>
+  >(`admin/alerttalk/templates/${templateKey}/test-send`, request);
+
+  return unwrap(response);
+};
+
+export const getAdminAlerttalkDeliveryLogs = async (
+  filters: AdminAlerttalkDeliveryLogFilters,
+): Promise<AdminAlerttalkDeliveryLogListResponse> => {
+  const response = await axiosInstanceV5.get<
+    ApiBaseResponse<
+      AdminAlerttalkDeliveryLogListResponse | AdminAlerttalkDeliveryLog[]
+    >
+  >('admin/alerttalk/delivery-logs', { params: filters });
+
+  return normalizeDeliveryLogs(unwrap(response));
+};
+
+export const getAdminAlerttalkDeliveryLogDetail = async (
+  jobId: number,
+): Promise<AdminAlerttalkDeliveryLogDetail> => {
+  const response = await axiosInstanceV5.get<
+    ApiBaseResponse<AdminAlerttalkDeliveryLogDetail>
+  >(`admin/alerttalk/delivery-logs/${jobId}`);
+
+  return unwrap(response);
+};
+
+export const retryAdminAlerttalkDeliveryLog = async ({
+  jobId,
+  request,
+}: {
+  jobId: number;
+  request: AdminAlerttalkRetryRequest;
+}): Promise<AdminAlerttalkRetryResponse> => {
+  const response = await axiosInstanceV5.post<
+    ApiBaseResponse<AdminAlerttalkRetryResponse>
+  >(`admin/alerttalk/delivery-logs/${jobId}/retry`, request);
+
+  return unwrap(response);
+};
+
+export const dryRunAdminAlerttalkSchedule = async (
+  request: AdminAlerttalkDryRunRequest,
+): Promise<AdminAlerttalkDryRunResponse> => {
+  const response = await axiosInstanceV5.post<
+    ApiBaseResponse<AdminAlerttalkDryRunResponse>
+  >('admin/alerttalk/schedules/dry-run', request);
+
+  return unwrap(response);
+};

--- a/src/features/admin/alerttalk/model/admin-alerttalk-contract.ts
+++ b/src/features/admin/alerttalk/model/admin-alerttalk-contract.ts
@@ -1,0 +1,137 @@
+export type AlerttalkApprovalStatus =
+  | 'APPROVED'
+  | 'REJECTED'
+  | 'PENDING_REVIEW'
+  | 'NOT_SYNCED';
+
+export type AlerttalkDeliveryStatus =
+  | 'CREATED'
+  | 'READY'
+  | 'SENT'
+  | 'FAILED'
+  | 'SKIPPED';
+
+export type AlerttalkRuleType =
+  | 'DAILY_REMINDER'
+  | 'LESSON_NUDGE_3D'
+  | 'RE_ENGAGEMENT'
+  | 'FINAL_NOTICE';
+
+export interface ApiBaseResponse<T> {
+  statusCode: number;
+  timestamp: string;
+  content: T;
+}
+
+export interface AdminAlerttalkTemplateListParams {
+  templateKey?: string;
+  approvalStatus?: AlerttalkApprovalStatus;
+}
+
+export interface AdminAlerttalkTemplate {
+  templateKey: string;
+  aligoTemplateCode?: string;
+  templateName: string;
+  approvalStatus: AlerttalkApprovalStatus | string;
+  dispatchEnabled: boolean;
+  testSendEnabled: boolean;
+  sendPolicySummary: string;
+  templateBodyPreview?: string;
+  lastSyncedAt?: string;
+  rejectionReason?: string;
+}
+
+export interface AdminAlerttalkTemplateListResponse {
+  templates: AdminAlerttalkTemplate[];
+}
+
+export interface AdminAlerttalkTemplateSyncRequest {
+  force?: boolean;
+}
+
+export interface AdminAlerttalkTemplateSyncResponse {
+  syncedCount: number;
+  changedKeys: string[];
+  approvalSummary: Record<string, number>;
+  lastSyncedAt: string;
+}
+
+export interface AdminAlerttalkTemplateTestSendRequest {
+  phoneNumber: string;
+  receiverName?: string;
+  variables?: Record<string, string>;
+}
+
+export interface AdminAlerttalkTemplateTestSendResponse {
+  templateKey: string;
+  templateName: string;
+  requestAccepted: boolean;
+  aligoMessageId?: string;
+  finalPreview: string;
+}
+
+export interface AdminAlerttalkDeliveryLogFilters {
+  templateKey?: string;
+  status?: Extract<AlerttalkDeliveryStatus, 'SENT' | 'FAILED' | 'SKIPPED'>;
+  from?: string;
+  to?: string;
+}
+
+export interface AdminAlerttalkDeliveryLog {
+  jobId: number;
+  triggerType: string;
+  sourceKey: string;
+  memberId?: number;
+  phoneMasked?: string;
+  status: AlerttalkDeliveryStatus | string;
+  templateKey: string;
+  failureReason?: string;
+  sentAt?: string;
+  payloadSnapshot?: Record<string, unknown>;
+}
+
+export interface AdminAlerttalkDeliveryLogListResponse {
+  logs: AdminAlerttalkDeliveryLog[];
+}
+
+export interface AdminAlerttalkDeliveryLogDetail {
+  jobId: number;
+  templateKey: string;
+  triggerType: string;
+  sourceKey: string;
+  status: AlerttalkDeliveryStatus | string;
+  targetCount: number;
+  sentCount: number;
+  failedCount: number;
+  skippedCount: number;
+  targets: AdminAlerttalkDeliveryLog[];
+}
+
+export interface AdminAlerttalkRetryRequest {
+  targetIds?: number[];
+  reason?: string;
+}
+
+export interface AdminAlerttalkRetryResponse {
+  retriedJobId: number;
+  originalJobId: number;
+  retriedTargetCount: number;
+  status: string;
+}
+
+export interface AdminAlerttalkDryRunRequest {
+  templateKey: AlerttalkRuleType;
+  at: string;
+  limit?: number;
+}
+
+export interface AdminAlerttalkDryRunResponse {
+  templateKey: string;
+  candidateCount: number;
+  previewTargets: Array<{
+    memberId?: number;
+    phoneMasked?: string;
+    whyIncluded: string;
+  }>;
+  dispatchCreated: boolean;
+}

--- a/src/features/admin/alerttalk/model/use-admin-alerttalk-query.ts
+++ b/src/features/admin/alerttalk/model/use-admin-alerttalk-query.ts
@@ -1,0 +1,124 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  dryRunAdminAlerttalkSchedule,
+  getAdminAlerttalkDeliveryLogDetail,
+  getAdminAlerttalkDeliveryLogs,
+  getAdminAlerttalkTemplates,
+  retryAdminAlerttalkDeliveryLog,
+  syncAdminAlerttalkTemplates,
+  testSendAdminAlerttalkTemplate,
+} from '@/features/admin/alerttalk/api/admin-alerttalk-api';
+import type {
+  AdminAlerttalkDeliveryLogFilters,
+  AdminAlerttalkTemplateListParams,
+} from '@/features/admin/alerttalk/model/admin-alerttalk-contract';
+import { useToastStore } from '@/stores/use-toast-store';
+import { analyzeError } from '@/utils/error-handler';
+
+export const adminAlerttalkQueryKeys = {
+  all: ['admin-alerttalk'] as const,
+  templates: (params: AdminAlerttalkTemplateListParams) =>
+    [...adminAlerttalkQueryKeys.all, 'templates', params] as const,
+  templateLists: () => [...adminAlerttalkQueryKeys.all, 'templates'] as const,
+  deliveryLogs: (filters: AdminAlerttalkDeliveryLogFilters) =>
+    [...adminAlerttalkQueryKeys.all, 'delivery-logs', filters] as const,
+  deliveryLogLists: () =>
+    [...adminAlerttalkQueryKeys.all, 'delivery-logs'] as const,
+  deliveryLogDetail: (jobId?: number) =>
+    [...adminAlerttalkQueryKeys.all, 'delivery-log-detail', jobId] as const,
+};
+
+const showMutationError = (error: unknown) => {
+  const { userMessage } = analyzeError(error);
+  useToastStore
+    .getState()
+    .showToast(userMessage || '요청 처리 중 오류가 발생했습니다.', 'error');
+};
+
+export const useAdminAlerttalkTemplatesQuery = (
+  params: AdminAlerttalkTemplateListParams,
+) =>
+  useQuery({
+    queryKey: adminAlerttalkQueryKeys.templates(params),
+    queryFn: () => getAdminAlerttalkTemplates(params),
+    staleTime: 60_000,
+  });
+
+export const useAdminAlerttalkDeliveryLogsQuery = (
+  filters: AdminAlerttalkDeliveryLogFilters,
+) =>
+  useQuery({
+    queryKey: adminAlerttalkQueryKeys.deliveryLogs(filters),
+    queryFn: () => getAdminAlerttalkDeliveryLogs(filters),
+    staleTime: 30_000,
+  });
+
+export const useAdminAlerttalkDeliveryLogDetailQuery = (jobId?: number) =>
+  useQuery({
+    queryKey: adminAlerttalkQueryKeys.deliveryLogDetail(jobId),
+    queryFn: () => getAdminAlerttalkDeliveryLogDetail(jobId ?? 0),
+    enabled: typeof jobId === 'number',
+    staleTime: 30_000,
+  });
+
+export const useSyncAdminAlerttalkTemplatesMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: syncAdminAlerttalkTemplates,
+    onSuccess: async (response) => {
+      useToastStore
+        .getState()
+        .showToast(
+          `${response.syncedCount}개 템플릿 상태를 동기화했습니다.`,
+          'success',
+        );
+      await queryClient.invalidateQueries({
+        queryKey: adminAlerttalkQueryKeys.templateLists(),
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useTestSendAdminAlerttalkTemplateMutation = () =>
+  useMutation({
+    mutationFn: testSendAdminAlerttalkTemplate,
+    onSuccess: () => {
+      useToastStore
+        .getState()
+        .showToast('테스트 발송을 요청했습니다.', 'success');
+    },
+    onError: showMutationError,
+  });
+
+export const useRetryAdminAlerttalkDeliveryLogMutation = (jobId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: retryAdminAlerttalkDeliveryLog,
+    onSuccess: async (response) => {
+      useToastStore
+        .getState()
+        .showToast(
+          `재실행 job ${response.retriedJobId}를 생성했습니다.`,
+          'success',
+        );
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: adminAlerttalkQueryKeys.deliveryLogLists(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: adminAlerttalkQueryKeys.deliveryLogDetail(jobId),
+        }),
+      ]);
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useDryRunAdminAlerttalkScheduleMutation = () =>
+  useMutation({
+    mutationFn: dryRunAdminAlerttalkSchedule,
+    onError: showMutationError,
+  });

--- a/src/features/admin/alerttalk/ui/admin-alerttalk-pages.tsx
+++ b/src/features/admin/alerttalk/ui/admin-alerttalk-pages.tsx
@@ -1,0 +1,935 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState, type ReactNode } from 'react';
+import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import Badge from '@/components/common/ui/badge';
+import Button from '@/components/common/ui/button';
+import { BaseInput, NativeSelect } from '@/components/common/ui/input';
+import { Modal } from '@/components/common/ui/modal';
+import {
+  DataTable,
+  DataTableCell,
+  DataTableHead,
+  DataTableHeadCell,
+  DataTableRow,
+} from '@/components/common/ui/table/data-table';
+import type {
+  AdminAlerttalkDeliveryLog,
+  AdminAlerttalkDeliveryLogFilters,
+  AdminAlerttalkDeliveryLogDetail,
+  AdminAlerttalkTemplate,
+  AdminAlerttalkTemplateTestSendResponse,
+  AlerttalkApprovalStatus,
+  AlerttalkDeliveryStatus,
+  AlerttalkRuleType,
+} from '@/features/admin/alerttalk/model/admin-alerttalk-contract';
+import {
+  useAdminAlerttalkDeliveryLogDetailQuery,
+  useAdminAlerttalkDeliveryLogsQuery,
+  useAdminAlerttalkTemplatesQuery,
+  useDryRunAdminAlerttalkScheduleMutation,
+  useRetryAdminAlerttalkDeliveryLogMutation,
+  useSyncAdminAlerttalkTemplatesMutation,
+  useTestSendAdminAlerttalkTemplateMutation,
+} from '@/features/admin/alerttalk/model/use-admin-alerttalk-query';
+
+const APPROVAL_STATUS_OPTIONS: Array<AlerttalkApprovalStatus | ''> = [
+  '',
+  'APPROVED',
+  'REJECTED',
+  'PENDING_REVIEW',
+  'NOT_SYNCED',
+];
+const DELIVERY_STATUS_OPTIONS: Array<
+  Extract<AlerttalkDeliveryStatus, 'SENT' | 'FAILED' | 'SKIPPED'> | ''
+> = ['', 'SENT', 'FAILED', 'SKIPPED'];
+const RULE_TYPE_OPTIONS: AlerttalkRuleType[] = [
+  'DAILY_REMINDER',
+  'LESSON_NUDGE_3D',
+  'RE_ENGAGEMENT',
+  'FINAL_NOTICE',
+];
+const EMPTY_TEMPLATES: AdminAlerttalkTemplate[] = [];
+
+const formatDateTime = (value?: string) => {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+};
+
+const statusLabelMap: Record<string, string> = {
+  APPROVED: '승인완료',
+  REJECTED: '반려',
+  PENDING_REVIEW: '검수중',
+  NOT_SYNCED: '미등록',
+  CREATED: '생성',
+  READY: '대기',
+  SENT: '성공',
+  FAILED: '실패',
+  SKIPPED: '스킵',
+};
+
+const getBadgeColor = (status: string) => {
+  if (status === 'APPROVED' || status === 'SENT' || status === 'READY') {
+    return 'green' as const;
+  }
+  if (status === 'REJECTED' || status === 'FAILED') return 'red' as const;
+  if (status === 'PENDING_REVIEW' || status === 'CREATED')
+    return 'orange' as const;
+
+  return 'gray' as const;
+};
+
+const StatusBadge = ({ status }: { status: string }) => (
+  <Badge color={getBadgeColor(status)} shape="rectangle">
+    {statusLabelMap[status] ?? status}
+  </Badge>
+);
+
+const BooleanBadge = ({ enabled }: { enabled: boolean }) => (
+  <Badge color={enabled ? 'green' : 'gray'} shape="rectangle">
+    {enabled ? '가능' : '불가'}
+  </Badge>
+);
+
+const PageTabs = ({ active }: { active: 'templates' | 'logs' | 'dry-run' }) => {
+  const tabs = [
+    {
+      key: 'templates',
+      label: '템플릿 관리',
+      href: '/admin/alerttalk/templates',
+    },
+    { key: 'logs', label: '발송 로그', href: '/admin/alerttalk/delivery-logs' },
+    {
+      key: 'dry-run',
+      label: '배치 점검',
+      href: '/admin/alerttalk/schedules/dry-run',
+    },
+  ] as const;
+
+  return (
+    <nav className="flex flex-wrap gap-75">
+      {tabs.map((tab) => (
+        <Link
+          key={tab.key}
+          href={tab.href}
+          className={cn(
+            'font-designer-14b rounded-100 border px-150 py-100',
+            active === tab.key
+              ? 'border-border-brand bg-fill-brand-subtle-default text-text-brand'
+              : 'border-border-default bg-background-default text-text-subtle',
+          )}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+};
+
+const PageShell = ({
+  active,
+  title,
+  description,
+  action,
+  children,
+}: {
+  active: 'templates' | 'logs' | 'dry-run';
+  title: string;
+  description: string;
+  action?: ReactNode;
+  children: ReactNode;
+}) => (
+  <main className="bg-background-alternative min-h-screen w-full p-300">
+    <div className="mx-auto flex w-full flex-col gap-200">
+      <PageTabs active={active} />
+      <header className="border-border-default bg-background-default rounded-150 flex flex-wrap items-start justify-between gap-150 border p-250">
+        <div>
+          <h1 className="font-designer-24b text-text-default">{title}</h1>
+          <p className="font-designer-14r text-text-subtle mt-75">
+            {description}
+          </p>
+        </div>
+        {action}
+      </header>
+      {children}
+    </div>
+  </main>
+);
+
+const SummaryCard = ({
+  label,
+  value,
+  description,
+}: {
+  label: string;
+  value: string | number;
+  description?: string;
+}) => (
+  <div className="border-border-default bg-background-default rounded-150 border p-200">
+    <p className="font-designer-13r text-text-subtle">{label}</p>
+    <p className="font-designer-24b text-text-default mt-75">{value}</p>
+    {description ? (
+      <p className="font-designer-12r text-text-subtlest mt-50">
+        {description}
+      </p>
+    ) : null}
+  </div>
+);
+
+const RejectionReasonModal = ({
+  template,
+  open,
+  onOpenChange,
+}: {
+  template?: AdminAlerttalkTemplate;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => (
+  <Modal.Root open={open} onOpenChange={onOpenChange}>
+    <Modal.Portal>
+      <Modal.Overlay />
+      <Modal.Content size="small">
+        <Modal.Header className="flex items-start justify-between gap-150">
+          <div>
+            <Modal.Title>반려/미등록 사유</Modal.Title>
+            <p className="font-designer-13r text-text-subtle mt-75">
+              {template?.templateName ?? '-'}
+            </p>
+          </div>
+          <Modal.CloseButton />
+        </Modal.Header>
+        <Modal.Body>
+          <p className="font-designer-14r text-text-default whitespace-pre-wrap">
+            {template?.rejectionReason || '등록된 사유가 없습니다.'}
+          </p>
+        </Modal.Body>
+      </Modal.Content>
+    </Modal.Portal>
+  </Modal.Root>
+);
+
+const TemplateTestSendModal = ({
+  template,
+  open,
+  onOpenChange,
+}: {
+  template?: AdminAlerttalkTemplate;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [receiverName, setReceiverName] = useState('');
+  const [result, setResult] =
+    useState<AdminAlerttalkTemplateTestSendResponse>();
+  const mutation = useTestSendAdminAlerttalkTemplateMutation();
+
+  const submit = async () => {
+    if (!template || !phoneNumber.trim()) return;
+    const response = await mutation.mutateAsync({
+      templateKey: template.templateKey,
+      request: {
+        phoneNumber: phoneNumber.trim(),
+        ...(receiverName.trim() ? { receiverName: receiverName.trim() } : {}),
+      },
+    });
+    setResult(response);
+  };
+
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        onOpenChange(nextOpen);
+        if (!nextOpen) {
+          setPhoneNumber('');
+          setReceiverName('');
+          setResult(undefined);
+        }
+      }}
+    >
+      <Modal.Portal>
+        <Modal.Overlay />
+        <Modal.Content size="medium">
+          <Modal.Header className="flex items-start justify-between gap-150">
+            <div>
+              <Modal.Title>템플릿 테스트 발송</Modal.Title>
+              <p className="font-designer-13r text-text-subtle mt-75">
+                실제 알림톡 발송 요청입니다. 검증용 번호만 입력하세요.
+              </p>
+            </div>
+            <Modal.CloseButton />
+          </Modal.Header>
+          <Modal.Body className="flex flex-col gap-200">
+            {template ? (
+              <section className="bg-background-alternative rounded-150 p-150">
+                <p className="font-designer-16b text-text-default">
+                  {template.templateName}
+                </p>
+                <p className="font-designer-13r text-text-subtle mt-50 break-all">
+                  {template.templateKey} ·{' '}
+                  {template.aligoTemplateCode ?? '코드 없음'}
+                </p>
+                <p className="font-designer-13r text-text-subtle mt-50">
+                  {template.sendPolicySummary}
+                </p>
+              </section>
+            ) : null}
+            <label className="flex flex-col gap-75">
+              <span className="font-designer-13b text-text-default">
+                전화번호
+              </span>
+              <BaseInput
+                inputMode="numeric"
+                placeholder="01012345678"
+                value={phoneNumber}
+                onValueChange={setPhoneNumber}
+              />
+            </label>
+            <label className="flex flex-col gap-75">
+              <span className="font-designer-13b text-text-default">
+                수신자명 선택
+              </span>
+              <BaseInput
+                placeholder="미입력 시 서버 기본값 사용"
+                value={receiverName}
+                onValueChange={setReceiverName}
+              />
+            </label>
+            {result ? (
+              <section className="border-border-success bg-fill-success-subtle-default rounded-150 flex flex-col gap-100 border p-150">
+                <div className="flex flex-wrap items-center gap-75">
+                  <StatusBadge
+                    status={result.requestAccepted ? 'SENT' : 'READY'}
+                  />
+                  <span className="font-designer-14b text-text-default">
+                    요청 접수: {result.requestAccepted ? '성공' : '확인 필요'}
+                  </span>
+                </div>
+                <p className="font-designer-13r text-text-default whitespace-pre-wrap">
+                  {result.finalPreview}
+                </p>
+                <p className="font-designer-13r text-text-subtle">
+                  Aligo message id: {result.aligoMessageId ?? '-'}
+                </p>
+              </section>
+            ) : null}
+          </Modal.Body>
+          <Modal.Footer className="flex justify-end gap-100">
+            <Button color="outlined" onClick={() => onOpenChange(false)}>
+              닫기
+            </Button>
+            <Button
+              loading={mutation.isPending}
+              disabled={!template || !phoneNumber.trim()}
+              onClick={submit}
+            >
+              발송하기
+            </Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal.Portal>
+    </Modal.Root>
+  );
+};
+
+const JsonPreview = ({ value }: { value?: Record<string, unknown> }) => {
+  if (!value) return <span>-</span>;
+
+  return (
+    <pre className="bg-background-alternative rounded-100 font-designer-12r text-text-subtle overflow-auto p-100 whitespace-pre-wrap">
+      {JSON.stringify(value, null, 2)}
+    </pre>
+  );
+};
+
+export function AdminAlerttalkTemplatePageClient() {
+  const [approvalStatus, setApprovalStatus] = useState<
+    AlerttalkApprovalStatus | ''
+  >('');
+  const [templateKey, setTemplateKey] = useState('');
+  const [reasonTemplate, setReasonTemplate] =
+    useState<AdminAlerttalkTemplate>();
+  const [testTemplate, setTestTemplate] = useState<AdminAlerttalkTemplate>();
+  const params = useMemo(
+    () => ({
+      ...(approvalStatus ? { approvalStatus } : {}),
+      ...(templateKey.trim() ? { templateKey: templateKey.trim() } : {}),
+    }),
+    [approvalStatus, templateKey],
+  );
+  const templatesQuery = useAdminAlerttalkTemplatesQuery(params);
+  const syncMutation = useSyncAdminAlerttalkTemplatesMutation();
+  const templates = templatesQuery.data?.templates ?? EMPTY_TEMPLATES;
+  const counts = useMemo(
+    () => ({
+      approved: templates.filter((item) => item.approvalStatus === 'APPROVED')
+        .length,
+      rejected: templates.filter((item) => item.approvalStatus === 'REJECTED')
+        .length,
+      notSynced: templates.filter(
+        (item) => item.approvalStatus === 'NOT_SYNCED',
+      ).length,
+      lastSyncedAt: templates
+        .map((item) => item.lastSyncedAt)
+        .filter(Boolean)
+        .sort()
+        .at(-1),
+    }),
+    [templates],
+  );
+
+  return (
+    <PageShell
+      active="templates"
+      title="클래스 알림톡 템플릿"
+      description="승인 상태, 반려 사유, 테스트 발송 가능 여부를 한 화면에서 확인합니다."
+      action={
+        <Button
+          loading={syncMutation.isPending}
+          onClick={() => syncMutation.mutate({ force: false })}
+        >
+          알리고 상태 다시 불러오기
+        </Button>
+      }
+    >
+      <section className="grid grid-cols-1 gap-150 md:grid-cols-4">
+        <SummaryCard label="승인완료" value={counts.approved} />
+        <SummaryCard label="반려" value={counts.rejected} />
+        <SummaryCard label="미등록" value={counts.notSynced} />
+        <SummaryCard
+          label="마지막 sync"
+          value={formatDateTime(counts.lastSyncedAt)}
+        />
+      </section>
+
+      <section className="border-border-default bg-background-default rounded-150 flex flex-col gap-150 border p-200">
+        <div className="flex flex-wrap gap-100">
+          <NativeSelect
+            value={approvalStatus}
+            onChange={(event) =>
+              setApprovalStatus(
+                event.target.value as AlerttalkApprovalStatus | '',
+              )
+            }
+          >
+            {APPROVAL_STATUS_OPTIONS.map((status) => (
+              <option key={status || 'ALL'} value={status}>
+                {status ? (statusLabelMap[status] ?? status) : '전체 상태'}
+              </option>
+            ))}
+          </NativeSelect>
+          <div className="min-w-0 flex-1">
+            <BaseInput
+              placeholder="templateKey 검색"
+              value={templateKey}
+              onValueChange={setTemplateKey}
+            />
+          </div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <DataTable>
+            <DataTableHead>
+              <DataTableRow>
+                {[
+                  '템플릿명',
+                  '내부 키',
+                  '알리고 코드',
+                  '승인상태',
+                  '발송시점',
+                  '발송',
+                  '테스트',
+                  '본문 미리보기',
+                  '액션',
+                ].map((header) => (
+                  <DataTableHeadCell key={header}>{header}</DataTableHeadCell>
+                ))}
+              </DataTableRow>
+            </DataTableHead>
+            <tbody>
+              {templates.length === 0 ? (
+                <DataTableRow>
+                  <DataTableCell colSpan={9} align="center" tone="subtle">
+                    {templatesQuery.isLoading
+                      ? '템플릿을 불러오는 중입니다.'
+                      : '조회된 템플릿이 없습니다.'}
+                  </DataTableCell>
+                </DataTableRow>
+              ) : (
+                templates.map((template) => (
+                  <DataTableRow key={template.templateKey}>
+                    <DataTableCell tone="strong">
+                      {template.templateName}
+                    </DataTableCell>
+                    <DataTableCell>
+                      <span className="break-all">{template.templateKey}</span>
+                    </DataTableCell>
+                    <DataTableCell>
+                      {template.aligoTemplateCode ?? '-'}
+                    </DataTableCell>
+                    <DataTableCell>
+                      <StatusBadge status={template.approvalStatus} />
+                    </DataTableCell>
+                    <DataTableCell>{template.sendPolicySummary}</DataTableCell>
+                    <DataTableCell>
+                      <BooleanBadge enabled={template.dispatchEnabled} />
+                    </DataTableCell>
+                    <DataTableCell>
+                      <BooleanBadge enabled={template.testSendEnabled} />
+                    </DataTableCell>
+                    <DataTableCell>
+                      <p className="line-clamp-2 whitespace-normal">
+                        {template.templateBodyPreview ?? '-'}
+                      </p>
+                    </DataTableCell>
+                    <DataTableCell>
+                      <div className="flex flex-wrap gap-75">
+                        <Button
+                          color="outlined"
+                          size="xsmall"
+                          disabled={!template.rejectionReason}
+                          onClick={() => setReasonTemplate(template)}
+                        >
+                          사유 보기
+                        </Button>
+                        <Button
+                          size="xsmall"
+                          disabled={!template.testSendEnabled}
+                          onClick={() => setTestTemplate(template)}
+                        >
+                          발송 테스트
+                        </Button>
+                      </div>
+                    </DataTableCell>
+                  </DataTableRow>
+                ))
+              )}
+            </tbody>
+          </DataTable>
+        </div>
+      </section>
+
+      <RejectionReasonModal
+        template={reasonTemplate}
+        open={Boolean(reasonTemplate)}
+        onOpenChange={(open) => !open && setReasonTemplate(undefined)}
+      />
+      <TemplateTestSendModal
+        template={testTemplate}
+        open={Boolean(testTemplate)}
+        onOpenChange={(open) => !open && setTestTemplate(undefined)}
+      />
+    </PageShell>
+  );
+}
+
+const DeliveryLogFilters = ({
+  filters,
+  onChange,
+}: {
+  filters: AdminAlerttalkDeliveryLogFilters;
+  onChange: (filters: AdminAlerttalkDeliveryLogFilters) => void;
+}) => (
+  <section className="border-border-default bg-background-default rounded-150 flex flex-wrap items-end gap-100 border p-200">
+    <label className="flex min-w-0 flex-1 flex-col gap-75">
+      <span className="font-designer-13b text-text-default">템플릿</span>
+      <BaseInput
+        placeholder="templateKey"
+        value={filters.templateKey ?? ''}
+        onValueChange={(value) =>
+          onChange({ ...filters, templateKey: value || undefined })
+        }
+      />
+    </label>
+    <label className="flex flex-col gap-75">
+      <span className="font-designer-13b text-text-default">상태</span>
+      <NativeSelect
+        value={filters.status ?? ''}
+        onChange={(event) =>
+          onChange({
+            ...filters,
+            status: event.target.value
+              ? (event.target
+                  .value as AdminAlerttalkDeliveryLogFilters['status'])
+              : undefined,
+          })
+        }
+      >
+        {DELIVERY_STATUS_OPTIONS.map((status) => (
+          <option key={status || 'ALL'} value={status}>
+            {status ? (statusLabelMap[status] ?? status) : '전체'}
+          </option>
+        ))}
+      </NativeSelect>
+    </label>
+    <label className="flex flex-col gap-75">
+      <span className="font-designer-13b text-text-default">from</span>
+      <BaseInput
+        type="datetime-local"
+        value={filters.from ?? ''}
+        onValueChange={(value) =>
+          onChange({ ...filters, from: value || undefined })
+        }
+      />
+    </label>
+    <label className="flex flex-col gap-75">
+      <span className="font-designer-13b text-text-default">to</span>
+      <BaseInput
+        type="datetime-local"
+        value={filters.to ?? ''}
+        onValueChange={(value) =>
+          onChange({ ...filters, to: value || undefined })
+        }
+      />
+    </label>
+    <Button color="outlined" onClick={() => onChange({})}>
+      초기화
+    </Button>
+  </section>
+);
+
+const DeliveryLogTable = ({ logs }: { logs: AdminAlerttalkDeliveryLog[] }) => (
+  <div className="border-border-default bg-background-default rounded-150 overflow-x-auto border p-200">
+    <DataTable>
+      <DataTableHead>
+        <DataTableRow>
+          {[
+            '발송시각',
+            '템플릿',
+            '트리거',
+            '회원 ID',
+            '전화번호',
+            '상태',
+            '실패 사유',
+            'source key',
+            '상세',
+          ].map((header) => (
+            <DataTableHeadCell key={header}>{header}</DataTableHeadCell>
+          ))}
+        </DataTableRow>
+      </DataTableHead>
+      <tbody>
+        {logs.length === 0 ? (
+          <DataTableRow>
+            <DataTableCell colSpan={9} align="center" tone="subtle">
+              조회된 로그가 없습니다.
+            </DataTableCell>
+          </DataTableRow>
+        ) : (
+          logs.map((log) => (
+            <DataTableRow key={`${log.jobId}-${log.memberId ?? 'job'}`}>
+              <DataTableCell>{formatDateTime(log.sentAt)}</DataTableCell>
+              <DataTableCell>{log.templateKey}</DataTableCell>
+              <DataTableCell>{log.triggerType}</DataTableCell>
+              <DataTableCell>{log.memberId ?? '-'}</DataTableCell>
+              <DataTableCell>{log.phoneMasked ?? '-'}</DataTableCell>
+              <DataTableCell>
+                <StatusBadge status={log.status} />
+              </DataTableCell>
+              <DataTableCell>{log.failureReason ?? '-'}</DataTableCell>
+              <DataTableCell>{log.sourceKey}</DataTableCell>
+              <DataTableCell>
+                <Button asChild size="xsmall" color="outlined">
+                  <Link href={`/admin/alerttalk/delivery-logs/${log.jobId}`}>
+                    상세
+                  </Link>
+                </Button>
+              </DataTableCell>
+            </DataTableRow>
+          ))
+        )}
+      </tbody>
+    </DataTable>
+  </div>
+);
+
+export function AdminAlerttalkDeliveryLogListPageClient() {
+  const [filters, setFilters] = useState<AdminAlerttalkDeliveryLogFilters>({});
+  const logsQuery = useAdminAlerttalkDeliveryLogsQuery(filters);
+
+  return (
+    <PageShell
+      active="logs"
+      title="알림톡 발송 로그"
+      description="성공, 실패, 스킵 결과를 검색하고 상세 원인을 확인합니다."
+    >
+      <DeliveryLogFilters filters={filters} onChange={setFilters} />
+      <DeliveryLogTable logs={logsQuery.data?.logs ?? []} />
+    </PageShell>
+  );
+}
+
+const RetryModal = ({
+  detail,
+  open,
+  onOpenChange,
+}: {
+  detail?: AdminAlerttalkDeliveryLogDetail;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const [reason, setReason] = useState('');
+  const mutation = useRetryAdminAlerttalkDeliveryLogMutation(
+    detail?.jobId ?? 0,
+  );
+
+  const submit = async () => {
+    if (!detail) return;
+    await mutation.mutateAsync({
+      jobId: detail.jobId,
+      request: reason.trim() ? { reason: reason.trim() } : {},
+    });
+    setReason('');
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal.Root open={open} onOpenChange={onOpenChange}>
+      <Modal.Portal>
+        <Modal.Overlay />
+        <Modal.Content size="small">
+          <Modal.Header className="flex items-start justify-between gap-150">
+            <div>
+              <Modal.Title>실패/스킵 건 재실행</Modal.Title>
+              <p className="font-designer-13r text-text-subtle mt-75">
+                원본 job {detail?.jobId ?? '-'}의 재실행 job을 새로 만듭니다.
+              </p>
+            </div>
+            <Modal.CloseButton />
+          </Modal.Header>
+          <Modal.Body>
+            <label className="flex flex-col gap-75">
+              <span className="font-designer-13b text-text-default">
+                재실행 사유 선택
+              </span>
+              <textarea
+                className="font-designer-14r border-border-default bg-background-default text-text-default rounded-100 min-h-600 w-full resize-y border p-150 focus:border-border-brand focus:outline-none"
+                value={reason}
+                onChange={(event) => setReason(event.target.value)}
+                placeholder="운영자 재실행 사유를 남기면 감사에 도움이 됩니다."
+              />
+            </label>
+          </Modal.Body>
+          <Modal.Footer className="flex justify-end gap-100">
+            <Button color="outlined" onClick={() => onOpenChange(false)}>
+              취소
+            </Button>
+            <Button loading={mutation.isPending} onClick={submit}>
+              재실행
+            </Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal.Portal>
+    </Modal.Root>
+  );
+};
+
+export function AdminAlerttalkDeliveryLogDetailPageClient({
+  jobId,
+}: {
+  jobId: number;
+}) {
+  const [retryOpen, setRetryOpen] = useState(false);
+  const detailQuery = useAdminAlerttalkDeliveryLogDetailQuery(jobId);
+  const detail = detailQuery.data;
+  const retryVisible = detail
+    ? detail.failedCount + detail.skippedCount > 0
+    : false;
+
+  return (
+    <PageShell
+      active="logs"
+      title="알림톡 발송 로그 상세"
+      description="job 집계와 target별 실패/스킵 원인을 확인합니다."
+      action={
+        retryVisible ? (
+          <Button onClick={() => setRetryOpen(true)}>재실행</Button>
+        ) : undefined
+      }
+    >
+      {detail ? (
+        <>
+          <section className="grid grid-cols-1 gap-150 md:grid-cols-4">
+            <SummaryCard
+              label="job"
+              value={detail.jobId}
+              description={detail.status}
+            />
+            <SummaryCard label="대상" value={detail.targetCount} />
+            <SummaryCard label="성공" value={detail.sentCount} />
+            <SummaryCard
+              label="실패/스킵"
+              value={`${detail.failedCount}/${detail.skippedCount}`}
+            />
+          </section>
+          <section className="border-border-default bg-background-default rounded-150 border p-200">
+            <div className="mb-150 grid grid-cols-1 gap-100 md:grid-cols-3">
+              <SummaryCard label="templateKey" value={detail.templateKey} />
+              <SummaryCard label="triggerType" value={detail.triggerType} />
+              <SummaryCard label="sourceKey" value={detail.sourceKey} />
+            </div>
+            <div className="overflow-x-auto">
+              <DataTable>
+                <DataTableHead>
+                  <DataTableRow>
+                    {[
+                      'memberId',
+                      'phoneMasked',
+                      'status',
+                      'failureReason',
+                      'payloadSnapshot',
+                    ].map((header) => (
+                      <DataTableHeadCell key={header}>
+                        {header}
+                      </DataTableHeadCell>
+                    ))}
+                  </DataTableRow>
+                </DataTableHead>
+                <tbody>
+                  {detail.targets.map((target) => (
+                    <DataTableRow
+                      key={`${target.jobId}-${target.memberId ?? target.phoneMasked}`}
+                    >
+                      <DataTableCell>{target.memberId ?? '-'}</DataTableCell>
+                      <DataTableCell>{target.phoneMasked ?? '-'}</DataTableCell>
+                      <DataTableCell>
+                        <StatusBadge status={target.status} />
+                      </DataTableCell>
+                      <DataTableCell>
+                        {target.failureReason ?? '-'}
+                      </DataTableCell>
+                      <DataTableCell>
+                        <JsonPreview value={target.payloadSnapshot} />
+                      </DataTableCell>
+                    </DataTableRow>
+                  ))}
+                </tbody>
+              </DataTable>
+            </div>
+          </section>
+          <RetryModal
+            detail={detail}
+            open={retryOpen}
+            onOpenChange={setRetryOpen}
+          />
+        </>
+      ) : (
+        <section className="border-border-default bg-background-default rounded-150 border p-300 text-center">
+          <p className="font-designer-14r text-text-subtle">
+            {detailQuery.isLoading
+              ? '상세를 불러오는 중입니다.'
+              : '상세를 찾지 못했습니다.'}
+          </p>
+        </section>
+      )}
+    </PageShell>
+  );
+}
+
+export function AdminAlerttalkDryRunPageClient() {
+  const [templateKey, setTemplateKey] =
+    useState<AlerttalkRuleType>('DAILY_REMINDER');
+  const [at, setAt] = useState('');
+  const [limit, setLimit] = useState('100');
+  const mutation = useDryRunAdminAlerttalkScheduleMutation();
+  const result = mutation.data;
+
+  const submit = () => {
+    const now = new Date().toISOString().slice(0, 16);
+    mutation.mutate({
+      templateKey,
+      at: at || now,
+      limit: Number(limit) || 100,
+    });
+  };
+
+  return (
+    <PageShell
+      active="dry-run"
+      title="알림톡 배치 점검"
+      description="예약성 알림 후보를 실제 발송 없이 미리 확인합니다."
+    >
+      <section className="border-border-brand bg-fill-brand-subtle-default rounded-150 border p-200">
+        <p className="font-designer-16b text-text-brand">실제 발송 없음</p>
+        <p className="font-designer-14r text-text-default mt-75">
+          이 화면은 후보만 계산하며 dispatch job을 생성하지 않습니다.
+        </p>
+      </section>
+      <section className="border-border-default bg-background-default rounded-150 flex flex-wrap items-end gap-100 border p-200">
+        <label className="flex flex-col gap-75">
+          <span className="font-designer-13b text-text-default">rule</span>
+          <NativeSelect
+            value={templateKey}
+            onChange={(event) =>
+              setTemplateKey(event.target.value as AlerttalkRuleType)
+            }
+          >
+            {RULE_TYPE_OPTIONS.map((rule) => (
+              <option key={rule} value={rule}>
+                {rule}
+              </option>
+            ))}
+          </NativeSelect>
+        </label>
+        <label className="flex flex-col gap-75">
+          <span className="font-designer-13b text-text-default">기준 시각</span>
+          <BaseInput type="datetime-local" value={at} onValueChange={setAt} />
+        </label>
+        <label className="flex flex-col gap-75">
+          <span className="font-designer-13b text-text-default">limit</span>
+          <BaseInput
+            inputMode="numeric"
+            value={limit}
+            onValueChange={setLimit}
+          />
+        </label>
+        <Button loading={mutation.isPending} onClick={submit}>
+          후보 미리보기
+        </Button>
+      </section>
+      {result ? (
+        <section className="border-border-default bg-background-default rounded-150 border p-200">
+          <div className="mb-150 flex flex-wrap items-center gap-100">
+            <SummaryCard label="templateKey" value={result.templateKey} />
+            <SummaryCard label="candidateCount" value={result.candidateCount} />
+            <Badge
+              color={result.dispatchCreated ? 'red' : 'green'}
+              shape="rectangle"
+            >
+              dispatchCreated={String(result.dispatchCreated)}
+            </Badge>
+          </div>
+          <div className="overflow-x-auto">
+            <DataTable>
+              <DataTableHead>
+                <DataTableRow>
+                  {['memberId', 'phoneMasked', 'whyIncluded'].map((header) => (
+                    <DataTableHeadCell key={header}>{header}</DataTableHeadCell>
+                  ))}
+                </DataTableRow>
+              </DataTableHead>
+              <tbody>
+                {result.previewTargets.map((target) => (
+                  <DataTableRow
+                    key={`${target.memberId ?? 'unknown'}-${target.phoneMasked ?? target.whyIncluded}`}
+                  >
+                    <DataTableCell>{target.memberId ?? '-'}</DataTableCell>
+                    <DataTableCell>{target.phoneMasked ?? '-'}</DataTableCell>
+                    <DataTableCell>{target.whyIncluded}</DataTableCell>
+                  </DataTableRow>
+                ))}
+              </tbody>
+            </DataTable>
+          </div>
+        </section>
+      ) : null}
+    </PageShell>
+  );
+}


### PR DESCRIPTION
## 작업 내용
- 어드민 알림톡 템플릿/발송 로그/dry-run 화면 추가
- 알림톡 API contract 및 TanStack Query hook 추가
- 어드민 사이드바에 알림톡 관리 메뉴 추가

## 검증
- yarn prettier:fix
- yarn lint:fix (기존 warning만 존재, 0 errors)
- yarn typecheck
- 로컬 MVP 백엔드 ./run-local.sh + 프론트 yarn dev + Playwright 스모크 검증
  - /admin/alerttalk/templates
  - /admin/alerttalk/delivery-logs
  - /admin/alerttalk/schedules/dry-run
  - 테스트 발송 모달은 열림만 확인, 실제 발송 미실행
  - console error 0

## 참고
- backend endpoint 기준: /api/v5/admin/alerttalk/*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 알림톡 관리 대시보드: 템플릿 목록 조회, 동기화, 테스트 발송 기능 제공
  * 발송 로그 통합 관리: 목록 조회, 상세 분석, 실패 건 재실행 기능
  * 배치 점검(드라이런) 페이지: 예약된 발송 사전 테스트 및 영향 범위 확인 가능
  * 관리자 사이드바에 알림톡 관리 메뉴 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->