### PR TITLE
fix: 관리자 코스 수강 상태 분기 반영

### DIFF
--- a/src/app/(landing)/class/[slug]/page.tsx
+++ b/src/app/(landing)/class/[slug]/page.tsx
@@ -19,6 +19,13 @@ import { ClassDetailInstructorSection } from '@/components/pages/class/class-det
 import { ClassDetailRoadmapSection } from '@/components/pages/class/class-detail-roadmap-section';
 import { ClassDetailSidebar } from '@/components/pages/class/class-detail-sidebar';
 import { ClassDetailTabNav } from '@/components/pages/class/class-detail-tab-nav';
+import {
+  canShowCourseFreeEnrollCta,
+  getCourseViewerStatusLabel,
+  hasCourseFullAccess,
+  isCourseFreeEnrolled,
+  isCoursePaidEnrolled,
+} from '@/components/pages/class/course-viewer-status';
 import { useAuth } from '@/features/auth/model/use-auth';
 import {
   useCreateCourseFreeEnrollment,
@@ -51,15 +58,21 @@ export default function ClassDetailPage({
 
   // 커리큘럼은 DB에서 가져오되, 코스가 없으면 하드코딩된 CHAPTERS로 fallback.
   const { data: curriculum } = useGetCourseCurriculum(slug);
-  const { data: courseDetail } = useGetCourseDetail(slug);
+  const { data: courseDetail, refetch: refetchCourseDetail } =
+    useGetCourseDetail(slug);
   const courseId = courseDetail?.courseId ?? 0;
   const { data: builderFeedShowcase } = useGetBuilderFeedShowcase(courseId);
   const createCourseFreeEnrollment = useCreateCourseFreeEnrollment();
   const createStudyWithMeSubscription = useCreateStudyWithMeSubscription();
+  const canFreeEnrollFromDetail = canShowCourseFreeEnrollCta(courseDetail);
+  const hasFullAccessFromDetail = hasCourseFullAccess(courseDetail);
+  const viewerStatusLabel = getCourseViewerStatusLabel(courseDetail);
   const ctaLabel = (() => {
     if (createCourseFreeEnrollment.isPending) return '등록 중...';
-    if (courseDetail?.viewerStatus === 'PAID') return '학습하러 가기';
-    if (courseDetail?.viewerStatus === 'FREE_ENROLLED') return '학습 계속하기';
+    if (isCoursePaidEnrolled(courseDetail)) return '학습하러 가기';
+    if (isCourseFreeEnrolled(courseDetail)) return '학습 계속하기';
+    if (canFreeEnrollFromDetail) return '무료 코스 시작하기';
+    if (hasFullAccessFromDetail) return '관리자 권한으로 보기';
     return '무료 코스 시작하기';
   })();
   const { data: myGiftEmail } = useGetMyGiftEmail({
@@ -124,12 +137,10 @@ export default function ClassDetailPage({
       showToast('코스 정보를 불러오는 중입니다.', 'info');
       return;
     }
-    if (
-      courseDetail.viewerStatus === 'LOGIN_ONLY' &&
-      courseDetail.canFreeEnroll
-    ) {
+    if (canShowCourseFreeEnrollCta(courseDetail)) {
       try {
         await createCourseFreeEnrollment.mutateAsync(courseDetail.courseId);
+        await refetchCourseDetail();
         showToast('무료 코스 등록이 완료되었어요.');
       } catch {
         showToast('무료 코스 등록 중 오류가 발생했어요.', 'error');
@@ -262,6 +273,7 @@ export default function ClassDetailPage({
             courseDetail={courseDetail}
             isAuthenticated={isAuthenticated}
             ctaLabel={ctaLabel}
+            viewerStatusLabel={viewerStatusLabel}
             isEnrolling={createCourseFreeEnrollment.isPending}
             onShare={handleShare}
             onStartCourse={handleStartCourse}

--- a/src/components/pages/class/class-detail-sidebar.tsx
+++ b/src/components/pages/class/class-detail-sidebar.tsx
@@ -15,6 +15,7 @@ interface ClassDetailSidebarProps {
   courseDetail: CourseDetailResponse | undefined;
   isAuthenticated: boolean;
   ctaLabel: string;
+  viewerStatusLabel: string | undefined;
   isEnrolling: boolean;
   onShare: () => void;
   onStartCourse: () => void;
@@ -29,6 +30,7 @@ export function ClassDetailSidebar({
   courseDetail,
   isAuthenticated,
   ctaLabel,
+  viewerStatusLabel,
   isEnrolling,
   onShare,
   onStartCourse,
@@ -59,6 +61,12 @@ export function ClassDetailSidebar({
             {courseDetail?.description ??
               '바이브 코딩 막막함 이젠 여기서 끝내세요!\nZERO-ONE의 빌더들과 함께 뿌셔보세요!'}
           </p>
+
+          {viewerStatusLabel ? (
+            <span className="mt-150 inline-block rounded-50 bg-gray-100 px-75 py-25 font-designer-12r text-gray-800">
+              {viewerStatusLabel}
+            </span>
+          ) : null}
 
           <span className="mt-150 inline-block rounded-50 bg-gray-400 px-75 py-25 font-designer-12r text-text-inverse">
             혜택

--- a/src/components/pages/class/course-viewer-status.test.ts
+++ b/src/components/pages/class/course-viewer-status.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { CourseDetailResponse } from '@/types/api/course.types';
+import {
+  canShowCourseFreeEnrollCta,
+  getCourseViewerStatusLabel,
+  hasCourseFullAccess,
+  isCourseFreeEnrolled,
+  isCoursePaidEnrolled,
+} from './course-viewer-status';
+
+const baseCourse: CourseDetailResponse = {
+  courseId: 1,
+  slug: 'sample-course',
+  viewerStatus: 'LOGIN_ONLY',
+  title: 'Sample',
+  description: null,
+  thumbnailUrl: null,
+  learnerCount: null,
+  durationDays: null,
+  completionCount: null,
+  exploringCount: null,
+  plans: null,
+  earlyBirdEndsAt: null,
+  canFreeEnroll: null,
+  isFreeEnrolled: null,
+  freeLessonCount: null,
+  journeyMapAvailable: null,
+  hasFullAccess: null,
+  isPaidEnrolled: null,
+  canPurchase: null,
+};
+
+describe('course viewer status helpers', () => {
+  it('ADMIN is full-access but not an actual learner by default', () => {
+    const course = {
+      ...baseCourse,
+      viewerStatus: 'ADMIN',
+      hasFullAccess: true,
+      canFreeEnroll: true,
+    } satisfies CourseDetailResponse;
+
+    expect(hasCourseFullAccess(course)).toBe(true);
+    expect(isCourseFreeEnrolled(course)).toBe(false);
+    expect(isCoursePaidEnrolled(course)).toBe(false);
+    expect(canShowCourseFreeEnrollCta(course)).toBe(true);
+    expect(getCourseViewerStatusLabel(course)).toBe(
+      '관리자 권한으로 미리보기 중',
+    );
+  });
+
+  it('ADMIN free enrollment keeps ADMIN status and becomes a real free learner', () => {
+    const course = {
+      ...baseCourse,
+      viewerStatus: 'ADMIN',
+      hasFullAccess: true,
+      canFreeEnroll: null as CourseDetailResponse['canFreeEnroll'],
+      isFreeEnrolled: true,
+    } satisfies CourseDetailResponse;
+
+    expect(isCourseFreeEnrolled(course)).toBe(true);
+    expect(canShowCourseFreeEnrollCta(course)).toBe(false);
+    expect(getCourseViewerStatusLabel(course)).toBe('무료수강중');
+  });
+
+  it('PAID means actual paid learner', () => {
+    const course = {
+      ...baseCourse,
+      viewerStatus: 'PAID',
+      isPaidEnrolled: true,
+      hasFullAccess: true,
+    } satisfies CourseDetailResponse;
+
+    expect(isCoursePaidEnrolled(course)).toBe(true);
+    expect(hasCourseFullAccess(course)).toBe(true);
+    expect(getCourseViewerStatusLabel(course)).toBe('결제 수강중');
+  });
+});

--- a/src/components/pages/class/course-viewer-status.ts
+++ b/src/components/pages/class/course-viewer-status.ts
@@ -1,0 +1,51 @@
+import type { CourseDetailResponse } from '@/types/api/course.types';
+
+export function isAdminViewer(course?: CourseDetailResponse): boolean {
+  return course?.viewerStatus === 'ADMIN';
+}
+
+export function isCourseFreeEnrolled(course?: CourseDetailResponse): boolean {
+  return (
+    course?.isFreeEnrolled === true || course?.viewerStatus === 'FREE_ENROLLED'
+  );
+}
+
+export function isCoursePaidEnrolled(course?: CourseDetailResponse): boolean {
+  return course?.isPaidEnrolled === true || course?.viewerStatus === 'PAID';
+}
+
+export function hasCourseFullAccess(course?: CourseDetailResponse): boolean {
+  return (
+    course?.hasFullAccess === true ||
+    isAdminViewer(course) ||
+    isCoursePaidEnrolled(course)
+  );
+}
+
+export function canShowCourseFreeEnrollCta(
+  course?: CourseDetailResponse,
+): boolean {
+  if (course?.canFreeEnroll !== true) return false;
+  if (isCourseFreeEnrolled(course) || isCoursePaidEnrolled(course)) {
+    return false;
+  }
+  return (
+    course.viewerStatus === 'LOGIN_ONLY' || course.viewerStatus === 'ADMIN'
+  );
+}
+
+export function getCourseViewerStatusLabel(
+  course?: CourseDetailResponse,
+): string | undefined {
+  if (!course) return undefined;
+
+  if (isAdminViewer(course)) {
+    if (isCoursePaidEnrolled(course)) return '결제 수강중';
+    if (isCourseFreeEnrolled(course)) return '무료수강중';
+    return '관리자 권한으로 미리보기 중';
+  }
+
+  if (isCoursePaidEnrolled(course)) return '결제 수강중';
+  if (isCourseFreeEnrolled(course)) return '무료수강중';
+  return undefined;
+}

--- a/src/components/pages/class/roadmap-tab.tsx
+++ b/src/components/pages/class/roadmap-tab.tsx
@@ -21,6 +21,12 @@ import {
 import type { CourseCurriculumChapterResponse } from '@/types/api/course.types';
 import { ChapterHeader } from './chapter-header';
 import {
+  hasCourseFullAccess,
+  isAdminViewer,
+  isCourseFreeEnrolled,
+  isCoursePaidEnrolled,
+} from './course-viewer-status';
+import {
   buildLessonMap,
   FALLBACK_CHAPTERS,
   type LessonDisplayInfo,
@@ -60,6 +66,11 @@ export function RoadmapTab({ slug }: { slug: string }) {
   const completedLessons = progress?.completedLessons ?? 0;
   const totalLessons = progress?.totalLessons ?? 0;
   const progressRate = progress?.progressRate ?? 0;
+  const isFreeEnrolled = isCourseFreeEnrolled(course);
+  const isPaidEnrolled = isCoursePaidEnrolled(course);
+  const hasFullAccess = hasCourseFullAccess(course);
+  const isAdminPreview =
+    isAdminViewer(course) && !isFreeEnrolled && !isPaidEnrolled;
 
   const nextAccessibleLesson = journeyMap?.lessons.find(
     (l) => l.status !== 'COMPLETED' && l.isAccessible,
@@ -108,6 +119,11 @@ export function RoadmapTab({ slug }: { slug: string }) {
           <p className="font-designer-20r">
             매 레슨을 완료하면 다음 길이 열려요.
           </p>
+          {isAdminPreview ? (
+            <p className="font-designer-16m text-text-brand">
+              관리자 권한으로 미리보기 중
+            </p>
+          ) : null}
         </div>
 
         {/* Progress */}
@@ -139,7 +155,7 @@ export function RoadmapTab({ slug }: { slug: string }) {
         </div>
 
         {/* 안내창 — State 1: 최초 접속 (no progress yet) */}
-        {course?.viewerStatus === 'FREE_ENROLLED' && completedLessons === 0 ? (
+        {isFreeEnrolled && !hasFullAccess && completedLessons === 0 ? (
           <div className="mt-300 flex flex-col gap-75 rounded-200 border border-gray-300 bg-gray-100 px-350 py-300">
             <p className="font-designer-20b text-gray-800">
               Chapter3까지 무료 코스! 마음껏 학습하세요.
@@ -149,7 +165,8 @@ export function RoadmapTab({ slug }: { slug: string }) {
             </p>
           </div>
         ) : /* State 2: free lessons exhausted → payment CTA */
-        course?.viewerStatus === 'FREE_ENROLLED' &&
+        isFreeEnrolled &&
+          !hasFullAccess &&
           completedLessons >= (course.freeLessonCount ?? 0) &&
           course?.canPurchase ? (
           <div className="mt-300 flex flex-col gap-150 rounded-200 border border-gray-300 bg-gray-100 px-350 py-300">
@@ -172,8 +189,8 @@ export function RoadmapTab({ slug }: { slug: string }) {
           </div>
         ) : /* State 3: mid-progress free or paid → next lesson info */
         nextAccessibleLesson &&
-          (course?.viewerStatus === 'PAID' ||
-            (course?.viewerStatus === 'FREE_ENROLLED' &&
+          (hasFullAccess ||
+            (isFreeEnrolled &&
               completedLessons > 0 &&
               completedLessons < (course.freeLessonCount ?? 0))) ? (
           <div className="mt-300 flex items-center gap-300 rounded-200 border border-gray-300 bg-gray-100 px-350 py-300">
@@ -574,7 +591,8 @@ export function RoadmapTab({ slug }: { slug: string }) {
       )}
 
       {/* Sticky payment CTA for free-enrolled users */}
-      {course?.viewerStatus === 'FREE_ENROLLED' &&
+      {isFreeEnrolled &&
+        !hasFullAccess &&
         course?.canPurchase &&
         course?.plans?.[0]?.planCode && (
           <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border-subtle bg-background-default px-600 py-300 shadow-3">

--- a/src/types/api/course.types.ts
+++ b/src/types/api/course.types.ts
@@ -48,7 +48,8 @@ export type ViewerStatus =
   | 'ANONYMOUS'
   | 'LOGIN_ONLY'
   | 'FREE_ENROLLED'
-  | 'PAID';
+  | 'PAID'
+  | 'ADMIN';
 
 // ─── Course List ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## 작업 내용
- `viewerStatus=ADMIN`을 프론트 타입/분기에서 별도 상태로 추가했습니다.
- 코스 상세 CTA/배지를 `PAID` 단일 판단이 아니라 `hasFullAccess`, `isFreeEnrolled`, `isPaidEnrolled`, `canFreeEnroll` 기준으로 분리했습니다.
- 관리자 무료수강신청 성공 후 A-02 코스 상세를 재조회하도록 했습니다.
- 학습여정에서 관리자 미수강 상태는 “관리자 권한으로 미리보기 중”으로 표시하고, 실제 무료수강/결제 상태와 full access UX를 분리했습니다.
- 상태 해석 헬퍼와 단위 테스트를 추가했습니다.

## 백엔드 계약 확인
- `study-platform-mvp origin/dev`의 `ViewerStatus.ADMIN` enum 확인
- `CourseDetailResponse.admin(...)`에서 `viewerStatus=ADMIN`, `hasFullAccess=true`, 실제 수강 플래그(`isFreeEnrolled`/`isPaidEnrolled`) 별도 반환 확인

## 검증
- `vitest run --project unit src/components/pages/class/course-viewer-status.test.ts` 통과
- `yarn lint:fix` 통과 (기존 warning 유지)
- `yarn prettier:fix` 통과
- `yarn typecheck` 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 코스 수강 상태(관리자 권한, 결제 수강, 무료수강 등)가 사이드바에 명확하게 표시됩니다.
  * 무료 코스 등록 후 코스 상세 정보가 실시간으로 갱신됩니다.

* **Refactor**
  * 코스 접근 권한 판별 로직이 통합되어 일관성이 개선되었습니다.

* **Tests**
  * 코스 상태 판별 기능에 대한 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->