### PR TITLE
[cherry-pick] 이미지 업로드 정규화 및 유틸 정리

### DIFF
--- a/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-qna-submission-modal.tsx
+++ b/src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-qna-submission-modal.tsx
@@ -4,6 +4,7 @@ import { ImagePlus, Info, X } from 'lucide-react';
 import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import { normalizeImageFileForUpload } from '@/components/common/ui/editor/image-utils';
 import MarkdownEditor from '@/components/common/ui/editor/markdown-editor';
 import { uploadCommunityMarkdownImage } from '@/features/community/model/community-markdown-image-upload';
 import { useCreateLessonQna } from '@/hooks/queries/course/course-api';
@@ -89,9 +90,10 @@ export function LessonQnaSubmissionModal({
     }
     setIsUploadingImage(true);
     try {
-      const publicUrl = await uploadCommunityMarkdownImage(file);
+      const normalizedFile = await normalizeImageFileForUpload(file);
+      const publicUrl = await uploadCommunityMarkdownImage(normalizedFile);
       const key = new URL(publicUrl).pathname.slice(1);
-      const previewUrl = URL.createObjectURL(file);
+      const previewUrl = URL.createObjectURL(normalizedFile);
       setImages((prev) => [...prev, { previewUrl, key }]);
     } catch {
       showToast('이미지 업로드에 실패했습니다.', 'error');

--- a/src/app/(landing)/class/[slug]/(learning)/feed/[id]/page.tsx
+++ b/src/app/(landing)/class/[slug]/(learning)/feed/[id]/page.tsx
@@ -15,10 +15,7 @@ import {
   FeedShareIcon,
 } from '@/components/common/ui/icons/course-icons';
 import MarkdownContentCore from '@/components/common/ui/rich-text/markdown-content-core';
-import {
-  ROLE_LABELS,
-  RoleBadge,
-} from '@/components/pages/class/utils/builder-feed-utils';
+import { RoleBadge } from '@/components/pages/class/utils/builder-feed-utils';
 import { useAuth } from '@/features/auth/model/use-auth';
 import {
   useCreateFeedComment,
@@ -30,6 +27,7 @@ import {
   useToggleFeedLike,
 } from '@/hooks/queries/course/course-api';
 import { useToastStore } from '@/stores/use-toast-store';
+import { stripHtml } from '@/utils/markdown-content-text';
 
 function isImageUrl(url: string): boolean {
   return /\.(jpg|jpeg|png|gif|webp)(\?.*)?$/i.test(url);
@@ -691,7 +689,7 @@ export default function FeedDetailPage({
                     </div>
                     <div className="p-200">
                       <p className="line-clamp-2 font-designer-14r text-gray-800">
-                        {f.content}
+                        {stripHtml(f.content)}
                       </p>
                       <div className="mt-100 flex items-center gap-75">
                         <FeedHeartIcon className="h-200 w-200 text-gray-400" />

--- a/src/app/(landing)/class/[slug]/(learning)/qa/[id]/page.tsx
+++ b/src/app/(landing)/class/[slug]/(learning)/qa/[id]/page.tsx
@@ -16,6 +16,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { use, useRef, useState } from 'react';
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import { normalizeImageFileForUpload } from '@/components/common/ui/editor/image-utils';
 import MarkdownEditor from '@/components/common/ui/editor/markdown-editor';
 import { RoleBadge } from '@/components/pages/class/utils/builder-feed-utils';
 import { useAuth } from '@/features/auth/model/use-auth';
@@ -34,14 +35,11 @@ import {
 import { useToastStore } from '@/stores/use-toast-store';
 import { AUTH_ROLE_IDS } from '@/types/auth/domain';
 import { analyzeError } from '@/utils/error-handler';
+import { stripHtml } from '@/utils/markdown-content-text';
 
 function formatDate(dateStr: string) {
   const d = new Date(dateStr);
   return `${d.getMonth() + 1}월 ${d.getDate()}일`;
-}
-
-function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, '').trim();
 }
 
 function HtmlContent({ html }: { html: string }) {
@@ -268,9 +266,10 @@ export default function QnaDetailPage({
     }
     setIsUploadingAnswerImage(true);
     try {
-      const publicUrl = await uploadCommunityMarkdownImage(file);
+      const normalizedFile = await normalizeImageFileForUpload(file);
+      const publicUrl = await uploadCommunityMarkdownImage(normalizedFile);
       const key = new URL(publicUrl).pathname.slice(1);
-      const previewUrl = URL.createObjectURL(file);
+      const previewUrl = URL.createObjectURL(normalizedFile);
       setAnswerImages((prev) => [...prev, { previewUrl, key }]);
     } catch {
       showToast('이미지 업로드에 실패했습니다.', 'error');

--- a/src/components/common/ui/editor/image-utils.ts
+++ b/src/components/common/ui/editor/image-utils.ts
@@ -37,15 +37,6 @@ export const MARKDOWN_IMAGE_DEFAULT_ALLOWED_EXTENSIONS = [
   'heif',
 ] as const;
 
-const IMAGE_MIME_TO_EXT = {
-  'image/gif': 'gif',
-  'image/heic': 'heic',
-  'image/heif': 'heif',
-  'image/jpeg': 'jpg',
-  'image/png': 'png',
-  'image/webp': 'webp',
-} as const;
-
 const IMAGE_MIME_TO_EXTS = {
   'image/gif': ['gif'],
   'image/heic': ['heic'],
@@ -123,7 +114,9 @@ const normalizeImageMimeType = (
 export const getExtensionFromMime = (mimeType: string): string => {
   const normalizedMimeType = normalizeImageMimeType(mimeType);
   return (
-    (normalizedMimeType ? IMAGE_MIME_TO_EXT[normalizedMimeType] : undefined) ??
+    (normalizedMimeType
+      ? IMAGE_MIME_TO_EXTS[normalizedMimeType][0]
+      : undefined) ??
     mimeType.split('/')[1]?.toLowerCase() ??
     ''
   );
@@ -245,20 +238,17 @@ const convertHeicImageFileToJpeg = async (file: File) => {
 };
 
 export const normalizeImageFileForUpload = async (file: File) => {
-  const detectedMimeType = detectImageMimeTypeFromHeader(
-    new Uint8Array(await file.slice(0, IMAGE_HEADER_BYTE_LENGTH).arrayBuffer()),
+  const headerBytes = new Uint8Array(
+    await file.slice(0, IMAGE_HEADER_BYTE_LENGTH).arrayBuffer(),
   );
+  const detectedMimeType = detectImageMimeTypeFromHeader(headerBytes);
   const reportedMimeType = normalizeImageMimeType(file.type);
-
-  if (isHeicLikeImageMimeType(detectedMimeType)) {
-    return convertHeicImageFileToJpeg(file);
-  }
-
-  if (!detectedMimeType && isHeicLikeImageMimeType(reportedMimeType)) {
-    return convertHeicImageFileToJpeg(file);
-  }
-
   const resolvedMimeType = detectedMimeType ?? reportedMimeType;
+
+  if (isHeicLikeImageMimeType(resolvedMimeType)) {
+    return convertHeicImageFileToJpeg(file);
+  }
+
   if (!resolvedMimeType) {
     return file;
   }
@@ -273,10 +263,7 @@ export const normalizeImageFileForUpload = async (file: File) => {
   return new File(
     [file],
     replaceFileExtension(file.name, getExtensionFromMime(resolvedMimeType)),
-    {
-      type: resolvedMimeType,
-      lastModified: file.lastModified,
-    },
+    { type: resolvedMimeType, lastModified: file.lastModified },
   );
 };
 
@@ -298,8 +285,13 @@ export const getImageFileNormalizationErrorMessage = (
  * toImageInputAccept(['jpg', 'png', 'webp']) // '.jpg,.png,.webp'
  */
 export const toImageInputAccept = (extensions: readonly string[]) => {
-  const mimeTypes = Object.entries(IMAGE_MIME_TO_EXT)
-    .filter(([, ext]) => extensions.includes(ext))
+  const mimeTypes = (
+    Object.entries(IMAGE_MIME_TO_EXTS) as [
+      SupportedImageMimeType,
+      readonly string[],
+    ][]
+  )
+    .filter(([, exts]) => exts.some((ext) => extensions.includes(ext)))
     .map(([mime]) => mime);
 
   const extensionParts = extensions.map((extension) => `.${extension}`);


### PR DESCRIPTION
## 개요

QA 답변 이미지 업로드 시 `normalizeImageFileForUpload`가 적용되지 않아 MIME 타입·확장자가 올바르게 처리되지 않는 문제를 수정합니다. 또한 `IMAGE_MIME_TO_EXT` / `IMAGE_MIME_TO_EXTS` 중복 레지스트리를 단일화하고, 각 페이지에 산재된 `stripHtml` 로컬 구현을 공용 util로 통합합니다.

## 원본 PR

- develop PR: #695 (https://github.com/code-zero-to-one/study-platform-client/pull/695)
- 원본 브랜치: `fix/image-key`

## Cherry-pick 대상 커밋

- `f4a80d3` — [image-key] fix : refactor(image-utils): IMAGE_MIME_TO_EXT 제거 — IMAGE_MIME_TO_EXTS 단일 레지스트리로 통합
- `6c1a583` — [image-key] fix : 이미지 업로드 시 normalizeImageFileForUpload 적용, stripHtml 공용 함수로 교체

(두 번째 커밋 `b0cc24a` stripHtml export는 main에 이미 반영되어 skip)

## 변경 파일

- `src/app/(class-lesson)/class/[slug]/lesson/[id]/_components/lesson-qna-submission-modal.tsx` — 이미지 업로드에 `normalizeImageFileForUpload` 적용
- `src/app/(landing)/class/[slug]/(learning)/feed/[id]/page.tsx` — 로컬 `stripHtml` → 공용 util 교체, 미사용 import 제거
- `src/app/(landing)/class/[slug]/(learning)/qa/[id]/page.tsx` — 이미지 업로드 정규화 + 로컬 `stripHtml` 제거 → 공용 util 사용
- `src/components/common/ui/editor/image-utils.ts` — `IMAGE_MIME_TO_EXT` 삭제, `IMAGE_MIME_TO_EXTS` 단일 레지스트리로 통합, HEIC 분기 단순화

## 혼입 검증 결과

`git diff main...fix/image-key --stat` 기준 241개 파일 (develop이 main보다 앞서 있음).
cherry-pick은 PR #695의 3개 커밋만 적용 → 실제 변경 4개 파일, develop 전용 코드 혼입 없음.

- [x] develop 전용 코드 혼입 없음 (변경 파일이 원본 PR 범위와 일치)

## Test plan

- [ ] QA 페이지에서 JPEG/PNG/WEBP 이미지 업로드 후 preview 및 서버 키 정상 확인
- [ ] QA 페이지에서 HEIC 이미지 업로드 시 JPEG 변환 후 업로드 확인
- [ ] 레슨 QnA 제출 모달에서 이미지 업로드 정상 동작 확인
- [ ] 피드 상세 페이지에서 HTML 태그 포함 댓글 내용이 텍스트만 렌더링되는지 확인
- [ ] QA 상세 페이지에서 `stripHtml` 적용 결과 동일하게 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이미지 업로드 처리 과정을 정규화하여 업로드 안정성 및 미리보기 표시 개선
  * 수업 Q&A 및 피드에서 HTML/마크업이 포함된 콘텐츠를 올바르게 표시하도록 수정
  * HEIC/HEIF 형식 이미지 자동 변환 지원

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->