### PR TITLE
fix: 프론트가 백엔드 공유 네트워크를 유지하도록 수정

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,3 +15,11 @@ services:
     env_file:
       - .env
     restart: unless-stopped
+    networks:
+      - default
+      - backend-shared
+
+networks:
+  backend-shared:
+    name: ${BACKEND_SHARED_NETWORK:-zeroone-net-qa}
+    external: true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,3 +15,11 @@ services:
     env_file:
       - .env
     restart: unless-stopped
+    networks:
+      - default
+      - backend-shared
+
+networks:
+  backend-shared:
+    name: ${BACKEND_SHARED_NETWORK:-zeroone-net-prod}
+    external: true


### PR DESCRIPTION
## 작업 내용
- `docker-compose.dev.yml`에 QA 백엔드 shared external network 연결 추가
- `docker-compose.prod.yml`에 Prod 백엔드 shared external network 연결 추가
- 배포 시 프론트 컨테이너가 재생성되어도 백엔드 alias(`mvp-app-qa`, `mvp-app-prod`)를 내부에서 계속 해석할 수 있도록 구성 고정

## 배경
테스트 서버 점검 중 프론트 컨테이너가 자체 default network에만 붙어 있어서 QA/Prod 백엔드 컨테이너가 붙는 external network와 분리되어 있음을 확인했습니다. 이 상태에서는 CI/CD가 프론트 컨테이너를 재생성할 때 수동 `docker network connect` 조치가 매번 사라져 내부 direct 통신이 다시 끊어질 수 있습니다.

## 검증
- `docker compose -f docker-compose.dev.yml config`
- `docker compose -f docker-compose.prod.yml config`
- `git push` 과정의 pre-push `next build` 성공

## 리스크
- 실제 서버 반영 후 `frontend-dev` / `frontend-prod`가 각각 `zeroone-net-qa` / `zeroone-net-prod`에 붙는지 후속 확인 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 개발 및 프로덕션 환경의 네트워크 구성을 업데이트했습니다.
  * 환경변수를 통한 동적 네트워크 설정 지원을 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/699?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->