### PR TITLE
fix: 무료수강 CTA 계약 정렬

### DIFF
--- a/src/app/(landing)/class/[slug]/page.tsx
+++ b/src/app/(landing)/class/[slug]/page.tsx
@@ -69,11 +69,11 @@ export default function ClassDetailPage({
   const viewerStatusLabel = getCourseViewerStatusLabel(courseDetail);
   const ctaLabel = (() => {
     if (createCourseFreeEnrollment.isPending) return '등록 중...';
+    if (canFreeEnrollFromDetail) return '무료 코스 시작하기';
     if (isCoursePaidEnrolled(courseDetail)) return '학습하러 가기';
     if (isCourseFreeEnrolled(courseDetail)) return '학습 계속하기';
-    if (canFreeEnrollFromDetail) return '무료 코스 시작하기';
     if (hasFullAccessFromDetail) return '관리자 권한으로 보기';
-    return '무료 코스 시작하기';
+    return undefined;
   })();
   const { data: myGiftEmail } = useGetMyGiftEmail({
     enabled: isAuthenticated && !!courseDetail?.isPaidEnrolled,
@@ -144,8 +144,8 @@ export default function ClassDetailPage({
         showToast('무료 코스 등록이 완료되었어요.');
       } catch {
         showToast('무료 코스 등록 중 오류가 발생했어요.', 'error');
-        return;
       }
+      return;
     }
     router.push(learningHomeHref);
   }

--- a/src/components/pages/class/class-detail-sidebar.tsx
+++ b/src/components/pages/class/class-detail-sidebar.tsx
@@ -14,7 +14,7 @@ const LoginModal = dynamic(
 interface ClassDetailSidebarProps {
   courseDetail: CourseDetailResponse | undefined;
   isAuthenticated: boolean;
-  ctaLabel: string;
+  ctaLabel: string | undefined;
   viewerStatusLabel: string | undefined;
   isEnrolling: boolean;
   onShare: () => void;
@@ -135,27 +135,29 @@ export function ClassDetailSidebar({
             >
               공유하기
             </button>
-            {isAuthenticated ? (
-              <button
-                type="button"
-                onClick={onStartCourse}
-                disabled={isEnrolling}
-                className="flex h-550 w-full items-center justify-center rounded-100 bg-background-brand-default font-designer-14b text-text-inverse"
-              >
-                {ctaLabel}
-              </button>
-            ) : (
-              <LoginModal
-                openTrigger={
+            {isAuthenticated
+              ? ctaLabel && (
                   <button
                     type="button"
+                    onClick={onStartCourse}
+                    disabled={isEnrolling}
                     className="flex h-550 w-full items-center justify-center rounded-100 bg-background-brand-default font-designer-14b text-text-inverse"
                   >
-                    무료 코스 시작하기
+                    {ctaLabel}
                   </button>
-                }
-              />
-            )}
+                )
+              : courseDetail?.canFreeEnroll === true && (
+                  <LoginModal
+                    openTrigger={
+                      <button
+                        type="button"
+                        className="flex h-550 w-full items-center justify-center rounded-100 bg-background-brand-default font-designer-14b text-text-inverse"
+                      >
+                        무료 코스 시작하기
+                      </button>
+                    }
+                  />
+                )}
           </div>
 
           {isAuthenticated && courseDetail?.isPaidEnrolled && (

--- a/src/components/pages/class/course-viewer-status.test.ts
+++ b/src/components/pages/class/course-viewer-status.test.ts
@@ -48,6 +48,18 @@ describe('course viewer status helpers', () => {
     );
   });
 
+  it('shows free enrollment CTA solely from canFreeEnroll', () => {
+    const course = {
+      ...baseCourse,
+      viewerStatus: 'ADMIN',
+      hasFullAccess: true,
+      canFreeEnroll: true,
+      isFreeEnrolled: true,
+    } satisfies CourseDetailResponse;
+
+    expect(canShowCourseFreeEnrollCta(course)).toBe(true);
+  });
+
   it('ADMIN free enrollment keeps ADMIN status and becomes a real free learner', () => {
     const course = {
       ...baseCourse,
@@ -58,7 +70,6 @@ describe('course viewer status helpers', () => {
     } satisfies CourseDetailResponse;
 
     expect(isCourseFreeEnrolled(course)).toBe(true);
-    expect(canShowCourseFreeEnrollCta(course)).toBe(false);
     expect(getCourseViewerStatusLabel(course)).toBe('무료수강중');
   });
 

--- a/src/components/pages/class/course-viewer-status.ts
+++ b/src/components/pages/class/course-viewer-status.ts
@@ -5,33 +5,21 @@ export function isAdminViewer(course?: CourseDetailResponse): boolean {
 }
 
 export function isCourseFreeEnrolled(course?: CourseDetailResponse): boolean {
-  return (
-    course?.isFreeEnrolled === true || course?.viewerStatus === 'FREE_ENROLLED'
-  );
+  return course?.isFreeEnrolled === true;
 }
 
 export function isCoursePaidEnrolled(course?: CourseDetailResponse): boolean {
-  return course?.isPaidEnrolled === true || course?.viewerStatus === 'PAID';
+  return course?.isPaidEnrolled === true;
 }
 
 export function hasCourseFullAccess(course?: CourseDetailResponse): boolean {
-  return (
-    course?.hasFullAccess === true ||
-    isAdminViewer(course) ||
-    isCoursePaidEnrolled(course)
-  );
+  return course?.hasFullAccess === true;
 }
 
 export function canShowCourseFreeEnrollCta(
   course?: CourseDetailResponse,
 ): boolean {
-  if (course?.canFreeEnroll !== true) return false;
-  if (isCourseFreeEnrolled(course) || isCoursePaidEnrolled(course)) {
-    return false;
-  }
-  return (
-    course.viewerStatus === 'LOGIN_ONLY' || course.viewerStatus === 'ADMIN'
-  );
+  return course?.canFreeEnroll === true;
 }
 
 export function getCourseViewerStatusLabel(


### PR DESCRIPTION
## 요약
- PR #683 후속으로 코스 상세 응답 계약에 맞춰 무료수강 CTA/수강상태 분기를 정렬했습니다.
- `canFreeEnroll === true`만 무료수강 CTA 노출 기준으로 사용합니다. (`ADMIN != PAID`)
- 실제 수강 상태는 `isFreeEnrolled` / `isPaidEnrolled`, 전체 접근은 `hasFullAccess`만 기준으로 사용합니다.
- 무료수강신청 성공 후 즉시 학습홈으로 이동하지 않고 코스 상세를 재조회한 뒤 응답 기준으로 화면을 다시 그립니다.

## 백엔드 계약 확인
- `/tmp/spmvp-chapter-open-fix/src/main/java/com/codezerotoone/mvp/domain/course/dto/response/CourseDetailResponse.java`
- `/tmp/spmvp-chapter-open-fix/src/main/java/com/codezerotoone/mvp/domain/course/controller/CourseFreeEnrollmentController.java`
- `/tmp/spmvp-chapter-open-fix/src/main/java/com/codezerotoone/mvp/domain/course/controller/apidocs/GetCourseDetailApiDocs.java`
- `/tmp/spmvp-chapter-open-fix/src/main/java/com/codezerotoone/mvp/domain/course/controller/apidocs/PostCourseFreeEnrollmentApiDocs.java`

## 검증
- `yarn prettier:fix`
- `yarn typecheck`
- `./node_modules/.bin/vitest run --project unit src/components/pages/class/course-viewer-status.test.ts`
- `yarn lint:fix` (0 errors, existing warnings only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 수강 신청 버튼 표시 조건 및 우선순위 개선
  * 무료 코스 등록 시 에러 처리 흐름 개선
  * 미인증 사용자의 무료 코스 접근 로직 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->