### PR TITLE
[cherry-pick] 레슨 피드백 글자수 제한·카운터, 피드 이미지 JPEG 수정

### DIFF
--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-review-form.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-review-form.tsx
@@ -317,12 +317,18 @@ export function LessonReviewForm({
             ))}
           </div>
         </div>
-        <textarea
-          value={feedbackText}
-          onChange={(e) => setFeedbackText(e.target.value)}
-          placeholder="어떠한 피드백도 좋아요! 간략히 적어주세요! (선택사항)"
-          className="h-1625 w-full resize-none rounded-200 border border-gray-300 bg-background-default px-300 py-250 font-designer-16m text-gray-800 outline-none placeholder:text-gray-400 focus:border-border-brand"
-        />
+        <div className="flex flex-col gap-75">
+          <textarea
+            value={feedbackText}
+            onChange={(e) => setFeedbackText(e.target.value)}
+            maxLength={1000}
+            placeholder="어떠한 피드백도 좋아요! 간략히 적어주세요! (선택사항)"
+            className="h-1625 w-full resize-none rounded-200 border border-gray-300 bg-background-default px-300 py-250 font-designer-16m text-gray-800 outline-none placeholder:text-gray-400 focus:border-border-brand"
+          />
+          <p className="text-right font-designer-12r text-gray-400">
+            {feedbackText.length}/1000
+          </p>
+        </div>
       </div>
 
       {/* Submit */}

--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-screenshot-modal.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-screenshot-modal.tsx
@@ -3,6 +3,7 @@
 import { ImagePlus, X } from 'lucide-react';
 import Image from 'next/image';
 import { useRef, useState } from 'react';
+import { normalizeImageFileForUpload } from '@/components/common/ui/editor/image-utils';
 import { uploadCommunityMarkdownImage } from '@/features/community/model/community-markdown-image-upload';
 import { useToastStore } from '@/stores/use-toast-store';
 
@@ -32,8 +33,9 @@ export function LessonScreenshotModal({ open, onClose, onConfirm }: Props) {
     }
     setUploading(true);
     try {
-      const url = await uploadCommunityMarkdownImage(file);
-      const preview = URL.createObjectURL(file);
+      const normalizedFile = await normalizeImageFileForUpload(file);
+      const url = await uploadCommunityMarkdownImage(normalizedFile);
+      const preview = URL.createObjectURL(normalizedFile);
       setImageUrl(url);
       setPreviewUrl(preview);
     } catch {

--- a/src/app/(landing)/class/[slug]/(learning)/feed/write/page.tsx
+++ b/src/app/(landing)/class/[slug]/(learning)/feed/write/page.tsx
@@ -413,7 +413,6 @@ export default function FeedWritePage() {
                   ? '내용을 수정해주세요.'
                   : '코딩을 하며 다양한 순간을 글로 작성해보세요! 이번 레슨에서 배운 것, 새롭게 알게 된 것을 자유롭게 작성해보세요.'
               }
-              uploadImage={uploadCommunityMarkdownImage}
             />
 
             {/* Notice */}

--- a/src/app/(landing)/class/[slug]/(learning)/feed/write/page.tsx
+++ b/src/app/(landing)/class/[slug]/(learning)/feed/write/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import { normalizeImageFileForUpload } from '@/components/common/ui/editor/image-utils';
 import MarkdownEditor from '@/components/common/ui/editor/markdown-editor';
 import { uploadCommunityMarkdownImage } from '@/features/community/model/community-markdown-image-upload';
 import {
@@ -104,9 +105,10 @@ export default function FeedWritePage() {
     }
     setIsUploadingImage(true);
     try {
-      const publicUrl = await uploadCommunityMarkdownImage(file);
+      const normalizedFile = await normalizeImageFileForUpload(file);
+      const publicUrl = await uploadCommunityMarkdownImage(normalizedFile);
       const key = new URL(publicUrl).pathname.slice(1);
-      const previewUrl = URL.createObjectURL(file);
+      const previewUrl = URL.createObjectURL(normalizedFile);
       setImages((prev) => [...prev, { previewUrl, key }]);
     } catch {
       showToast('이미지 업로드에 실패했습니다.', 'error');

--- a/src/features/community/api/community-api.ts
+++ b/src/features/community/api/community-api.ts
@@ -31,7 +31,7 @@ const unwrap = <T>(response: { data: CommunityBaseResponse<T> }) =>
 
 const COMMUNITY_IMAGE_EXTENSION_BY_MIME = {
   'image/gif': 'gif',
-  'image/jpeg': 'jpeg',
+  'image/jpeg': 'jpg',
   'image/png': 'png',
   'image/webp': 'webp',
 } as const;


### PR DESCRIPTION
## 개요

레슨 피드백 textarea에 1000자 제한 및 실시간 카운터를 추가하고, 피드 이미지 업로드 시 JPEG 확장자를 `jpeg → jpg`로 통일했습니다. 또한 피드 등록 마크다운 에디터 내부의 이미지 업로드 기능을 제거해 중복 업로드 경로를 정리했습니다.

## 원본 PR

- hotfix PR: #691 (https://github.com/code-zero-to-one/study-platform-client/pull/691)
- 원본 브랜치: `hotfix/lesson-submit`

## Cherry-pick 대상 커밋

- `de7b055` — [lesson-submit] fix : 피드 이미지 업로드 시 JPEG 확장자 jpeg → jpg 통일
- `b2c4457` — [lesson-submit] fix : 레슨 피드백 1000자 제한·카운터 추가, 이미지 업로드 normalizeImageFileForUpload 적용
- `d1e7d09` — [lesson-submit] fix : 피드 등록 마크다운 에디터 내부 이미지 업로드 기능 제거

## 변경 파일

- `src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-review-form.tsx` — 1000자 제한 + 실시간 글자 수 카운터 추가
- `src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-screenshot-modal.tsx` — 이미지 업로드 normalizeImageFileForUpload 적용
- `src/app/(landing)/class/[slug]/(learning)/feed/write/page.tsx` — 마크다운 에디터 내부 이미지 업로드 기능 제거, JPEG 확장자 통일
- `src/features/community/api/community-api.ts` — JPEG 확장자 jpeg → jpg 통일

## 혼입 검증 결과

- [x] develop 전용 코드 혼입 없음 (cherry-pick 대상 3개 커밋이 위 4개 파일만 수정, PR #691 범위와 일치)

## Test plan

- [ ] 레슨 피드백 textarea에 1000자 초과 입력 시 제한 동작 확인
- [ ] 글자 수 카운터 실시간 업데이트 확인
- [ ] 피드 이미지 업로드 시 `.jpeg` 확장자가 `.jpg`로 저장되는지 확인
- [ ] 피드 작성 페이지(`/feed/write`)에서 마크다운 에디터 내 이미지 업로드 버튼 제거 확인
- [ ] 기존 이미지 업로드 흐름 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)