### PR TITLE
[cherry-pick] 마이페이지 계정 탈퇴 API 연동

### DIFF
--- a/src/app/(service)/(my)/my-page/_components/withdrawal-confirm-modal.tsx
+++ b/src/app/(service)/(my)/my-page/_components/withdrawal-confirm-modal.tsx
@@ -3,20 +3,21 @@
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import Button from '@/components/common/ui/button';
 import { Modal } from '@/components/common/ui/modal';
+import { useWithdrawMemberMutation } from '@/hooks/queries/user/use-withdraw-member-mutation';
 
 interface WithdrawalConfirmModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-// TODO: withdrawal API not yet available — wire DELETE /api/v1/members/me when added
 export default function WithdrawalConfirmModal({
   open,
   onOpenChange,
 }: WithdrawalConfirmModalProps) {
-  const handleConfirm = async () => {
-    // TODO: call DELETE /api/v1/members/me and redirect to /
-    onOpenChange(false);
+  const { mutate: withdraw, isPending } = useWithdrawMemberMutation();
+
+  const handleConfirm = () => {
+    withdraw();
   };
 
   return (
@@ -88,6 +89,7 @@ export default function WithdrawalConfirmModal({
                 color="secondary"
                 size="medium"
                 className="flex-1"
+                disabled={isPending}
                 onClick={() => onOpenChange(false)}
               >
                 취소
@@ -96,9 +98,10 @@ export default function WithdrawalConfirmModal({
                 color="primary"
                 size="medium"
                 className="flex-1"
+                disabled={isPending}
                 onClick={handleConfirm}
               >
-                탈퇴하기
+                {isPending ? '탈퇴 중...' : '탈퇴하기'}
               </Button>
             </div>
           </Modal.Footer>

--- a/src/hooks/queries/user/use-withdraw-member-mutation.ts
+++ b/src/hooks/queries/user/use-withdraw-member-mutation.ts
@@ -3,6 +3,7 @@ import { axiosInstanceV6 } from '@/api/client/axios';
 import { AUTH_ROUTE_PATHS } from '@/features/auth/model/auth-route';
 import { clearClientAuthStateAndRedirect } from '@/features/auth/model/client-auth-cleanup';
 import { useToastStore } from '@/stores/use-toast-store';
+import { analyzeError, sendErrorToSentry } from '@/utils/error-handler';
 
 export const useWithdrawMemberMutation = () => {
   const showToast = useToastStore((state) => state.showToast);
@@ -15,8 +16,10 @@ export const useWithdrawMemberMutation = () => {
     onSuccess: () => {
       clearClientAuthStateAndRedirect(AUTH_ROUTE_PATHS.LANDING);
     },
-    onError: () => {
-      showToast('탈퇴에 실패했습니다. 잠시 후 다시 시도해주세요.', 'error');
+    onError: (error) => {
+      const errorInfo = analyzeError(error);
+      showToast(errorInfo.userMessage, 'error');
+      sendErrorToSentry(errorInfo, { source: 'useWithdrawMemberMutation' });
     },
   });
 };

--- a/src/hooks/queries/user/use-withdraw-member-mutation.ts
+++ b/src/hooks/queries/user/use-withdraw-member-mutation.ts
@@ -1,0 +1,22 @@
+import { useMutation } from '@tanstack/react-query';
+import { axiosInstanceV6 } from '@/api/client/axios';
+import { AUTH_ROUTE_PATHS } from '@/features/auth/model/auth-route';
+import { clearClientAuthStateAndRedirect } from '@/features/auth/model/client-auth-cleanup';
+import { useToastStore } from '@/stores/use-toast-store';
+
+export const useWithdrawMemberMutation = () => {
+  const showToast = useToastStore((state) => state.showToast);
+
+  return useMutation({
+    mutationFn: () =>
+      axiosInstanceV6.delete('mypage/class/withdraw', {
+        data: { agreedToClassWithdrawalNotice: true },
+      }),
+    onSuccess: () => {
+      clearClientAuthStateAndRedirect(AUTH_ROUTE_PATHS.LANDING);
+    },
+    onError: () => {
+      showToast('탈퇴에 실패했습니다. 잠시 후 다시 시도해주세요.', 'error');
+    },
+  });
+};


### PR DESCRIPTION
## 개요

마이페이지 프로필의 계정 탈퇴 버튼에 실제 API를 연동합니다. `DELETE /api/v6/mypage/class/withdraw` 호출 후 성공 시 모든 클라이언트 상태(쿠키, Zustand, QueryCache)를 초기화하고 랜딩 페이지로 리다이렉트합니다. 에러 핸들링은 hook 레벨 `onError`에서 처리해 global MutationCache와 중복 토스트가 발생하지 않도록 합니다.

## 원본 PR

- develop PR: #701 (https://github.com/code-zero-to-one/study-platform-client/pull/701)
- 원본 브랜치: `fix/withdrawal`

## Cherry-pick 대상 커밋

- `06816c3` — [withdrawal] fix : feat(my-page): 계정 탈퇴 API 연동
- `e2195ec` — [withdrawal] fix : 탈퇴 에러 핸들링 analyzeError 경유로 통일

## 변경 파일

- `src/hooks/queries/user/use-withdraw-member-mutation.ts` — 계정 탈퇴 mutation hook 신규 추가 (DELETE API 연동, analyzeError 경유 에러 처리)
- `src/app/(service)/(my)/my-page/_components/withdrawal-confirm-modal.tsx` — mutation 연동, isPending 중 취소/탈퇴 버튼 disabled 처리

## 혼입 검증 결과

각 커밋의 `--stat` 확인 결과:
- 커밋 1: `withdrawal-confirm-modal.tsx` + `use-withdraw-member-mutation.ts` 2개 파일만 변경
- 커밋 2: `use-withdraw-member-mutation.ts` 1개 파일만 변경
- [x] develop 전용 코드 혼입 없음 (변경 파일이 원본 PR 범위와 일치)

## Test plan

- [ ] 마이페이지 > 프로필 > '계정 탈퇴' 버튼 클릭 → 안내 모달 표시 확인
- [ ] 탈퇴하기 클릭 → 로딩 중 버튼 텍스트 '탈퇴 중...' 및 취소/탈퇴 버튼 비활성화 확인
- [ ] 탈퇴 성공 → 랜딩(`/`) 리다이렉트, 로그인 상태 해제 확인
- [ ] 탈퇴 실패 시 에러 토스트 1개만 표시, 모달 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 회원 탈퇴 기능이 이제 실제로 작동합니다.
  * 탈퇴 진행 중 UI 개선: 버튼 비활성화 및 "탈퇴 중..." 상태 표시를 통해 진행 상황을 명확히 전달합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->