### PR TITLE
마이페이지 계정 탈퇴 API 연동

### DIFF
--- a/src/app/(service)/(my)/my-page/_components/withdrawal-confirm-modal.tsx
+++ b/src/app/(service)/(my)/my-page/_components/withdrawal-confirm-modal.tsx
@@ -3,20 +3,21 @@
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import Button from '@/components/common/ui/button';
 import { Modal } from '@/components/common/ui/modal';
+import { useWithdrawMemberMutation } from '@/hooks/queries/user/use-withdraw-member-mutation';
 
 interface WithdrawalConfirmModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-// TODO: withdrawal API not yet available — wire DELETE /api/v1/members/me when added
 export default function WithdrawalConfirmModal({
   open,
   onOpenChange,
 }: WithdrawalConfirmModalProps) {
-  const handleConfirm = async () => {
-    // TODO: call DELETE /api/v1/members/me and redirect to /
-    onOpenChange(false);
+  const { mutate: withdraw, isPending } = useWithdrawMemberMutation();
+
+  const handleConfirm = () => {
+    withdraw();
   };
 
   return (
@@ -88,6 +89,7 @@ export default function WithdrawalConfirmModal({
                 color="secondary"
                 size="medium"
                 className="flex-1"
+                disabled={isPending}
                 onClick={() => onOpenChange(false)}
               >
                 취소
@@ -96,9 +98,10 @@ export default function WithdrawalConfirmModal({
                 color="primary"
                 size="medium"
                 className="flex-1"
+                disabled={isPending}
                 onClick={handleConfirm}
               >
-                탈퇴하기
+                {isPending ? '탈퇴 중...' : '탈퇴하기'}
               </Button>
             </div>
           </Modal.Footer>

--- a/src/hooks/queries/user/use-withdraw-member-mutation.ts
+++ b/src/hooks/queries/user/use-withdraw-member-mutation.ts
@@ -3,6 +3,7 @@ import { axiosInstanceV6 } from '@/api/client/axios';
 import { AUTH_ROUTE_PATHS } from '@/features/auth/model/auth-route';
 import { clearClientAuthStateAndRedirect } from '@/features/auth/model/client-auth-cleanup';
 import { useToastStore } from '@/stores/use-toast-store';
+import { analyzeError, sendErrorToSentry } from '@/utils/error-handler';
 
 export const useWithdrawMemberMutation = () => {
   const showToast = useToastStore((state) => state.showToast);
@@ -15,8 +16,10 @@ export const useWithdrawMemberMutation = () => {
     onSuccess: () => {
       clearClientAuthStateAndRedirect(AUTH_ROUTE_PATHS.LANDING);
     },
-    onError: () => {
-      showToast('탈퇴에 실패했습니다. 잠시 후 다시 시도해주세요.', 'error');
+    onError: (error) => {
+      const errorInfo = analyzeError(error);
+      showToast(errorInfo.userMessage, 'error');
+      sendErrorToSentry(errorInfo, { source: 'useWithdrawMemberMutation' });
     },
   });
 };

--- a/src/hooks/queries/user/use-withdraw-member-mutation.ts
+++ b/src/hooks/queries/user/use-withdraw-member-mutation.ts
@@ -1,0 +1,22 @@
+import { useMutation } from '@tanstack/react-query';
+import { axiosInstanceV6 } from '@/api/client/axios';
+import { AUTH_ROUTE_PATHS } from '@/features/auth/model/auth-route';
+import { clearClientAuthStateAndRedirect } from '@/features/auth/model/client-auth-cleanup';
+import { useToastStore } from '@/stores/use-toast-store';
+
+export const useWithdrawMemberMutation = () => {
+  const showToast = useToastStore((state) => state.showToast);
+
+  return useMutation({
+    mutationFn: () =>
+      axiosInstanceV6.delete('mypage/class/withdraw', {
+        data: { agreedToClassWithdrawalNotice: true },
+      }),
+    onSuccess: () => {
+      clearClientAuthStateAndRedirect(AUTH_ROUTE_PATHS.LANDING);
+    },
+    onError: () => {
+      showToast('탈퇴에 실패했습니다. 잠시 후 다시 시도해주세요.', 'error');
+    },
+  });
+};


### PR DESCRIPTION
## Problem

마이페이지 > 프로필의 '계정 탈퇴' 버튼은 UI만 존재하고 실제 API 연동이 없었음. 탈퇴하기 클릭 시 아무런 동작이 발생하지 않는 상태.

## Solution

`DELETE /api/v6/mypage/class/withdraw` 엔드포인트를 연동. 탈퇴 성공 시 `clearClientAuthStateAndRedirect('/')` 호출로 모든 클라이언트 상태(쿠키, Zustand 스토어, QueryCache)를 초기화하고 랜딩 페이지로 리다이렉트.

에러 핸들링은 `useMutation` 레벨 `onError`에 정의 — call-time 콜백 방식은 `MutationCache.onError` global 핸들러가 suppress되지 않아 에러 토스트가 2번 표시되는 문제가 있어 hook 레벨에서 처리.

## Changes

### Features
| File | Description |
|------|-------------|
| `src/hooks/queries/user/use-withdraw-member-mutation.ts` | 계정 탈퇴 mutation hook 신규 추가 |
| `src/app/(service)/(my)/my-page/_components/withdrawal-confirm-modal.tsx` | mutation 연동, isPending 중 취소/탈퇴 버튼 disabled 처리 |

## Result

- 마이페이지 > 프로필 하단 '계정 탈퇴' → 안내 모달 → '탈퇴하기' 클릭 시 실제 탈퇴 API 호출
- 성공: 모든 세션 상태 초기화 후 `/` 리다이렉트
- 실패: 에러 토스트 1회 표시, 모달 유지 (재시도 가능)
- API 호출 중 취소/탈퇴 버튼 모두 비활성화 → 중복 요청 및 실수로 인한 취소 방지

## Test plan

- [ ] 마이페이지 > 프로필 > '계정 탈퇴' 버튼 클릭 → 안내 모달 표시 확인
- [ ] 탈퇴하기 클릭 → 로딩 중 버튼 텍스트 '탈퇴 중...' 및 취소/탈퇴 버튼 비활성화 확인
- [ ] 탈퇴 성공 → 랜딩(`/`) 리다이렉트, 로그인 상태 해제 확인
- [ ] 탈퇴 실패 시 에러 토스트 1개만 표시, 모달 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회원 탈퇴 기능 구현 완료 - 사용자는 이제 마이페이지에서 서비스 탈퇴 가능

* **버그 수정**
  * 탈퇴 확인 모달 로직 개선 - 로딩 상태 표시 및 에러 처리 추가
  * 탈퇴 중일 때 중복 요청 방지를 위해 버튼 비활성화
  * 탈퇴 실패 시 사용자에게 오류 메시지 표시

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->