### PR TITLE
release: registry pointer 실패 조건을 release 문서에 고정한다

### DIFF
--- a/ops/backend-release-dispatch.md
+++ b/ops/backend-release-dispatch.md
@@ -105,6 +105,7 @@ The frontend workflow that receives this event is:
 
 - `summary`
 - `metadata.previous_deploy_image` - backend Jenkins resolves the image behind the registry `latest-prod`/`prod` pointer before the new deploy
+- When the registry pointer is missing or no canonical digest match exists, backend deployment must stop or require explicit bootstrap approval.
 - `metadata.pull_request_number`
 - `metadata.pull_request_labels`
 

--- a/ops/release-record-shared-contract.md
+++ b/ops/release-record-shared-contract.md
@@ -2,6 +2,8 @@
 
 This is the shared production release-record contract between `study-platform-mvp` backend and `study-platform-client` frontend.
 
+Direct pushes to `main` without a PR and its `release:major|minor|patch` label are not valid production release inputs.
+
 It fixes two schemas:
 
 1. the backend-to-frontend release payload schema, and

--- a/ops/release-record-shared-contract.md
+++ b/ops/release-record-shared-contract.md
@@ -132,6 +132,7 @@ The frontend script also accepts the inner `client_payload` object directly when
 
 - `summary`
 - `metadata.previous_deploy_image` - backend Jenkins resolves the image behind the registry `latest-prod`/`prod` pointer before the new deploy
+- The release record is still the audit trail; the registry pointer only helps backend Jenkins recover the previous immutable backend image before dispatch.
 - `metadata.pull_request_number`
 - `metadata.pull_request_labels`
 

--- a/ops/version-management.md
+++ b/ops/version-management.md
@@ -4,6 +4,8 @@ This document is the frontend repository source of truth for ZERO-ONE production
 
 This document follows the shared FE/BE contract in `ops/release-record-shared-contract.md`.
 
+- Do not direct-push commits to `main` or bypass the PR path. Production deploy/release recording depends on the PR and its `release:major|minor|patch` label.
+
 ## Responsibility
 
 - `study-platform-client` owns the final production release record because it is the user-facing application and the running product depends on a compatible frontend/backend/database combination.


### PR DESCRIPTION
## 작업 내용
- backend dispatch shared contract에 registry pointer 실패 조건을 추가합니다.
- `metadata.previous_deploy_image`가 registry pointer 해석 결과이며, release record는 audit trail이라는 역할 분리를 더 명확히 적습니다.

## 변경 이유
- 이전 턴에서 관련 문서 변경이 main에 직접 반영된 잘못이 있었습니다.
- frontend repository도 PR 경로에서 같은 release contract를 검토할 수 있도록 후속 PR을 만듭니다.

## dev/QA 검증 evidence
- [x] `git diff --check`
- [ ] frontend workflow runtime 동작 변경은 없어서 별도 build/typecheck는 수행하지 않았습니다.

## production 영향
- runtime behavior 변경은 없습니다.
- backend dispatch / release record 운영 문서 해석이 더 명확해집니다.

## release contract 영향
- `metadata.previous_deploy_image`는 backend Jenkins가 registry `latest-prod`/`prod` 포인터를 해석해 채운다는 점을 유지합니다.
- pointer 부재나 canonical digest 불일치 시 bootstrap 승인 또는 중단이 필요하다는 점을 명시합니다.

## 검증 방법
- [x] `git diff --check`

## 브랜치 정보
- base: main
- head: followup/release-registry-pr-path
- 기준 range: origin/main..HEAD

## 롤백 계획
- PR 미머지 상태에서는 영향 없음
- 머지 후 문제 시 docs-only revert로 원복 가능합니다.

## known risk / not-tested
- runtime behavior change는 없지만, 이전 direct push commit은 main history에 이미 남아 있습니다. 이번 PR은 같은 계약을 PR 경로에서 다시 검토하기 위한 follow-up입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* 백엔드 배포 시 레지스트리 포인터 부재 또는 캐노니컬 다이제스트 불일치 시 배포 중단 조건이 명시되었습니다.
* 배포 이미지 메타데이터의 목적과 감사 추적 출처에 대한 설명이 보완되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->