### PR TITLE
fix: 학습 알림톡 시간 저장 연결

### DIFF
--- a/src/app/(service)/(my)/my-class/_components/learning-notification-modal.tsx
+++ b/src/app/(service)/(my)/my-class/_components/learning-notification-modal.tsx
@@ -27,21 +27,23 @@ export default function LearningNotificationModal({
 }: LearningNotificationModalProps) {
   const showToast = useToastStore((s) => s.showToast);
   const { data: setting } = useGetNotificationSetting();
-  const { mutateAsync: updateSetting } = useUpdateNotificationSetting();
+  const updateSettingMutation = useUpdateNotificationSetting();
 
   const [hour, setHour] = useState(8);
   const [minute, setMinute] = useState(0);
 
   useEffect(() => {
-    if (setting?.notifyHour !== null && setting?.notifyHour !== undefined)
-      setHour(setting.notifyHour);
-    if (setting?.notifyMinute !== null && setting?.notifyMinute !== undefined)
+    if (typeof setting?.notifyHour === 'number') setHour(setting.notifyHour);
+    if (typeof setting?.notifyMinute === 'number')
       setMinute(setting.notifyMinute);
   }, [setting]);
 
   const handleSave = async () => {
     try {
-      await updateSetting({ notifyHour: hour, notifyMinute: minute });
+      await updateSettingMutation.mutateAsync({
+        notifyHour: hour,
+        notifyMinute: minute,
+      });
       showToast('알림 시간이 저장되었습니다.', 'success');
       onOpenChange(false);
     } catch {
@@ -131,9 +133,10 @@ export default function LearningNotificationModal({
                 color="primary"
                 size="medium"
                 className="flex-1 whitespace-nowrap"
+                disabled={updateSettingMutation.isPending}
                 onClick={handleSave}
               >
-                저장하기
+                {updateSettingMutation.isPending ? '저장 중...' : '저장하기'}
               </Button>
             </div>
           </Modal.Footer>

--- a/src/app/(service)/(my)/my-class/page.tsx
+++ b/src/app/(service)/(my)/my-class/page.tsx
@@ -25,7 +25,11 @@ function pad(n: number) {
 export default function MyClassPage() {
   const { data: courses = [] } = useGetCourseList();
   const { data: giftEmail } = useGetMyGiftEmail();
-  const { data: notificationSetting } = useGetNotificationSetting();
+  const {
+    data: notificationSetting,
+    isError: isNotificationSettingError,
+    isLoading: isNotificationSettingLoading,
+  } = useGetNotificationSetting();
   const [alarmModalOpen, setAlarmModalOpen] = useState(false);
 
   const isEnabled = notificationSetting?.isEnabled ?? false;
@@ -46,6 +50,8 @@ export default function MyClassPage() {
             isEnabled={isEnabled}
             notifyHour={notificationSetting?.notifyHour}
             notifyMinute={notificationSetting?.notifyMinute}
+            isLoading={isNotificationSettingLoading}
+            isError={isNotificationSettingError}
             onOpenModal={() => setAlarmModalOpen(true)}
           />
           <GiftEmailCard
@@ -122,21 +128,25 @@ function AlarmCard({
   isEnabled,
   notifyHour,
   notifyMinute,
+  isLoading,
+  isError,
   onOpenModal,
 }: {
   isEnabled: boolean;
   notifyHour?: number;
   notifyMinute?: number;
+  isLoading: boolean;
+  isError: boolean;
   onOpenModal: () => void;
 }) {
   const hasTime =
-    notifyHour !== null &&
-    notifyHour !== undefined &&
-    notifyMinute !== null &&
-    notifyMinute !== undefined;
-  const timeText = hasTime
-    ? `${pad(notifyHour!)}:${pad(notifyMinute!)}`
-    : '현재 지정된 시간이 없습니다.';
+    typeof notifyHour === 'number' && typeof notifyMinute === 'number';
+  const timeText = (() => {
+    if (isLoading) return '알림 시간을 불러오는 중입니다.';
+    if (isError) return '알림 시간 조회에 실패했습니다.';
+    if (hasTime) return `${pad(notifyHour)}:${pad(notifyMinute)}`;
+    return '현재 지정된 시간이 없습니다.';
+  })();
 
   return (
     <div

--- a/src/hooks/queries/notification/use-notification-setting.ts
+++ b/src/hooks/queries/notification/use-notification-setting.ts
@@ -1,22 +1,23 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { axiosInstanceV5 } from '@/api/client/axios';
 
-interface NotificationSettingResponse {
+export interface NotificationSettingResponse {
   notifyHour?: number;
   notifyMinute?: number;
   isEnabled?: boolean;
+  saved?: boolean;
 }
 
-interface NotificationSettingUpdateRequest {
+export interface NotificationSettingUpdateRequest {
   notifyHour: number;
   notifyMinute: number;
 }
 
-const QUERY_KEY = ['notification-setting'] as const;
+export const NOTIFICATION_SETTING_QUERY_KEY = ['notification-setting'] as const;
 
 export function useGetNotificationSetting() {
   return useQuery({
-    queryKey: QUERY_KEY,
+    queryKey: NOTIFICATION_SETTING_QUERY_KEY,
     queryFn: async () => {
       const { data } = await axiosInstanceV5.get<{
         content: NotificationSettingResponse;
@@ -35,8 +36,11 @@ export function useUpdateNotificationSetting() {
       }>('members/me/notification-setting', req);
       return data.content;
     },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    onSuccess: async (data) => {
+      queryClient.setQueryData(NOTIFICATION_SETTING_QUERY_KEY, data);
+      await queryClient.invalidateQueries({
+        queryKey: NOTIFICATION_SETTING_QUERY_KEY,
+      });
     },
   });
 }


### PR DESCRIPTION
## 요약
- 마이 클래스 알림톡 시간 조회/저장 상태를 백엔드 B-02/B-03 API와 연결
- 저장 성공 시 notification-setting 캐시 즉시 반영 및 재조회
- 저장 중 중복 클릭 방지와 조회 loading/error 문구 연결

## 검증
- yarn typecheck
- scoped ESLint: my-class page/modal + notification hook
- scoped Biome format: my-class page/modal + notification hook
- git diff --check

## 범위
- 알림톡 시간 설정만 포함
- 무료수강신청 CTA 로컬 변경은 포함하지 않음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 알림 설정 저장 중 "저장 중..." 텍스트와 함께 저장 버튼을 비활성화하여 사용자 혼동 방지
  * 알림 설정 로딩 및 오류 상태를 화면에 표시하여 사용자 경험 개선
  * 알림 시간 표시 로직을 안정화하여 더 정확한 상태 정보 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->