### PR TITLE
ci(github-actions): @claude Notion MCP 연동 + 코드리뷰 인라인 코멘트 게시

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # --comment: 리뷰 findings를 PR 인라인 코멘트로 게시. 미지정 시 automation 모드에서 결과가 모델 출력에만 남아 PR엔 안 보임(= success인데 리뷰 없음).
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
 
       # 자동 리뷰 완료 시 프론트엔드 Slack 채널에 알림. 기존 PR open 알림과는 별도 메시지로 구분.
       - name: Notify Slack on review complete

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,9 +30,32 @@ jobs:
         with:
           fetch-depth: 1
 
+      # claude-code-action은 working dir의 .mcp.json을 enableAllProjectMcpServers로 자동 로드한다.
+      # repo에 .mcp.json을 두지 않고(로컬 환경 침범 방지) 워크플로우 실행 중에만 생성하여 Notion MCP를 등록.
+      # claude_args의 --mcp-config는 v1에서 무시되는 정황이 확인되어 자동 로드 경로를 사용.
+      - name: Generate .mcp.json for Notion MCP
+        run: |
+          cat > .mcp.json <<'JSON'
+          {
+            "mcpServers": {
+              "notion": {
+                "command": "npx",
+                "args": ["-y", "@notionhq/notion-mcp-server"]
+              }
+            }
+          }
+          JSON
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          # Notion MCP 서버(@notionhq/notion-mcp-server)가 OpenAPI 호출 시 사용할 인증 헤더.
+          # npx 자식 프로세스가 step env를 자동 상속하므로 MCP config 파일에는 별도로 명시하지 않음.
+          # 토큰은 "스터디 플랫폼 : 코드 제로투원" 페이지에 connection된 integration의 권한 범위 내에서만 동작.
+          OPENAPI_MCP_HEADERS: '{"Authorization":"Bearer ${{ secrets.NOTION_TOKEN }}","Notion-Version":"2022-06-28"}'
+          # @notionhq/notion-mcp-server가 NOTION_TOKEN을 직접 읽는 케이스 fallback.
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -40,8 +63,8 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # 프론트엔드 작업에 필요한 패키지 매니저 명령어 허용
-          claude_args: '--allowed-tools "Bash(npm *),Bash(yarn *),Bash(pnpm *),Bash(npx *)"'
+          # 자동 로드된 mcp__notion__*가 LLM에 노출되도록 + 프론트엔드 패키지 매니저 명령어 허용
+          claude_args: '--allowedTools "mcp__notion__*,Bash(npm *),Bash(yarn *),Bash(pnpm *),Bash(npx *),Edit,Write,Read,Glob,Grep,LS"'
 
       # Claude 응답 완료 시 프론트엔드 Slack 채널에 알림. 성공/실패 모두 통지하여 쿼터 소진 등 에러 상황도 추적 가능하게 함.
       - name: Notify Slack on Claude response


### PR DESCRIPTION
## 배경
- `@claude` 멘션 시 client 레포에서만 Notion MCP 조회가 안 됨 → 원인: client `claude.yml`이 애초에 MCP 미설정 (backend에만 설정돼 있었음).
- 코드리뷰 워크플로우가 Slack엔 "리뷰 완료(success)"라 알리는데 PR엔 리뷰가 안 보임 → 원인: automation(prompt) 모드에서 `/code-review`가 `--comment` 없이 실행돼 결과가 모델 출력에만 남고 PR엔 게시 안 됨.

## 변경
- **claude.yml**: backend 검증 설정 미러링
  - 런타임 `.mcp.json` 생성 step 추가 (Notion MCP 서버 자동 로드)
  - `Run Claude Code` step에 `OPENAPI_MCP_HEADERS` / `NOTION_TOKEN` env 추가
  - `claude_args` allowedTools에 `mcp__notion__*` 추가 (프론트 패키지매니저 권한은 보존)
- **claude-code-review.yml**: `/code-review` prompt에 `--comment` 추가 → findings가 PR 인라인 코멘트로 게시됨

## 사전 조건
- [x] `NOTION_TOKEN` 시크릿 client 레포에 등록 완료
- [ ] Notion integration이 조회 대상 페이지에 connection 연결돼 있어야 함

## 적용 시점
- `@claude` 멘션(issue_comment 트리거)은 **기본 브랜치(develop) 머지 후** 동작.

관련: 백엔드(mvp) PR #1133 (코드리뷰 --comment 동일 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * Notion 통합 추가로 확장된 기능 지원
  
* **개선사항**
  * PR 코드 리뷰 의견이 인라인 코멘트로 직접 게시되도록 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/code-zero-to-one/study-platform-client/pull/713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->