### PR TITLE
feat: 어드민 코스 플랜 관리 UI를 연결한다

### DIFF
--- a/src/components/admin/courses/admin-course-detail-page-client.tsx
+++ b/src/components/admin/courses/admin-course-detail-page-client.tsx
@@ -8,6 +8,7 @@ import {
   AdminCourseCompletionMessageContent,
   AdminCourseFormContent,
 } from '@/components/admin/courses/admin-course-form-sections';
+import AdminCoursePlanManagement from '@/components/admin/courses/admin-course-plan-management';
 import Badge from '@/components/common/ui/badge';
 import Button from '@/components/common/ui/button';
 import MarkdownContent from '@/components/common/ui/editor/markdown-content';
@@ -57,13 +58,10 @@ const emptyCourseForm: AdminCourseFormValues = {
   cardHeadline: '',
   cardSummary: '',
   cardTags: '',
-  regularPrice: '',
-  discountPrice: '',
   description: '',
   thumbnailUrl: '',
   status: 'COMING_SOON',
   durationDays: '',
-  earlyBirdEndsAt: null,
 };
 
 const COURSE_THUMBNAIL_INPUT_ACCEPT =
@@ -104,8 +102,6 @@ const toAdminCourseFormValues = (
   cardHeadline: courseDetail.cardHeadline ?? '',
   cardSummary: courseDetail.cardSummary ?? '',
   cardTags: courseDetail.cardTags.join(', '),
-  regularPrice: '',
-  discountPrice: '',
   description: courseDetail.description ?? '',
   thumbnailUrl: courseDetail.thumbnailUrl ?? '',
   status: courseDetail.status,
@@ -113,7 +109,6 @@ const toAdminCourseFormValues = (
     typeof courseDetail.durationDays === 'number'
       ? String(courseDetail.durationDays)
       : '',
-  earlyBirdEndsAt: null,
 });
 
 const CoursePreviewPanel = ({
@@ -705,6 +700,12 @@ export default function AdminCourseDetailPageClient({
               />
             </AdminCourseField>
           </div>
+
+          {!isCreateMode && courseId && (
+            <div className="mt-200">
+              <AdminCoursePlanManagement courseId={courseId} />
+            </div>
+          )}
         </div>
 
         <CoursePreviewPanel

--- a/src/components/admin/courses/admin-course-management-page-client.tsx
+++ b/src/components/admin/courses/admin-course-management-page-client.tsx
@@ -99,13 +99,10 @@ const emptyCourseForm: AdminCourseFormValues = {
   cardHeadline: '',
   cardSummary: '',
   cardTags: '',
-  regularPrice: '',
-  discountPrice: '',
   description: '',
   thumbnailUrl: '',
   status: 'COMING_SOON',
   durationDays: '',
-  earlyBirdEndsAt: null,
 };
 
 const emptyLessonForm: AdminLessonUpsertRequest = {

--- a/src/components/admin/courses/admin-course-plan-management.tsx
+++ b/src/components/admin/courses/admin-course-plan-management.tsx
@@ -1,0 +1,447 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Button from '@/components/common/ui/button';
+import { BaseInput, NativeSelect } from '@/components/common/ui/input';
+import type {
+  AdminCoursePlan,
+  AdminCoursePlanItemUpsertRequest,
+  AdminCoursePlanUpsertRequest,
+} from '@/features/admin/course-management/model/admin-course-management-contract';
+import {
+  useAdminCoursePlansQuery,
+  useCreateAdminCoursePlanMutation,
+  useDeactivateAdminCoursePlanMutation,
+  useUpdateAdminCoursePlanMutation,
+} from '@/features/admin/course-management/model/use-admin-course-management-query';
+import { useToastStore } from '@/stores/use-toast-store';
+
+interface PlanFormValues {
+  planCode: string;
+  name: string;
+  subtitle: string;
+  description: string;
+  regularPrice: string;
+  discountPrice: string;
+  earlyBirdEndsAt: string;
+  isActive: 'true' | 'false';
+  isRecommended: 'true' | 'false';
+  displayOrder: string;
+  itemsText: string;
+}
+
+const emptyPlanForm: PlanFormValues = {
+  planCode: '',
+  name: '',
+  subtitle: '',
+  description: '',
+  regularPrice: '',
+  discountPrice: '',
+  earlyBirdEndsAt: '',
+  isActive: 'true',
+  isRecommended: 'false',
+  displayOrder: '0',
+  itemsText: '',
+};
+
+const toDateTimeLocalValue = (value: string | null) => {
+  if (!value) return '';
+  return value.slice(0, 16);
+};
+
+const toKstOffsetDateTime = (value: string) => {
+  if (!value) return null;
+  return `${value.length === 16 ? `${value}:00` : value}+09:00`;
+};
+
+const serializePlanItems = (items: AdminCoursePlan['items']) => {
+  return items
+    .map((item, index) =>
+      [
+        item.itemCode ?? '',
+        item.label,
+        item.valueAmount ?? 0,
+        item.displayOrder ?? index,
+      ].join(' | '),
+    )
+    .join('\n');
+};
+
+const toPlanFormValues = (plan: AdminCoursePlan): PlanFormValues => ({
+  planCode: plan.planCode,
+  name: plan.name,
+  subtitle: plan.subtitle ?? '',
+  description: plan.description ?? '',
+  regularPrice: String(plan.regularPrice),
+  discountPrice: String(plan.discountPrice),
+  earlyBirdEndsAt: toDateTimeLocalValue(plan.earlyBirdEndsAt),
+  isActive: plan.isActive ? 'true' : 'false',
+  isRecommended: plan.isRecommended ? 'true' : 'false',
+  displayOrder: String(plan.displayOrder),
+  itemsText: serializePlanItems(plan.items),
+});
+
+const parseRequiredNumber = (value: string, fieldName: string) => {
+  const parsed = Number(value.trim());
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${fieldName} 숫자를 입력해주세요.`);
+  }
+  return parsed;
+};
+
+const parsePlanItems = (
+  itemsText: string,
+): AdminCoursePlanItemUpsertRequest[] =>
+  itemsText
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line, index) => {
+      const [itemCode, label, valueAmount, displayOrder] = line
+        .split('|')
+        .map((part) => part.trim());
+
+      if (!label) {
+        throw new Error('플랜 구성 항목 label을 입력해주세요.');
+      }
+
+      return {
+        itemCode: itemCode || null,
+        label,
+        valueAmount: valueAmount
+          ? parseRequiredNumber(valueAmount, '항목 금액')
+          : 0,
+        displayOrder: displayOrder
+          ? parseRequiredNumber(displayOrder, '항목 순서')
+          : index,
+      };
+    });
+
+const showValidationError = (error: unknown) => {
+  if (error instanceof Error) {
+    useToastStore.getState().showToast(error.message, 'info');
+  }
+};
+
+const toPlanPayload = (form: PlanFormValues): AdminCoursePlanUpsertRequest => {
+  if (!form.planCode.trim() || !form.name.trim()) {
+    throw new Error('플랜 코드와 이름을 입력해주세요.');
+  }
+
+  return {
+    planCode: form.planCode.trim(),
+    name: form.name.trim(),
+    subtitle: form.subtitle.trim() || null,
+    description: form.description.trim() || null,
+    regularPrice: parseRequiredNumber(form.regularPrice, '정가'),
+    discountPrice: parseRequiredNumber(form.discountPrice, '할인가'),
+    earlyBirdEndsAt: toKstOffsetDateTime(form.earlyBirdEndsAt),
+    isActive: form.isActive === 'true',
+    isRecommended: form.isRecommended === 'true',
+    displayOrder: parseRequiredNumber(form.displayOrder, '노출 순서'),
+    items: parsePlanItems(form.itemsText),
+  };
+};
+
+export default function AdminCoursePlanManagement({
+  courseId,
+}: {
+  courseId: number;
+}) {
+  const plansQuery = useAdminCoursePlansQuery(courseId);
+  const createPlanMutation = useCreateAdminCoursePlanMutation();
+  const updatePlanMutation = useUpdateAdminCoursePlanMutation();
+  const deactivatePlanMutation = useDeactivateAdminCoursePlanMutation();
+  const [createForm, setCreateForm] = useState<PlanFormValues>(emptyPlanForm);
+  const [editForms, setEditForms] = useState<Record<number, PlanFormValues>>(
+    {},
+  );
+  const isMutating =
+    createPlanMutation.isPending ||
+    updatePlanMutation.isPending ||
+    deactivatePlanMutation.isPending;
+
+  useEffect(() => {
+    if (!plansQuery.data) return;
+    setEditForms(
+      Object.fromEntries(
+        plansQuery.data.map((plan) => [plan.planId, toPlanFormValues(plan)]),
+      ),
+    );
+  }, [plansQuery.data]);
+
+  const activePlans = useMemo(
+    () => plansQuery.data?.filter((plan) => plan.isActive) ?? [],
+    [plansQuery.data],
+  );
+
+  const updateCreateFormField = <FieldName extends keyof PlanFormValues>(
+    field: FieldName,
+    value: PlanFormValues[FieldName],
+  ) => {
+    setCreateForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const updateEditFormField = <FieldName extends keyof PlanFormValues>(
+    planId: number,
+    field: FieldName,
+    value: PlanFormValues[FieldName],
+  ) => {
+    setEditForms((prev) => ({
+      ...prev,
+      [planId]: { ...(prev[planId] ?? emptyPlanForm), [field]: value },
+    }));
+  };
+
+  const handleCreatePlan = async () => {
+    let request: AdminCoursePlanUpsertRequest;
+
+    try {
+      request = toPlanPayload(createForm);
+    } catch (error) {
+      showValidationError(error);
+      return;
+    }
+
+    await createPlanMutation.mutateAsync({
+      courseId,
+      request,
+    });
+    setCreateForm(emptyPlanForm);
+  };
+
+  const handleUpdatePlan = async (planId: number) => {
+    const form = editForms[planId];
+    if (!form) return;
+
+    let request: AdminCoursePlanUpsertRequest;
+
+    try {
+      request = toPlanPayload(form);
+    } catch (error) {
+      showValidationError(error);
+      return;
+    }
+
+    await updatePlanMutation.mutateAsync({
+      courseId,
+      planId,
+      request,
+    });
+  };
+
+  return (
+    <div className="border-border-default bg-background-default rounded-150 border p-200">
+      <div className="mb-150 flex items-start justify-between gap-100">
+        <div>
+          <h2 className="font-designer-20b text-text-default">플랜 관리</h2>
+          <p className="font-designer-13r text-text-subtle mt-50">
+            가격과 얼리버드는 코스 기본정보가 아니라 course_plan row를 SoT로
+            관리합니다.
+          </p>
+        </div>
+        <span className="font-designer-13m text-text-subtle">
+          활성 플랜 {activePlans.length}개
+        </span>
+      </div>
+
+      {plansQuery.isLoading ? (
+        <p className="font-designer-14r text-text-subtle">
+          플랜 목록을 불러오는 중입니다.
+        </p>
+      ) : plansQuery.isError ? (
+        <p className="font-designer-14r text-text-error">
+          플랜 목록을 불러오지 못했습니다.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-150">
+          {plansQuery.data?.map((plan) => (
+            <PlanEditor
+              key={plan.planId}
+              form={editForms[plan.planId] ?? toPlanFormValues(plan)}
+              isLocked={isMutating}
+              title={`${plan.name} · ${plan.planCode}`}
+              onChange={(field, value) =>
+                updateEditFormField(plan.planId, field, value)
+              }
+              onDeactivate={() =>
+                deactivatePlanMutation.mutate({ courseId, planId: plan.planId })
+              }
+              onSave={() => handleUpdatePlan(plan.planId)}
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="border-border-subtle mt-200 border-t pt-150">
+        <h3 className="font-designer-16b text-text-default">새 플랜 생성</h3>
+        <PlanEditor
+          form={createForm}
+          isLocked={isMutating}
+          title="신규 플랜"
+          onChange={updateCreateFormField}
+          onSave={handleCreatePlan}
+        />
+      </div>
+    </div>
+  );
+}
+
+function PlanEditor({
+  form,
+  isLocked,
+  title,
+  onChange,
+  onDeactivate,
+  onSave,
+}: {
+  form: PlanFormValues;
+  isLocked: boolean;
+  title: string;
+  onChange: <FieldName extends keyof PlanFormValues>(
+    field: FieldName,
+    value: PlanFormValues[FieldName],
+  ) => void;
+  onDeactivate?: () => void;
+  onSave: () => void;
+}) {
+  return (
+    <div className="border-border-default rounded-150 border p-150">
+      <div className="mb-125 flex items-center justify-between gap-100">
+        <h3 className="font-designer-16b text-text-default">{title}</h3>
+        <div className="flex gap-75">
+          {onDeactivate && (
+            <Button
+              color="outlined"
+              size="xsmall"
+              disabled={isLocked || form.isActive === 'false'}
+              onClick={onDeactivate}
+            >
+              비활성화
+            </Button>
+          )}
+          <Button size="xsmall" disabled={isLocked} onClick={onSave}>
+            저장
+          </Button>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-100">
+        <PlanInput
+          disabled={isLocked}
+          label="planCode"
+          value={form.planCode}
+          onChange={(value) => onChange('planCode', value)}
+        />
+        <PlanInput
+          disabled={isLocked}
+          label="플랜명"
+          value={form.name}
+          onChange={(value) => onChange('name', value)}
+        />
+        <PlanInput
+          disabled={isLocked}
+          label="부제"
+          value={form.subtitle}
+          onChange={(value) => onChange('subtitle', value)}
+        />
+        <PlanInput
+          disabled={isLocked}
+          label="설명"
+          value={form.description}
+          onChange={(value) => onChange('description', value)}
+        />
+        <PlanInput
+          disabled={isLocked}
+          label="정가"
+          type="number"
+          value={form.regularPrice}
+          onChange={(value) => onChange('regularPrice', value)}
+        />
+        <PlanInput
+          disabled={isLocked}
+          label="얼리버드 할인가"
+          type="number"
+          value={form.discountPrice}
+          onChange={(value) => onChange('discountPrice', value)}
+        />
+        <PlanInput
+          disabled={isLocked}
+          label="얼리버드 종료"
+          type="datetime-local"
+          value={form.earlyBirdEndsAt}
+          onChange={(value) => onChange('earlyBirdEndsAt', value)}
+        />
+        <PlanInput
+          disabled={isLocked}
+          label="노출 순서"
+          type="number"
+          value={form.displayOrder}
+          onChange={(value) => onChange('displayOrder', value)}
+        />
+        <label className="font-designer-13m text-text-subtle flex flex-col gap-50">
+          활성 여부
+          <NativeSelect
+            disabled={isLocked}
+            value={form.isActive}
+            onChange={(event) =>
+              onChange('isActive', event.target.value as 'true' | 'false')
+            }
+          >
+            <option value="true">활성</option>
+            <option value="false">비활성</option>
+          </NativeSelect>
+        </label>
+        <label className="font-designer-13m text-text-subtle flex flex-col gap-50">
+          대표 플랜
+          <NativeSelect
+            disabled={isLocked}
+            value={form.isRecommended}
+            onChange={(event) =>
+              onChange('isRecommended', event.target.value as 'true' | 'false')
+            }
+          >
+            <option value="true">대표</option>
+            <option value="false">일반</option>
+          </NativeSelect>
+        </label>
+      </div>
+      <label className="font-designer-13m text-text-subtle mt-100 flex flex-col gap-50">
+        구성 항목
+        <textarea
+          className="border-border-default rounded-100 min-h-260 border bg-background-default px-100 py-75 font-designer-13r text-text-default"
+          disabled={isLocked}
+          value={form.itemsText}
+          placeholder="itemCode | label | valueAmount | displayOrder"
+          onChange={(event) => onChange('itemsText', event.target.value)}
+        />
+      </label>
+    </div>
+  );
+}
+
+function PlanInput({
+  disabled,
+  label,
+  type = 'text',
+  value,
+  onChange,
+}: {
+  disabled: boolean;
+  label: string;
+  type?: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="font-designer-13m text-text-subtle flex flex-col gap-50">
+      {label}
+      <BaseInput
+        disabled={disabled}
+        size="m"
+        type={type}
+        value={value}
+        onValueChange={onChange}
+      />
+    </label>
+  );
+}

--- a/src/features/admin/course-management/api/admin-course-management-api.ts
+++ b/src/features/admin/course-management/api/admin-course-management-api.ts
@@ -4,6 +4,9 @@ import {
 } from '@/api/client/axios';
 import type {
   AdminBuilderFeedCurationRequest,
+  AdminCoursePlan,
+  AdminCoursePlanCreateResponse,
+  AdminCoursePlanUpsertRequest,
   AdminLessonBatchImportResponse,
   AdminLessonBatchUpdateRequest,
   AdminLessonBatchUpdateResponse,
@@ -222,6 +225,57 @@ export const deleteAdminCourse = async (
   >(`admin/courses/${courseId}`);
 
   return normalizeDeleteResponse(unwrap(response));
+};
+
+export const getAdminCoursePlans = async (
+  courseId: number,
+): Promise<AdminCoursePlan[]> => {
+  const response = await axiosInstanceV5.get<
+    ApiBaseResponse<AdminCoursePlan[]>
+  >(`admin/courses/${courseId}/plans`);
+
+  return unwrap(response);
+};
+
+export const createAdminCoursePlan = async ({
+  courseId,
+  request,
+}: {
+  courseId: number;
+  request: AdminCoursePlanUpsertRequest;
+}): Promise<AdminCoursePlanCreateResponse> => {
+  const response = await axiosInstanceV5.post<
+    ApiBaseResponse<AdminCoursePlanCreateResponse>
+  >(`admin/courses/${courseId}/plans`, request);
+
+  return unwrap(response);
+};
+
+export const updateAdminCoursePlan = async ({
+  courseId,
+  planId,
+  request,
+}: {
+  courseId: number;
+  planId: number;
+  request: AdminCoursePlanUpsertRequest;
+}): Promise<void> => {
+  await axiosInstanceV5.put<ApiBaseResponse<void>>(
+    `admin/courses/${courseId}/plans/${planId}`,
+    request,
+  );
+};
+
+export const deactivateAdminCoursePlan = async ({
+  courseId,
+  planId,
+}: {
+  courseId: number;
+  planId: number;
+}): Promise<void> => {
+  await axiosInstanceV5.patch<ApiBaseResponse<void>>(
+    `admin/courses/${courseId}/plans/${planId}/inactive`,
+  );
 };
 
 export const getAdminCourseLessons = async (

--- a/src/features/admin/course-management/model/admin-course-management-contract.ts
+++ b/src/features/admin/course-management/model/admin-course-management-contract.ts
@@ -66,17 +66,64 @@ export interface AdminCourseFormValues {
   cardHeadline: string;
   cardSummary: string;
   cardTags: string;
-  regularPrice: string;
-  discountPrice: string;
   description: string;
   thumbnailUrl: string;
   status: AdminCourseStatus;
   durationDays: string;
-  earlyBirdEndsAt: string | null;
 }
 
 export interface AdminCourseCreateResponse {
   courseId: number;
+}
+
+export interface AdminCoursePlanItem {
+  itemId?: number;
+  itemCode: string | null;
+  label: string;
+  valueAmount: number | null;
+  displayOrder: number | null;
+}
+
+export interface AdminCoursePlan {
+  planId: number;
+  courseId: number;
+  planCode: string;
+  name: string;
+  subtitle: string | null;
+  description: string | null;
+  regularPrice: number;
+  discountPrice: number;
+  earlyBirdEndsAt: string | null;
+  isActive: boolean;
+  isRecommended: boolean;
+  displayOrder: number;
+  items: AdminCoursePlanItem[];
+  updatedAt: string | null;
+}
+
+export interface AdminCoursePlanItemUpsertRequest {
+  itemCode?: string | null;
+  label: string;
+  valueAmount?: number | null;
+  displayOrder?: number | null;
+}
+
+export interface AdminCoursePlanUpsertRequest {
+  planCode: string;
+  name: string;
+  subtitle?: string | null;
+  description?: string | null;
+  regularPrice: number;
+  discountPrice: number;
+  earlyBirdEndsAt?: string | null;
+  isActive: boolean;
+  isRecommended: boolean;
+  displayOrder: number;
+  items: AdminCoursePlanItemUpsertRequest[];
+}
+
+export interface AdminCoursePlanCreateResponse {
+  planId: number;
 }
 
 export interface AdminCourseDeleteResponse {

--- a/src/features/admin/course-management/model/use-admin-course-management-query.ts
+++ b/src/features/admin/course-management/model/use-admin-course-management-query.ts
@@ -1,13 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   createAdminCourse,
+  createAdminCoursePlan,
   batchUpdateAdminLessons,
   bulkUpdateAdminLessons,
   createAdminLesson,
   createAdminLessonsFromNotionZips,
   deleteAdminCourse,
+  deactivateAdminCoursePlan,
   deleteAdminLesson,
   getAdminCourseDetail,
+  getAdminCoursePlans,
   getAdminCompletionMessage,
   getAdminCourseLessons,
   getAdminCourses,
@@ -17,6 +20,7 @@ import {
   getAdminLessonRetrospectives,
   importAdminLessonContentZip,
   updateAdminBuilderFeedCuration,
+  updateAdminCoursePlan,
   createAdminLessonQnaAnswer,
   getAdminLessonBuilderFeeds,
   reorderAdminLessons,
@@ -44,6 +48,8 @@ export const adminCourseManagementQueryKeys = {
     [...adminCourseManagementQueryKeys.all, 'courses', params] as const,
   courseDetail: (courseId?: number) =>
     [...adminCourseManagementQueryKeys.all, 'course-detail', courseId] as const,
+  coursePlans: (courseId?: number) =>
+    [...adminCourseManagementQueryKeys.all, 'course-plans', courseId] as const,
   lessons: (courseId?: number) =>
     [...adminCourseManagementQueryKeys.all, 'lessons', courseId] as const,
   lessonDetail: (lessonId?: number) =>
@@ -134,6 +140,14 @@ export const useAdminCourseDetailQuery = (courseId?: number) =>
   useQuery({
     queryKey: adminCourseManagementQueryKeys.courseDetail(courseId),
     queryFn: () => getAdminCourseDetail(courseId ?? 0),
+    enabled: typeof courseId === 'number',
+    staleTime: 30_000,
+  });
+
+export const useAdminCoursePlansQuery = (courseId?: number) =>
+  useQuery({
+    queryKey: adminCourseManagementQueryKeys.coursePlans(courseId),
+    queryFn: () => getAdminCoursePlans(courseId ?? 0),
     enabled: typeof courseId === 'number',
     staleTime: 30_000,
   });
@@ -230,6 +244,66 @@ export const useDeleteAdminCourseMutation = () => {
             : '수강 이력이 있어 코스를 삭제하지 않고 비공개 처리했습니다.',
           'success',
         );
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useCreateAdminCoursePlanMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createAdminCoursePlan,
+    onSuccess: async (_, variables) => {
+      useToastStore.getState().showToast('플랜을 생성했습니다.', 'success');
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.coursePlans(
+          variables.courseId,
+        ),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useUpdateAdminCoursePlanMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateAdminCoursePlan,
+    onSuccess: async (_, variables) => {
+      useToastStore.getState().showToast('플랜을 저장했습니다.', 'success');
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.coursePlans(
+          variables.courseId,
+        ),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.all,
+      });
+    },
+    onError: showMutationError,
+  });
+};
+
+export const useDeactivateAdminCoursePlanMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deactivateAdminCoursePlan,
+    onSuccess: async (_, variables) => {
+      useToastStore.getState().showToast('플랜을 비활성화했습니다.', 'success');
+      await queryClient.invalidateQueries({
+        queryKey: adminCourseManagementQueryKeys.coursePlans(
+          variables.courseId,
+        ),
+      });
       await queryClient.invalidateQueries({
         queryKey: adminCourseManagementQueryKeys.all,
       });


### PR DESCRIPTION
## 작업 내용
- 클래스 관리 > 코스정보편집에 플랜 관리 섹션을 추가했습니다.
- 플랜 목록 조회, 생성, 수정, 비활성화 API 연결과 계약 타입을 추가했습니다.
- 코스 폼의 legacy 가격/early bird 상태를 플랜 관리 중심으로 정리했습니다.

## 변경 이유
- 백엔드가 `course_plan` 기준 pricing/early bird SoT로 전환되면서 어드민 UI도 플랜 단위 관리가 필요했습니다.

## 검증 방법
- [x] `git diff --check`
- [x] `yarn lint:fix`
- [x] `yarn prettier:fix`
- [x] `yarn typecheck`

## 브랜치 정보
- base: develop
- head: feat/class-plan-admin-ui-develop
- 기준 range: origin/develop..HEAD

## QA 확인 포인트
- 코스정보편집에서 플랜 목록이 로드되는지
- 플랜 생성/수정/비활성화 후 리스트와 편집 상태가 즉시 동기화되는지
- 클래스 단위 early bird 입력 UI가 노출되지 않고 플랜별 필드만 보이는지

## 리스크
- 백엔드 플랜 API 응답 필드와 enum 값이 바뀌면 이 화면도 함께 맞춰야 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 코스 플랜 관리 기능 추가: 플랜 목록 조회, 생성, 수정, 비활성화 기능 구현
  * 관리자 페이지에 플랜 관리 UI 컴포넌트 추가

* **개선사항**
  * 코스 등록 폼에서 가격 관련 필드 정리 및 구조 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->