### PR TITLE
[fix-scrollbar] hotfix : fix(lesson): 레슨 페이지 스크롤을 왼쪽 컬럼 내부로 한정

### DIFF
--- a/e2e/class/journey-map.spec.ts
+++ b/e2e/class/journey-map.spec.ts
@@ -61,6 +61,7 @@ test.beforeEach(async ({ context, baseURL }) => {
 function makeCourseDetail(overrides: Partial<CourseDetailResponse> = {}): {
   content: CourseDetailResponse;
 } {
+  const viewerStatus = overrides.viewerStatus ?? 'FREE_ENROLLED';
   const base: CourseDetailResponse = {
     courseId: COURSE_ID,
     slug: 'vibe-intro',
@@ -86,11 +87,11 @@ function makeCourseDetail(overrides: Partial<CourseDetailResponse> = {}): {
     ],
     earlyBirdEndsAt: null,
     canFreeEnroll: null,
-    isFreeEnrolled: true,
+    isFreeEnrolled: viewerStatus === 'FREE_ENROLLED',
     freeLessonCount: 3,
     journeyMapAvailable: true,
-    hasFullAccess: false,
-    isPaidEnrolled: false,
+    hasFullAccess: viewerStatus === 'PAID',
+    isPaidEnrolled: viewerStatus === 'PAID',
     canPurchase: true,
   };
   return { content: { ...base, ...overrides } };

--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/page.tsx
@@ -47,16 +47,16 @@ export default function LessonPage({
   const reviewRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const topBarRef = useRef<HTMLDivElement>(null);
+  const leftColRef = useRef<HTMLDivElement>(null);
 
   function scrollToRef(ref: RefObject<HTMLDivElement | null>) {
-    if (!ref.current) return;
-    const headerHeight = topBarRef.current?.offsetHeight ?? 64;
+    if (!ref.current || !leftColRef.current) return;
+    const container = leftColRef.current;
     const top =
-      ref.current.getBoundingClientRect().top +
-      window.scrollY -
-      headerHeight -
-      16;
-    window.scrollTo({ top, behavior: 'smooth' });
+      container.scrollTop +
+      ref.current.getBoundingClientRect().top -
+      container.getBoundingClientRect().top;
+    container.scrollTo({ top, behavior: 'smooth' });
   }
 
   function handleTabChange(next: LessonTabValue) {
@@ -200,93 +200,101 @@ export default function LessonPage({
       </div>
 
       <div className="mx-auto w-full max-w-[1236px] px-300">
-        <div className="grid grid-cols-content-sidebar-360 items-start gap-250 pt-500">
+        <div className="flex items-start gap-250">
           {/* LEFT */}
-          <div className="min-w-0">
-            <Link
-              href={`/class/${lesson?.courseSlug ?? slug}/home`}
-              className="inline-flex items-center gap-125 rounded-full border border-gray-200 bg-background-default px-200 py-100"
-            >
-              <ArrowLeft className="h-250 w-250 text-gray-800" />
-              <span className="font-designer-14m text-gray-1000">
-                학습 여정 맵 돌아가기
-              </span>
-            </Link>
-
-            <div className="mt-300 flex items-center justify-between">
-              <div className="flex items-center gap-200">
-                <span className="rounded-100 bg-rose-200 px-125 py-25 font-designer-14m text-rose-400">
-                  Lesson {String(lessonId).padStart(2, '0')}
+          <div className="min-w-0 flex-1 flex flex-col h-[calc(100vh-var(--spacing-800))]">
+            {/* Fixed header: back link, title, description, tabs — never scrolls */}
+            <div className="shrink-0 pt-500">
+              <Link
+                href={`/class/${lesson?.courseSlug ?? slug}/home`}
+                className="inline-flex items-center gap-125 rounded-full border border-gray-200 bg-background-default px-200 py-100"
+              >
+                <ArrowLeft className="h-250 w-250 text-gray-800" />
+                <span className="font-designer-14m text-gray-1000">
+                  학습 여정 맵 돌아가기
                 </span>
-                <h1 className="font-designer-32b text-gray-800">
-                  {lesson?.title ?? 'AI 처음 만나는 날'}
-                </h1>
-              </div>
-              <p className="font-designer-16m text-gray-500">
-                {lesson?.estimatedMinutes
-                  ? `약 ${lesson.estimatedMinutes}분 소요`
-                  : ''}
-              </p>
-            </div>
+              </Link>
 
-            {lesson?.description ? (
-              <p className="mt-150 whitespace-pre-line font-designer-16r text-gray-700">
-                {lesson.description}
-              </p>
-            ) : null}
-
-            <div className="sticky top-800 z-20 mt-300 bg-gray-100">
-              <LessonTabs value={tab} onChange={handleTabChange} />
-            </div>
-
-            <div
-              ref={contentRef}
-              className="mt-300 min-h-[964px] rounded-150 bg-background-default p-500"
-            >
-              {lesson?.contentMarkdown ? (
-                <MarkdownContentCore content={lesson.contentMarkdown} />
-              ) : (
-                <p className="font-designer-16r text-gray-500">
-                  본문이 준비 중입니다.
+              <div className="mt-300 flex items-center justify-between">
+                <div className="flex items-center gap-200">
+                  <span className="rounded-100 bg-rose-200 px-125 py-25 font-designer-14m text-rose-400">
+                    Lesson {String(lessonId).padStart(2, '0')}
+                  </span>
+                  <h1 className="font-designer-32b text-gray-800">
+                    {lesson?.title ?? 'AI 처음 만나는 날'}
+                  </h1>
+                </div>
+                <p className="font-designer-16m text-gray-500">
+                  {lesson?.estimatedMinutes
+                    ? `약 ${lesson.estimatedMinutes}분 소요`
+                    : ''}
                 </p>
-              )}
+              </div>
+
+              {lesson?.description ? (
+                <p className="mt-150 whitespace-pre-line font-designer-16r text-gray-700">
+                  {lesson.description}
+                </p>
+              ) : null}
+
+              <div className="mt-300 bg-gray-100">
+                <LessonTabs value={tab} onChange={handleTabChange} />
+              </div>
             </div>
 
-            <div ref={reviewRef} />
-            <hr className="my-500 border-gray-300" />
+            {/* Scroll area: content + review form only */}
+            <div ref={leftColRef} className="flex-1 overflow-y-auto">
+              <div
+                ref={contentRef}
+                className="mt-300 min-h-[964px] rounded-150 bg-background-default p-500"
+              >
+                {lesson?.contentMarkdown ? (
+                  <MarkdownContentCore content={lesson.contentMarkdown} />
+                ) : (
+                  <p className="font-designer-16r text-gray-500">
+                    본문이 준비 중입니다.
+                  </p>
+                )}
+              </div>
 
-            {tab === 'review' || tab === 'follow' ? (
-              <LessonReviewForm
-                key={lessonId}
-                retrospectivePurpose={
-                  lesson?.retrospectivePurpose ?? 'ARTIFACT_SHARE'
-                }
-                retrospectivePrompt={lesson?.retrospectivePrompt}
-                artifactSubmissionRequired={
-                  lesson?.artifactSubmissionRequired ?? false
-                }
-                alreadySubmitted={alreadySubmitted}
-                submitting={submitRetrospective.isPending}
-                isLastLesson={isLastLesson}
-                onSubmit={handleSubmit}
-              />
-            ) : null}
+              <div ref={reviewRef} />
+              <hr className="my-500 border-gray-300" />
 
-            <div className="h-1000" />
+              {tab === 'review' || tab === 'follow' ? (
+                <LessonReviewForm
+                  key={lessonId}
+                  retrospectivePurpose={
+                    lesson?.retrospectivePurpose ?? 'ARTIFACT_SHARE'
+                  }
+                  retrospectivePrompt={lesson?.retrospectivePrompt}
+                  artifactSubmissionRequired={
+                    lesson?.artifactSubmissionRequired ?? false
+                  }
+                  alreadySubmitted={alreadySubmitted}
+                  submitting={submitRetrospective.isPending}
+                  isLastLesson={isLastLesson}
+                  onSubmit={handleSubmit}
+                />
+              ) : null}
+
+              <div className="h-1000" />
+            </div>
           </div>
 
-          {/* RIGHT sticky sidebar */}
-          <div className="sticky top-800 z-10 flex flex-col gap-250">
-            <LessonQnaCard
-              myQnas={qnaSidebar?.qnas ?? []}
-              builderQnas={qnaSidebar?.builderQnas ?? []}
-              onAskClick={() => setSubmissionModalOpen(true)}
-              onSelectQna={setSelectedQnaId}
-            />
-            <LessonBuilderFeedCard
-              feeds={feedPreview?.feeds ?? []}
-              onSelectFeed={setSelectedFeedId}
-            />
+          {/* RIGHT sidebar — stays put while left column scrolls */}
+          <div className="w-4500 shrink-0 pt-500">
+            <div className="flex flex-col gap-250">
+              <LessonQnaCard
+                myQnas={qnaSidebar?.qnas ?? []}
+                builderQnas={qnaSidebar?.builderQnas ?? []}
+                onAskClick={() => setSubmissionModalOpen(true)}
+                onSelectQna={setSelectedQnaId}
+              />
+              <LessonBuilderFeedCard
+                feeds={feedPreview?.feeds ?? []}
+                onSelectFeed={setSelectedFeedId}
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
window 스크롤 대신 leftColRef 컨테이너 스크롤로 전환.
헤더/탭은 고정, 본문+리뷰 영역만 overflow-y-auto 스크롤.

### 🌱 연관된 이슈

<!-- 관련 이슈를 적어주세요 -->

### ☘️ 작업 내용

<!-- 작업한 내용을 적어주세요 -->

### 🍀 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

#### 🎨 디자인 비교 (UI 컴포넌트 PR에만 작성)

<!-- /design-to-dev 실행 시 자동 첨부됩니다 -->

| Figma 원본 | Storybook 구현 |
|-----------|--------------|
| -         | -            |

<details>
<summary>비교 결과</summary>

| 항목 | 상태 | 비고 |
|------|------|------|
| 색상 | ✅ | |
| 간격 | ✅ | |
| 타이포그래피 | ✅ | |
| 반경 | ✅ | |
| 트랜스폼 | ✅ | |

</details>

#### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 레슨 페이지의 스크롤 동작이 개선되었습니다. 고정 헤더는 항상 화면 상단에 표시되며, 본문 영역만 부드럽게 스크롤됩니다.
  * 페이지 레이아웃이 재구성되어 우측 사이드바가 스크롤 중에도 고정 위치를 유지합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->