### PR TITLE
모바일 반응형 및 UI 버그 수정

### DIFF
--- a/src/app/(service)/(my)/my-page/page.tsx
+++ b/src/app/(service)/(my)/my-page/page.tsx
@@ -23,7 +23,7 @@ function ProfileRow({
 }) {
   return (
     <div className="flex flex-col gap-100 sm:flex-row sm:gap-400">
-      <span className="font-designer-16b text-gray-800 sm:w-2125 sm:shrink-0 sm:pt-150">
+      <span className="font-designer-16r text-text-default sm:w-2500 sm:shrink-0 sm:pt-150">
         {label}
       </span>
       <div className="flex-1">{children}</div>
@@ -293,48 +293,70 @@ export default function MyPage() {
       <section className="flex flex-col gap-500">
         <h2 className="font-designer-18b text-text-default">기본 정보</h2>
 
-        <ProfileRow label="인증완료">
-          <span className="font-designer-14r text-text-default pt-150 block">
-            {profile?.isVerified ? '본인 인증 완료' : '미인증'}
-          </span>
-        </ProfileRow>
-
-        {/* TODO: email — not present in memberProfile API response */}
-        <ProfileRow label="이메일">
-          <div className="flex items-center gap-200">
-            <input
-              type="text"
-              disabled
-              placeholder="이메일 정보를 불러올 수 없습니다."
-              className="border-border-default rounded-100 font-designer-14r text-text-subtlest placeholder:text-text-subtlest flex-1 border bg-gray-50 px-200 py-150 outline-none"
-            />
-            <span className="font-designer-12r text-text-subtlest shrink-0">
-              변경 불가
+        <div className="flex flex-col gap-375">
+          <ProfileRow label="인증완료">
+            <span className="font-designer-16b text-text-default">
+              {profile?.isVerified ? '본인 인증 완료' : '미인증'}
             </span>
-          </div>
-        </ProfileRow>
+          </ProfileRow>
 
-        <ProfileRow label="휴대폰 번호">
-          <div className="flex gap-200">
-            <select className="border-border-default rounded-100 font-designer-14r text-text-default shrink-0 border px-200 py-150 outline-none">
-              <option value="82">+82</option>
-            </select>
-            <input
-              type="tel"
-              disabled
-              value={profile?.memberProfile.tel ?? ''}
-              placeholder="휴대폰 번호를 입력하세요."
-              className="border-border-default rounded-100 font-designer-14r text-text-default placeholder:text-text-subtlest min-w-0 flex-1 border bg-gray-50 px-200 py-150 outline-none"
-            />
-            <button
-              type="button"
-              disabled
-              className="rounded-100 shrink-0 whitespace-nowrap border border-gray-300 px-300 py-150 font-designer-14m text-gray-400"
-            >
-              인증하기
-            </button>
-          </div>
-        </ProfileRow>
+          {/* TODO: email — not present in memberProfile API response */}
+          <ProfileRow label="이메일">
+            <div className="flex items-center gap-125">
+              <span className="font-designer-16b text-text-default">
+                이메일 정보를 불러올 수 없습니다.
+              </span>
+              <span className="font-designer-14r text-text-subtlest shrink-0">
+                변경 불가
+              </span>
+            </div>
+          </ProfileRow>
+
+          <ProfileRow label="휴대폰 번호">
+            <div className="flex flex-col gap-125">
+              <div className="flex items-center justify-between rounded-100 border border-border-default px-125 py-125">
+                <span className="font-designer-14m text-text-subtle">
+                  대한민국 +82
+                </span>
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                  className="shrink-0 text-text-subtle"
+                >
+                  <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z" />
+                </svg>
+              </div>
+              <div className="flex gap-125">
+                <input
+                  type="tel"
+                  disabled
+                  value={profile?.memberProfile.tel ?? ''}
+                  placeholder="휴대폰 번호를 입력해주세요."
+                  className="min-w-0 flex-1 rounded-100 border border-border-default bg-gray-50 px-125 py-125 font-designer-14r text-text-default placeholder:text-text-subtlest outline-none"
+                />
+                <button
+                  type="button"
+                  disabled
+                  className="shrink-0 rounded-100 bg-gray-200 px-125 py-125 font-designer-14r text-gray-500"
+                >
+                  인증하기
+                </button>
+              </div>
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  disabled
+                  className="rounded-100 px-125 py-125 font-designer-14r text-text-default"
+                >
+                  취소하기
+                </button>
+              </div>
+            </div>
+          </ProfileRow>
+        </div>
       </section>
 
       <hr className="border-border-subtle" />

--- a/src/app/(service)/(my)/my-page/page.tsx
+++ b/src/app/(service)/(my)/my-page/page.tsx
@@ -141,33 +141,35 @@ export default function MyPage() {
                 }}
                 maxLength={10}
                 placeholder="닉네임을 입력하세요 (2~10자)"
-                className="border-border-default rounded-100 font-designer-14r text-text-default placeholder:text-text-subtlest flex-1 border px-200 py-150 outline-none"
+                className="border-border-default rounded-100 font-designer-14r text-text-default placeholder:text-text-subtlest min-w-0 flex-1 border px-200 py-150 outline-none"
               />
-              <button
-                type="button"
-                disabled={
-                  isSameNickname ||
-                  nickname.length < 2 ||
-                  nickname.length > 10 ||
-                  checkingNickname
-                }
-                onClick={() => setNicknameToCheck(nickname)}
-                className="rounded-100 border border-border-brand px-300 py-150 font-designer-14m text-text-brand disabled:border-gray-300 disabled:text-gray-400"
-              >
-                {checkingNickname ? '확인 중...' : '중복 확인'}
-              </button>
-              <button
-                type="button"
-                disabled={
-                  isPending ||
-                  isSameNickname ||
-                  !(nicknameAvailable && nicknameToCheck === nickname)
-                }
-                onClick={handleSaveNickname}
-                className="rounded-100 border border-border-brand px-300 py-150 font-designer-14m text-text-brand disabled:border-gray-300 disabled:text-gray-400"
-              >
-                저장
-              </button>
+              <div className="flex gap-200">
+                <button
+                  type="button"
+                  disabled={
+                    isSameNickname ||
+                    nickname.length < 2 ||
+                    nickname.length > 10 ||
+                    checkingNickname
+                  }
+                  onClick={() => setNicknameToCheck(nickname)}
+                  className="rounded-100 border border-border-brand px-300 py-150 font-designer-14m text-text-brand disabled:border-gray-300 disabled:text-gray-400"
+                >
+                  {checkingNickname ? '확인 중...' : '중복 확인'}
+                </button>
+                <button
+                  type="button"
+                  disabled={
+                    isPending ||
+                    isSameNickname ||
+                    !(nicknameAvailable && nicknameToCheck === nickname)
+                  }
+                  onClick={handleSaveNickname}
+                  className="rounded-100 border border-border-brand px-300 py-150 font-designer-14m text-text-brand disabled:border-gray-300 disabled:text-gray-400"
+                >
+                  저장
+                </button>
+              </div>
             </div>
             {!isSameNickname &&
               nicknameAvailable &&
@@ -314,7 +316,7 @@ export default function MyPage() {
 
         <ProfileRow label="휴대폰 번호">
           <div className="flex gap-200">
-            <select className="border-border-default rounded-100 font-designer-14r text-text-default border px-200 py-150 outline-none">
+            <select className="border-border-default rounded-100 font-designer-14r text-text-default shrink-0 border px-200 py-150 outline-none">
               <option value="82">+82</option>
             </select>
             <input
@@ -322,12 +324,12 @@ export default function MyPage() {
               disabled
               value={profile?.memberProfile.tel ?? ''}
               placeholder="휴대폰 번호를 입력하세요."
-              className="border-border-default rounded-100 font-designer-14r text-text-default placeholder:text-text-subtlest flex-1 border bg-gray-50 px-200 py-150 outline-none"
+              className="border-border-default rounded-100 font-designer-14r text-text-default placeholder:text-text-subtlest min-w-0 flex-1 border bg-gray-50 px-200 py-150 outline-none"
             />
             <button
               type="button"
               disabled
-              className="rounded-100 border border-gray-300 px-300 py-150 font-designer-14m text-gray-400"
+              className="rounded-100 shrink-0 whitespace-nowrap border border-gray-300 px-300 py-150 font-designer-14m text-gray-400"
             >
               인증하기
             </button>
@@ -338,7 +340,7 @@ export default function MyPage() {
       <hr className="border-border-subtle" />
 
       {/* Section C: 배너 */}
-      <section className="flex gap-250">
+      <section className="flex flex-col gap-250 sm:flex-row">
         <a
           href="https://discord.gg/z66gzHnKp"
           target="_blank"

--- a/src/app/(service)/(my)/my-page/page.tsx
+++ b/src/app/(service)/(my)/my-page/page.tsx
@@ -367,7 +367,7 @@ export default function MyPage() {
           href="https://discord.gg/z66gzHnKp"
           target="_blank"
           rel="noopener noreferrer"
-          className="border-border-subtle rounded-200 flex flex-1 items-center justify-center gap-175 overflow-hidden border bg-gray-50 py-250 transition-colors hover:bg-gray-100"
+          className="border-[#D5D7DA] rounded-200 flex flex-1 items-center justify-center gap-175 overflow-hidden border bg-gray-50 py-250 transition-colors hover:bg-gray-100"
         >
           <div className="relative h-675 w-675 shrink-0 overflow-hidden rounded-150">
             <Image

--- a/src/components/common/layout/sidebar/my-page-mobile-nav.tsx
+++ b/src/components/common/layout/sidebar/my-page-mobile-nav.tsx
@@ -3,19 +3,26 @@
 import { usePathname, useRouter } from 'next/navigation';
 
 import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
+import { useToastStore } from '@/stores/use-toast-store';
 
 const NAV_ITEMS = [
   { href: '/my-page', label: '프로필' },
   { href: '/my-class', label: '마이 클래스' },
   { href: '/my-posts', label: '내가 작성한 글', prefixMatch: true },
   { href: 'http://pf.kakao.com/_VmCYn', label: '1:1 문의' },
-  { href: '/builder-letter', label: '빌더 레터', prefixMatch: true },
+  {
+    href: '/builder-ticket',
+    label: '빌더 티켓',
+    prefixMatch: true,
+    comingSoon: true,
+  },
   { href: '/class-payment-management', label: '결제 관리' },
 ];
 
 export default function MyPageMobileNav() {
   const pathname = usePathname();
   const router = useRouter();
+  const showToast = useToastStore((state) => state.showToast);
 
   return (
     <nav className="flex overflow-x-auto border-b border-border-subtle lg:hidden [&::-webkit-scrollbar]:hidden">
@@ -23,6 +30,10 @@ export default function MyPageMobileNav() {
         <button
           key={item.href}
           onClick={() => {
+            if (item.comingSoon) {
+              showToast('준비중인 기능입니다.', 'info');
+              return;
+            }
             if (item.href.startsWith('http')) {
               window.open(item.href, '_blank', 'noopener,noreferrer');
               return;


### PR DESCRIPTION
## Problem

- 모바일/태블릿 뷰포트에서 공통 레이아웃(헤더, 푸터, 사이드바), 클래스 페이지, 마이페이지의 UI가 Figma 디자인과 불일치하거나 레이아웃이 깨지는 문제 존재
- 마이페이지 > 기본 정보 섹션의 레이아웃이 Figma 디자인(node 2090:12203)과 다름 — 레이블 폰트, 이메일 표시 방식, 휴대폰 번호 UI 구조 불일치
- 모바일 nav에서 빌더 티켓 클릭 시 피드백 없이 반응 없음
- spacing 토큰 중 16 배수 값이 rem/px 혼재

## Solution

- 공통 레이아웃 반응형 클래스 및 breakpoint 정리
- 클래스 페이지(탭 내비, 로드맵, QnA, 피드) 모바일 반응형 수정
- 마이페이지 기본 정보 섹션을 Figma 스펙에 맞게 재구성
  - ProfileRow 레이블: Bold → Regular, 컬럼 170px → 200px
  - 인증완료 값: 14px Regular → 16px Bold
  - 이메일: disabled input → 인라인 텍스트 + "변경 불가"
  - 휴대폰 번호: 1행(select+input+button) → 3행 구조 (국가 드롭다운 / 입력+인증하기 / 취소하기)
  - 행 간격: 40px → 30px
- 빌더 티켓 버튼에 "준비 중" 토스트 추가
- 16 배수 spacing 토큰 rem으로 통일

## Changes

### Bug Fixes
| File | Description |
|------|-------------|
| `src/app/(service)/(my)/my-page/page.tsx` | 기본 정보 섹션 Figma 정합, 디스코드 배너 border 수정 |
| `src/app/global.css` | spacing 토큰 rem 통일 |
| `src/app/(landing)/class/[slug]/*` | 클래스 페이지 모바일 반응형 수정 |
| `src/components/common/layout/*` | 공통 레이아웃 모바일 반응형 개선 |
| `src/components/common/layout/sidebar/my-page-mobile-nav.tsx` | 빌더 티켓 "준비 중" 토스트 추가 |

## Result

- 모바일(390px) · 태블릿(768px) · 데스크톱(1280px) 3개 뷰포트에서 레이아웃 정상 렌더링
- 마이페이지 기본 정보 섹션이 Figma 디자인과 일치
- 빌더 티켓 클릭 시 준비 중 안내 토스트 노출

## Screenshots

스크린샷: `public/pr-screenshots/706/` 참조

## Test plan

- [ ] 모바일(390px) 뷰포트에서 클래스 목록/상세/QnA/피드 레이아웃 확인
- [ ] 태블릿(768px) 뷰포트에서 동일 페이지 레이아웃 확인
- [ ] 마이페이지 > 기본 정보: 레이블 Regular, 인증완료 Bold, 이메일 텍스트 표시 확인
- [ ] 마이페이지 > 기본 정보: 휴대폰 번호 3행 구조 확인
- [ ] 모바일 nav 빌더 티켓 클릭 시 "준비 중" 토스트 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)