### PR TITLE
feat(editor): 이모티콘 shortcode 피커 + 에디터에서 이미지로 표시

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -1300,6 +1300,41 @@ https://velog.io/@oneook/tailwindcss-4.0-%EB%AC%B4%EC%97%87%EC%9D%B4-%EB%8B%AC%E
   margin-bottom: var(--spacing-150);
 }
 
+/* 이모티콘은 본문 인라인 이미지로 표시(리사이즈 이미지와 별개) */
+.tiptap-editor .tiptap img.emoticon-inline,
+.tiptap-editor .tiptap img.emoticon-lg,
+.tiptap-editor .tiptap img.emoticon-xl,
+.tiptap-editor .tiptap img.emoticon-xxl {
+  display: inline-block;
+  width: auto;
+  max-width: none;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  vertical-align: middle;
+  object-fit: contain;
+}
+
+.tiptap-editor .tiptap img.emoticon-inline {
+  height: 24px;
+  max-height: 24px;
+}
+
+.tiptap-editor .tiptap img.emoticon-lg {
+  height: 48px;
+  max-height: 48px;
+}
+
+.tiptap-editor .tiptap img.emoticon-xl {
+  height: 96px;
+  max-height: 96px;
+}
+
+.tiptap-editor .tiptap img.emoticon-xxl {
+  height: 150px;
+  max-height: 150px;
+}
+
 .tiptap-editor .tiptap .tiptap-resizable-image {
   position: relative;
   display: inline-block;

--- a/src/components/common/ui/editor/emoticon-shortcode.test.ts
+++ b/src/components/common/ui/editor/emoticon-shortcode.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildEmoticonToken,
+  emoticonNameFromSrc,
+  emoticonSizeClass,
+  emoticonSizeFromClass,
+  replaceEmoticonShortcodes,
+} from './emoticon-shortcode';
+
+describe('replaceEmoticonShortcodes', () => {
+  it('카탈로그에 있는 :name: 을 emoticon img로 치환한다', () => {
+    expect(replaceEmoticonShortcodes(':okay:')).toBe(
+      '<img src="/emoticon/okay.png" alt=":okay:" class="emoticon-inline" />',
+    );
+  });
+
+  it('크기 suffix(_lg/_xl/_xxl)를 해당 class로 변환한다', () => {
+    expect(replaceEmoticonShortcodes(':okay_lg:')).toContain(
+      'class="emoticon-lg"',
+    );
+    expect(replaceEmoticonShortcodes(':happy_xxl:')).toContain(
+      'class="emoticon-xxl"',
+    );
+  });
+
+  it('카탈로그에 없는 토큰은 원문 그대로 둔다', () => {
+    expect(replaceEmoticonShortcodes(':nope:')).toBe(':nope:');
+    expect(replaceEmoticonShortcodes('비율 50:50 입니다')).toBe(
+      '비율 50:50 입니다',
+    );
+  });
+
+  it('대소문자 무관하게 매칭한다', () => {
+    expect(replaceEmoticonShortcodes(':OKAY:')).toContain('/emoticon/okay.png');
+  });
+});
+
+describe('emoticon size helpers', () => {
+  it('size 토큰 ↔ class 를 왕복 변환한다', () => {
+    expect(emoticonSizeClass('')).toBe('emoticon-inline');
+    expect(emoticonSizeClass('lg')).toBe('emoticon-lg');
+    expect(emoticonSizeFromClass('emoticon-inline')).toBe('');
+    expect(emoticonSizeFromClass('emoticon-xl')).toBe('xl');
+    expect(emoticonSizeFromClass('foo emoticon-lg bar')).toBe('lg');
+  });
+
+  it('알 수 없는 class 는 기본 size("")로 처리한다', () => {
+    expect(emoticonSizeFromClass('not-emoticon')).toBe('');
+  });
+});
+
+describe('emoticonNameFromSrc', () => {
+  it('src 경로에서 카탈로그 name을 역추출한다(대소문자/경로 무관)', () => {
+    expect(emoticonNameFromSrc('/emoticon/okay.png')).toBe('okay');
+    expect(emoticonNameFromSrc('/emoticon/Question.png')).toBe('question');
+    expect(emoticonNameFromSrc('https://x.test/emoticon/Euang.png')).toBe(
+      'euang',
+    );
+  });
+
+  it('카탈로그에 없는 파일은 빈 문자열을 반환한다', () => {
+    expect(emoticonNameFromSrc('/emoticon/unknown.png')).toBe('');
+  });
+});
+
+describe('buildEmoticonToken', () => {
+  it('size 가 없으면 name, 있으면 name_size 토큰을 만든다', () => {
+    expect(buildEmoticonToken('okay', '')).toBe('okay');
+    expect(buildEmoticonToken('okay', 'lg')).toBe('okay_lg');
+  });
+});

--- a/src/components/common/ui/editor/emoticon-shortcode.ts
+++ b/src/components/common/ui/editor/emoticon-shortcode.ts
@@ -33,17 +33,34 @@ export const EMOTICON_CATALOG: Record<string, string> = {
  * - _xl: 96px
  * - _xxl: 150px, 강조 단독 배치용
  */
-const EMOTICON_SIZE_CLASS: Record<string, string> = {
+export const EMOTICON_SIZE_CLASS: Record<string, string> = {
   '': 'emoticon-inline',
   lg: 'emoticon-lg',
   xl: 'emoticon-xl',
   xxl: 'emoticon-xxl',
 };
 
+const EMOTICON_CLASS_TO_SIZE: Record<string, string> = Object.fromEntries(
+  Object.entries(EMOTICON_SIZE_CLASS).map(([size, className]) => [
+    className,
+    size,
+  ]),
+);
+
+const EMOTICON_FILE_TO_NAME: Record<string, string> = Object.fromEntries(
+  Object.entries(EMOTICON_CATALOG).map(([name, file]) => [
+    file.toLowerCase(),
+    name,
+  ]),
+);
+
 const EMOTICON_SHORTCODE_REGEX = /:([a-zA-Z][a-zA-Z0-9_-]*):/g;
 const SIZE_SUFFIX_REGEX = /^(.+?)_(lg|xl|xxl)$/;
+const EMOTICON_TOKEN_ALT_REGEX = /^:([a-zA-Z][a-zA-Z0-9_-]*):$/;
 
-const parseEmoticonToken = (token: string): { name: string; size: string } => {
+export const parseEmoticonToken = (
+  token: string,
+): { name: string; size: string } => {
   const match = token.match(SIZE_SUFFIX_REGEX);
   if (match) {
     return { name: match[1], size: match[2] };
@@ -70,4 +87,66 @@ export const replaceEmoticonShortcodes = (input: string): string => {
     const className = EMOTICON_SIZE_CLASS[size] ?? EMOTICON_SIZE_CLASS[''];
     return `<img src="/emoticon/${fileName}" alt=":${token}:" class="${className}" />`;
   });
+};
+
+/** size 토큰('' | lg | xl | xxl)을 emoticon CSS class로 변환한다. */
+export const emoticonSizeClass = (size: string): string =>
+  EMOTICON_SIZE_CLASS[size] ?? EMOTICON_SIZE_CLASS[''];
+
+/** emoticon class 문자열에서 size 토큰을 역추출한다. */
+export const emoticonSizeFromClass = (className: string): string => {
+  const sizeClass =
+    className.split(/\s+/).find((token) => token.startsWith('emoticon-')) ??
+    'emoticon-inline';
+  return EMOTICON_CLASS_TO_SIZE[sizeClass] ?? '';
+};
+
+/** `/emoticon/okay.png` 같은 src에서 카탈로그 name을 역추출한다(없으면 ''). */
+export const emoticonNameFromSrc = (src: string): string => {
+  const file = (src.split('/').pop() ?? '').toLowerCase();
+  return EMOTICON_FILE_TO_NAME[file] ?? '';
+};
+
+/** name + size를 본문 shortcode 토큰(`okay`, `okay_lg`)으로 만든다. */
+export const buildEmoticonToken = (name: string, size: string): string =>
+  size ? `${name}_${size}` : name;
+
+/**
+ * 에디터가 렌더한 emoticon `<img>`를 다시 `:name:` shortcode 텍스트로 직렬화한다.
+ * (에디터에선 이미지로 보여주되 저장 본문은 shortcode로 유지하기 위함)
+ * emoticon 외 이미지는 건드리지 않는다.
+ */
+export const serializeEmoticonImagesToShortcodes = (html: string): string => {
+  if (!html || !html.includes('emoticon-') || typeof window === 'undefined') {
+    return html;
+  }
+
+  const document = new window.DOMParser().parseFromString(html, 'text/html');
+  let changed = false;
+
+  document.querySelectorAll('img[class*="emoticon-"]').forEach((image) => {
+    const alt = image.getAttribute('alt') ?? '';
+    const altMatch = alt.match(EMOTICON_TOKEN_ALT_REGEX);
+    let token = altMatch?.[1];
+
+    if (!token) {
+      const name = emoticonNameFromSrc(image.getAttribute('src') ?? '');
+      if (name) {
+        token = buildEmoticonToken(
+          name,
+          emoticonSizeFromClass(image.getAttribute('class') ?? ''),
+        );
+      }
+    }
+
+    if (
+      token &&
+      EMOTICON_CATALOG[parseEmoticonToken(token).name.toLowerCase()]
+    ) {
+      image.replaceWith(document.createTextNode(`:${token}:`));
+      changed = true;
+    }
+  });
+
+  return changed ? document.body.innerHTML : html;
 };

--- a/src/components/common/ui/editor/extensions.ts
+++ b/src/components/common/ui/editor/extensions.ts
@@ -27,6 +27,13 @@ import sql from 'highlight.js/lib/languages/sql';
 import swift from 'highlight.js/lib/languages/swift';
 import { common, createLowlight } from 'lowlight';
 import {
+  buildEmoticonToken,
+  EMOTICON_CATALOG,
+  emoticonNameFromSrc,
+  emoticonSizeClass,
+  emoticonSizeFromClass,
+} from './emoticon-shortcode';
+import {
   clampImageWidth,
   parseImageWidth,
   MARKDOWN_IMAGE_DEFAULT_WIDTH,
@@ -354,5 +361,82 @@ export const YouTubeEmbedExtension = Node.create({
     }
 
     return ['iframe', mergeAttributes(attrs)];
+  },
+});
+
+/**
+ * 사이트 공용 이모티콘을 에디터에서 실제 이미지로 보여주는 인라인 atom 노드입니다.
+ * - 본문 저장은 `:name:` shortcode로 유지(에디터 ↔ 저장 변환은 markdown-editor에서 처리)
+ * - 일반 이미지(ResizableImage)보다 우선 파싱되도록 priority를 높여, emoticon class img를
+ *   리사이즈 이미지가 아니라 이모티콘 노드로 인식한다.
+ */
+export const EmoticonExtension = Node.create({
+  name: 'emoticon',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  selectable: true,
+  draggable: false,
+  priority: 200,
+
+  addAttributes() {
+    return {
+      name: { default: '' },
+      size: { default: '' },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'img[class*="emoticon-"]',
+        getAttrs: (node) => {
+          const element = node instanceof HTMLElement ? node : null;
+          if (!element) {
+            return false;
+          }
+
+          const alt = element.getAttribute('alt') ?? '';
+          const altMatch = alt.match(/^:([a-zA-Z][a-zA-Z0-9_-]*):$/);
+          const className = element.getAttribute('class') ?? '';
+          const size = emoticonSizeFromClass(className);
+
+          let name = '';
+          if (altMatch?.[1]) {
+            const sizeSuffix = altMatch[1].match(/^(.+?)_(?:lg|xl|xxl)$/);
+            name = (sizeSuffix?.[1] ?? altMatch[1]).toLowerCase();
+          } else {
+            name = emoticonNameFromSrc(element.getAttribute('src') ?? '');
+          }
+
+          if (!name || !EMOTICON_CATALOG[name]) {
+            return false;
+          }
+
+          return { name, size };
+        },
+      },
+    ];
+  },
+
+  renderHTML({ node }) {
+    const name = String(node.attrs.name ?? '').toLowerCase();
+    const size = String(node.attrs.size ?? '');
+    const fileName = EMOTICON_CATALOG[name];
+
+    if (!fileName) {
+      return ['span'];
+    }
+
+    return [
+      'img',
+      mergeAttributes({
+        src: `/emoticon/${fileName}`,
+        alt: `:${buildEmoticonToken(name, size)}:`,
+        class: emoticonSizeClass(size),
+        draggable: 'false',
+        contenteditable: 'false',
+      }),
+    ];
   },
 });

--- a/src/components/common/ui/editor/markdown-editor.tsx
+++ b/src/components/common/ui/editor/markdown-editor.tsx
@@ -17,11 +17,13 @@ import {
   Loader2,
   Quote,
   Redo2,
+  Smile,
   Table2,
   Strikethrough,
   Underline as UnderlineIcon,
   Undo2,
 } from 'lucide-react';
+import Image from 'next/image';
 import {
   type FormEvent,
   memo,
@@ -47,6 +49,12 @@ import {
 } from './clipboard-utils';
 import EditorVisibleTextCounter from './editor-visible-text-counter';
 import {
+  EMOTICON_CATALOG,
+  replaceEmoticonShortcodes,
+  serializeEmoticonImagesToShortcodes,
+} from './emoticon-shortcode';
+import {
+  EmoticonExtension,
   InstantCodeBlockExtension,
   LinkExitOnSpaceExtension,
   lowlight,
@@ -116,6 +124,7 @@ function MarkdownEditor({
   const [, forceEditorRerender] = useState(0);
   const [isLinkInputOpen, setIsLinkInputOpen] = useState(false);
   const [linkInputValue, setLinkInputValue] = useState('');
+  const [isEmoticonPickerOpen, setIsEmoticonPickerOpen] = useState(false);
   const imageInputRef = useRef<HTMLInputElement>(null);
   const editorContentWrapperRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<Editor | null>(null);
@@ -124,15 +133,17 @@ function MarkdownEditor({
   >(undefined);
   const isInternalUpdate = useRef(false);
   const normalizedValue = normalizeContent(value);
-  // 기존 콘텐츠가 파이프-텍스트 표(`<p>| a | b |</p>` 등)로 저장돼 있으면 에디터 로드 시
-  // 실제 표(WYSIWYG)로 변환한다. 표가 없는 콘텐츠는 그대로 둔다(동작 불변).
-  const editorReadyValue = useMemo(
-    () =>
-      isHtmlContent(normalizedValue) && normalizedValue.includes('|')
-        ? renderMarkdownTablesInHtml(normalizedValue)
-        : normalizedValue,
-    [normalizedValue],
-  );
+  // 저장된 본문을 에디터에 로드하기 좋은 형태로 변환한다.
+  // - `:name:` 이모티콘 shortcode → 실제 emoticon <img>(EmoticonExtension이 이미지 노드로 인식)
+  // - 파이프-텍스트 표(`<p>| a | b |</p>` 등) → 실제 표(WYSIWYG)
+  // 해당 패턴이 없는 콘텐츠는 그대로 둔다(동작 불변).
+  const editorReadyValue = useMemo(() => {
+    const withEmoticons = replaceEmoticonShortcodes(normalizedValue);
+    if (isHtmlContent(withEmoticons) && withEmoticons.includes('|')) {
+      return renderMarkdownTablesInHtml(withEmoticons);
+    }
+    return withEmoticons;
+  }, [normalizedValue]);
   const currentVisibleTextLength = useMemo(() => {
     return getRichContentVisibleTextLength(normalizedValue);
   }, [normalizedValue]);
@@ -181,6 +192,20 @@ function MarkdownEditor({
       .focus()
       .insertTable({ rows: 3, cols: 2, withHeaderRow: true })
       .run();
+  };
+
+  const handleInsertEmoticon = (name: string) => {
+    const editorInstance = getValidEditorInstance();
+    if (!editorInstance) {
+      return;
+    }
+
+    editorInstance
+      .chain()
+      .focus()
+      .insertContent({ type: 'emoticon', attrs: { name, size: '' } })
+      .run();
+    setIsEmoticonPickerOpen(false);
   };
 
   const resolvedImageConfig = useMemo(() => {
@@ -325,6 +350,7 @@ function MarkdownEditor({
       MarkdownHistoryShortcutsExtension,
       LinkExitOnSpaceExtension,
       YouTubeEmbedExtension,
+      EmoticonExtension,
       ...MarkdownTableExtensions,
       UnderlineExtension,
       LinkExtension.configure({
@@ -342,7 +368,12 @@ function MarkdownEditor({
     content: editorReadyValue || '',
     onUpdate: ({ editor: updatedEditor }) => {
       isInternalUpdate.current = true;
-      onChange?.(normalizeContent(updatedEditor.getHTML()));
+      // 에디터에선 이모티콘을 이미지로 보여주지만 저장 본문은 `:name:` shortcode로 유지한다.
+      onChange?.(
+        serializeEmoticonImagesToShortcodes(
+          normalizeContent(updatedEditor.getHTML()),
+        ),
+      );
     },
     onTransaction: () => {
       forceEditorRerender((prev) => prev + 1);
@@ -538,7 +569,9 @@ function MarkdownEditor({
       return;
     }
 
-    const currentHtml = normalizeContent(editor.getHTML());
+    const currentHtml = serializeEmoticonImagesToShortcodes(
+      normalizeContent(editor.getHTML()),
+    );
     if (currentHtml !== normalizedValue) {
       editor.commands.setContent(editorReadyValue || '', { emitUpdate: false });
     }
@@ -757,6 +790,12 @@ function MarkdownEditor({
           onClick={handleToggleCodeBlock}
         />
         <ToolbarButton icon={Table2} label="표" onClick={handleInsertTable} />
+        <ToolbarButton
+          icon={Smile}
+          label="이모티콘"
+          isActive={isEmoticonPickerOpen}
+          onClick={() => setIsEmoticonPickerOpen((prev) => !prev)}
+        />
         {resolvedImageConfig && (
           <Button
             type="button"
@@ -816,6 +855,38 @@ function MarkdownEditor({
             취소
           </Button>
         </form>
+      )}
+
+      {isEmoticonPickerOpen && (
+        <div className="border-border-subtle border-b px-125 py-100">
+          <div className="flex flex-wrap gap-50">
+            {Object.entries(EMOTICON_CATALOG).map(([name, fileName]) => (
+              <button
+                key={name}
+                type="button"
+                title={`:${name}:`}
+                aria-label={`이모티콘 ${name} 삽입`}
+                onClick={() => handleInsertEmoticon(name)}
+                className={cn(
+                  'rounded-75 border-border-subtle hover:bg-background-alternative flex flex-col items-center gap-25 border p-50',
+                  'focus:outline-none focus:ring-2 focus:ring-border-brand',
+                )}
+              >
+                <Image
+                  src={`/emoticon/${fileName}`}
+                  alt={name}
+                  width={28}
+                  height={28}
+                  unoptimized
+                  className="object-contain"
+                />
+                <span className="font-designer-12r text-text-subtle">
+                  {name}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
       )}
 
       {resolvedImageConfig && (


### PR DESCRIPTION
release: minor

## 배경
에디터에서 이모티콘을 쓰려면 `:okay:` 같은 shortcode 이름을 **외워서 직접 타이핑**해야 했습니다. 목록을 보고 고를 수 있게 합니다.

## 변경
- **툴바 이모티콘 버튼** → 클릭 시 20종 그리드 피커(이미지+이름) 펼침 → 클릭하면 커서 위치에 삽입
- **EmoticonExtension** (인라인 atom 노드): 에디터에서 `:name:` 을 **실제 이모티콘 이미지**로 표시 (일반 이미지/ResizableImage보다 우선 파싱돼 리사이즈 이미지로 오인되지 않음)
- **저장 본문은 `:name:` shortcode로 유지**: 로드 시 이미지로 변환, 저장 시 이미지→shortcode 역직렬화. 이모티콘 없는 콘텐츠는 동작 불변(가드)
- 에디터용 이모티콘 인라인 CSS(24/48/96/150px) 추가
- 크기 변형(`:name_lg:` 등)은 그대로 타이핑 지원

## 영향 범위
공유 `MarkdownEditor`를 쓰는 모든 화면(admin 레슨/돌아보기/qna/피드/그룹스터디/멘토링)에 적용. 이모티콘 없는 기존 콘텐츠는 변환 가드로 동작 불변.

## 검증
- ✅ typecheck · lint(0 err) · prettier · unit 28/28(이모티콘 9종 신규) · webpack 컴파일
- 🔲 **권장: Vercel 프리뷰에서 실제 동작 확인** — 커스텀 에디터 노드라 브라우저 검증 권장:
  - 피커에서 이모티콘 선택 → 에디터에 이미지로 보이는지
  - 저장 후 재진입 → 이미지 유지 + 미리보기/상세 일치
  - 기존 `:name:` 본문 열었을 때 이미지로 보이는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마크다운 에디터에 이모티콘 기능 추가
  * 도구 모음에 이모티콘 선택 버튼 추가
  * 에디터 내 다양한 크기의 이모티콘 렌더링 지원
  * 이모티콘 숏코드(`:name:` 형식) 자동 변환 기능
  * 이모티콘 선택기에서 카탈로그의 모든 이모티콘 표시 및 선택 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->