### PR TITLE
fix(editor): 기존 파이프-텍스트 표를 에디터 로드 시 실제 표로 변환

### DIFF
--- a/src/components/common/ui/editor/markdown-editor.tsx
+++ b/src/components/common/ui/editor/markdown-editor.tsx
@@ -34,6 +34,7 @@ import { cn } from '@/components/common/ui/(shadcn)/lib/utils';
 import Button from '@/components/common/ui/button';
 import { extractImageUrls } from '@/utils/markdown-content-images';
 import { normalizeMarkdownContent } from '@/utils/markdown-content-normalize';
+import { isHtmlContent } from '@/utils/markdown-content-shared';
 import { getRichContentVisibleTextLength } from '@/utils/markdown-content-text';
 import {
   hasRenderableMarkdownSyntax,
@@ -66,6 +67,7 @@ import {
 import {
   convertTabularTextToHtmlTable,
   isHtmlTableOnlyPaste,
+  renderMarkdownTablesInHtml,
 } from './markdown-table-utils';
 import { normalizeRichClipboardHtml } from './rich-clipboard-normalizer';
 import { CODE_LANGUAGES, HEADING_OPTIONS, ToolbarButton } from './toolbar';
@@ -122,6 +124,15 @@ function MarkdownEditor({
   >(undefined);
   const isInternalUpdate = useRef(false);
   const normalizedValue = normalizeContent(value);
+  // 기존 콘텐츠가 파이프-텍스트 표(`<p>| a | b |</p>` 등)로 저장돼 있으면 에디터 로드 시
+  // 실제 표(WYSIWYG)로 변환한다. 표가 없는 콘텐츠는 그대로 둔다(동작 불변).
+  const editorReadyValue = useMemo(
+    () =>
+      isHtmlContent(normalizedValue) && normalizedValue.includes('|')
+        ? renderMarkdownTablesInHtml(normalizedValue)
+        : normalizedValue,
+    [normalizedValue],
+  );
   const currentVisibleTextLength = useMemo(() => {
     return getRichContentVisibleTextLength(normalizedValue);
   }, [normalizedValue]);
@@ -328,7 +339,7 @@ function MarkdownEditor({
         placeholder: placeholder ?? '내용을 자유롭게 작성해주세요.',
       }),
     ],
-    content: normalizedValue || '',
+    content: editorReadyValue || '',
     onUpdate: ({ editor: updatedEditor }) => {
       isInternalUpdate.current = true;
       onChange?.(normalizeContent(updatedEditor.getHTML()));
@@ -529,9 +540,9 @@ function MarkdownEditor({
 
     const currentHtml = normalizeContent(editor.getHTML());
     if (currentHtml !== normalizedValue) {
-      editor.commands.setContent(normalizedValue || '', { emitUpdate: false });
+      editor.commands.setContent(editorReadyValue || '', { emitUpdate: false });
     }
-  }, [editor, normalizeContent, normalizedValue]);
+  }, [editor, editorReadyValue, normalizeContent, normalizedValue]);
 
   const handleToggleLink = () => {
     if (!editor) {


### PR DESCRIPTION
release: patch

## 배경
#727로 admin 에디터에 WYSIWYG 표(TipTap Table)를 도입했지만, **#727 이전에 파이프 텍스트로 저장된 기존 콘텐츠**는 에디터에서 열면 `| 항목 | 설명 | / | --- | --- |` 글자 그대로 보였습니다 (TipTap이 기존 텍스트를 자동으로 표로 바꾸지 않음). 미리보기·상세에서는 이미 실제 표로 렌더되지만 에디터만 어긋났습니다.

## 변경
`markdown-editor.tsx`에서 콘텐츠를 에디터에 로드할 때, HTML이고 `|`를 포함하면 기존 `renderMarkdownTablesInHtml`로 파이프-텍스트 표를 실제 `<table>`로 변환한 뒤 TipTap에 주입합니다.
- 초기 `content` + 외부 값 동기화(setContent) 모두 변환된 값 사용
- **표가 없는 콘텐츠는 변환 스킵(`|` 미포함/비HTML)** → 기존 동작 불변
- 변환은 멱등: 실제 표로 바뀐 뒤엔 파이프가 없어 재변환되지 않음(루프 없음)

## 효과
- 기존 레슨을 admin 에디터에서 열면 **바로 편집 가능한 실제 표**로 보임
- 새 표(툴바 "표" 버튼)·붙여넣기 표는 #727에서 이미 WYSIWYG

## 검증
- ✅ typecheck · lint(0 err) · prettier · unit 19/19 · webpack 컴파일
- ⚠️ 로컬 build는 `/sitemap.xml` 백엔드 500(환경)로만 중단 — 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 마크다운 에디터에서 기존 테이블 콘텐츠를 로드할 때 올바르게 렌더링되도록 개선했습니다.
* 에디터 동기화 시 테이블 형식이 일관되게 유지되도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->